### PR TITLE
Add fallback rendering for other APIs

### DIFF
--- a/src/plugins/minimal_scene/CMakeLists.txt
+++ b/src/plugins/minimal_scene/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
   MinimalScene.cc
   MinimalSceneRhi.cc
   MinimalSceneRhiOpenGL.cc
+  EngineToQtInterface.cc
 )
 
 set(PROJECT_LINK_LIBS "")
@@ -22,6 +23,7 @@ endif()
 gz_gui_add_plugin(MinimalScene
   SOURCES
     ${SOURCES}
+    EngineToQtInterface.hh
   QT_HEADERS
     MinimalScene.hh
   PUBLIC_LINK_LIBS

--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "EngineToQtInterface.hh"
+
+#include <gz/common/Console.hh>
+#include <gz/rendering/Camera.hh>
+#include <gz/rendering/RenderEngine.hh>
+
+#include <QOpenGLExtraFunctions>
+
+#include <GL/glcorearb.h>
+
+// clang-format off
+namespace gz
+{
+namespace gui
+{
+namespace plugins
+{
+  /// \brief Private data class for EngineToQtInterfacePrivate
+  class EngineToQtInterfacePrivate
+  {
+    /// \brief FBO texture. Stores uploaded GPU -> CPU.
+    /// Used only during fallback.
+    public: GLuint fallbackTexture = 0;
+
+    /// \brief Stores downloaded GPU -> CPU. Used only during fallback
+    public: gz::rendering::ImagePtr fallbackImage;
+
+    /// \brief Qt's OpenGL context. Used only during fallback.
+    /// We need it to render using Qt's context.
+    public: QOpenGLContext *glContext = nullptr;
+  };
+}
+}
+}
+// clang-format on
+
+using namespace gz;
+using namespace gui;
+using namespace plugins;
+
+/////////////////////////////////////////////////
+EngineToQtInterface::EngineToQtInterface(QOpenGLContext *_glContext) :
+  dataPtr(std::make_unique<EngineToQtInterfacePrivate>())
+{
+  this->dataPtr->glContext = _glContext;
+}
+
+/////////////////////////////////////////////////
+EngineToQtInterface::~EngineToQtInterface()
+{
+  this->DestroyFallbackTexture();
+}
+
+/////////////////////////////////////////////////
+void EngineToQtInterface::CreateFallbackTexture()
+{
+  static bool bWarnedOnce = false;
+
+  if (!bWarnedOnce)
+  {
+    gzwarn
+      << "Using fallback method to render to Qt. Things will be SLOW.\n"
+         "Try another API (e.g. OpenGL vs Vulkan) or build against a newer "
+         "Qt version\n";
+    bWarnedOnce = true;
+  }
+
+  this->DestroyFallbackTexture();
+
+  GZ_ASSERT(this->dataPtr->fallbackTexture == 0, "Invalid State!");
+
+  QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
+
+  glFuncs->glGenTextures(1u, &this->dataPtr->fallbackTexture);
+
+  glFuncs->glBindTexture(GL_TEXTURE_2D, this->dataPtr->fallbackTexture);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+  glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0u);
+
+#ifndef __APPLE__
+  this->dataPtr->glContext->extraFunctions()->glTexStorage2D(
+    GL_TEXTURE_2D, 1u, GL_RGBA8, GLsizei(this->dataPtr->fallbackImage->Width()),
+    GLsizei(this->dataPtr->fallbackImage->Height()));
+#else
+  glFuncs->glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
+                        GLsizei(this->dataPtr->fallbackImage->Width()),
+                        GLsizei(this->dataPtr->fallbackImage->Height()), 0,
+                        GL_RGBA, GL_BYTE, nullptr);
+#endif
+}
+
+/////////////////////////////////////////////////
+void EngineToQtInterface::DestroyFallbackTexture()
+{
+  glDeleteTextures(1, &this->dataPtr->fallbackTexture);
+  this->dataPtr->fallbackTexture = 0;
+}
+
+/////////////////////////////////////////////////
+bool EngineToQtInterface::NeedsFallback(gz::rendering::CameraPtr &_camera)
+{
+  auto *renderEngine = _camera->Scene()->Engine();
+  if (renderEngine->GraphicsAPI() != gz::rendering::GraphicsAPI::OPENGL &&
+      renderEngine->GraphicsAPI() != gz::rendering::GraphicsAPI::METAL)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+/////////////////////////////////////////////////
+GLuint EngineToQtInterface::TextureId(gz::rendering::CameraPtr &_camera)
+{
+  if (!this->NeedsFallback(_camera))
+  {
+    return _camera->RenderTextureGLId();
+  }
+  else
+  {
+    if (!this->dataPtr->fallbackImage ||
+        this->dataPtr->fallbackImage->Width() != _camera->ImageWidth() ||
+        this->dataPtr->fallbackImage->Height() != _camera->ImageHeight())
+    {
+      this->dataPtr->fallbackImage =
+        std::make_shared<gz::rendering::Image>(
+          _camera->ImageWidth(), _camera->ImageHeight(),
+          gz::rendering::PF_R8G8B8A8);
+
+      this->CreateFallbackTexture();
+    }
+
+    _camera->Copy(*this->dataPtr->fallbackImage);
+
+    QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
+
+    // We don't care about buffering / performance so we perform a synchronous
+    // glTexSubImage2D copy. This is a slow fallback path.
+    // We don't want to make the code unnecessary complex.
+    glFuncs->glBindTexture(GL_TEXTURE_2D, this->dataPtr->fallbackTexture);
+
+    glFuncs->glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    // RGBA8888 is always naturally aligned to 4 bytes
+    glFuncs->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+    glFuncs->glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glFuncs->glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
+
+    glFuncs->glTexSubImage2D(
+      GL_TEXTURE_2D, 0, 0, 0, GLsizei(this->dataPtr->fallbackImage->Width()),
+      GLsizei(this->dataPtr->fallbackImage->Height()), GL_RGBA,
+      GL_UNSIGNED_INT_8_8_8_8_REV, this->dataPtr->fallbackImage->Data());
+
+    return this->dataPtr->fallbackTexture;
+  }
+}

--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -113,7 +113,8 @@ void EngineToQtInterface::CreateFallbackTexture()
 /////////////////////////////////////////////////
 void EngineToQtInterface::DestroyFallbackTexture()
 {
-  glDeleteTextures(1, &this->dataPtr->fallbackTexture);
+  QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
+  glFuncs->glDeleteTextures(1, &this->dataPtr->fallbackTexture);
   this->dataPtr->fallbackTexture = 0;
 }
 

--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -23,8 +23,6 @@
 
 #include <QOpenGLExtraFunctions>
 
-#include <GL/glcorearb.h>
-
 // clang-format off
 namespace gz
 {

--- a/src/plugins/minimal_scene/EngineToQtInterface.hh
+++ b/src/plugins/minimal_scene/EngineToQtInterface.hh
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_GUI_PLUGINS_ENGINETOQTINTERFACE_HH_
+#define GZ_GUI_PLUGINS_ENGINETOQTINTERFACE_HH_
+
+#include <gz/rendering/RenderTypes.hh>
+
+#include "gz/gui/qt.h"
+
+#include <memory>
+
+namespace gz
+{
+namespace gui
+{
+namespace plugins
+{
+  class EngineToQtInterfacePrivate;
+
+  /// \brief
+  ///
+  /// This class is in charge of delivering data to Qt in a format
+  /// it can understand.
+  ///
+  /// Ideally, this is a simple call. e.g. if Qt wants an OpenGL
+  /// texture handle, and we're rendering to a texture; we simply
+  /// give Qt the texture handle (i.e. that's what
+  /// gz::rendering::Camera::RenderTextureGLId does)
+  ///
+  /// If Qt wants an OpenGL texture handle, and we're rendering to Metal,
+  /// ask Metal to convert it to an OpenGL handle and give it that.
+  ///
+  /// However there are cases where this isn's so straightforward, either
+  /// because the API doesn't have an interface for converting handles
+  /// between rendering systems, the underlying engine (i.e. Ogre) hasn't
+  /// yet implemented it, or simply because there's a lot of driver bugs
+  /// around it.
+  ///
+  /// Or perhaps the Qt version being compiled against is too old and doesn't
+  /// have support (e.g. Qt is too old to have a Vulkan renderer mode or it's
+  /// buggy)
+  ///
+  /// For all these cases, we use a fallback method where we download the
+  /// data from GPU into CPU and then upload it again to GPU using Qt's OpenGL.
+  ///
+  /// This is slow, but it's almost certain guaranteed to work.
+  /// A warning will be issued once when fallback is used, as it has
+  /// an important performance impact.
+  class EngineToQtInterface
+  {
+    /// \brief Constructor
+    public: explicit EngineToQtInterface(QOpenGLContext *_glContext);
+
+    /// \brief Destructor
+    public: ~EngineToQtInterface();
+
+    /// \brief Creates the fallback OpenGL texture we will be
+    /// giving to Qt
+    private: void CreateFallbackTexture();
+
+    /// \brief Destroys the texture created by CreateFallbackTexture
+    private: void DestroyFallbackTexture();
+
+    /// \brief
+    /// Returns the texture handle that Qt wants, whether it's the
+    /// fallback or native one
+    /// \param[in] _camera The camera doing rendering that should be shown
+    /// on Qt
+    /// \return Texture handle for Qt
+    public: GLuint TextureId(gz::rendering::CameraPtr &_camera);
+
+    /// \brief
+    /// \param[in] _camera Camera that wants to be rendered
+    /// \return False if memory is kept in the GPU and TextureId returns
+    /// an API object. True if we must fallback to downloading data
+    /// from GPU -> CPU and then uploading again CPU -> GPU using
+    /// a different API (very slow)
+    public: bool NeedsFallback(gz::rendering::CameraPtr &_camera);
+
+    /// \internal
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<EngineToQtInterfacePrivate> dataPtr;
+  };
+}
+}
+}
+
+#endif

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -303,7 +303,8 @@ GzRenderer::GzRenderer()
 }
 
 /////////////////////////////////////////////////
-void GzRenderer::Render(RenderSync *_renderSync)
+void GzRenderer::Render(RenderSync *_renderSync,
+                        RenderThreadRhi &_renderThreadRhi)
 {
   std::unique_lock<std::mutex> lock(_renderSync->mutex);
   _renderSync->WaitForQtThreadAndBlock(lock);
@@ -330,7 +331,7 @@ void GzRenderer::Render(RenderSync *_renderSync)
   }
 
   // Update the render interface (texture)
-  this->dataPtr->rhi->Update(this->dataPtr->camera);
+  _renderThreadRhi.Update(this->dataPtr->camera);
 
   // view control
   this->HandleMouseEvent();
@@ -561,7 +562,7 @@ void GzRenderer::BroadcastKeyPress()
 }
 
 /////////////////////////////////////////////////
-std::string GzRenderer::Initialize()
+std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
 {
   if (this->initialized)
     return std::string();
@@ -637,7 +638,7 @@ std::string GzRenderer::Initialize()
   this->dataPtr->camera->PreRender();
 
   // Update the render interface (texture)
-  this->dataPtr->rhi->Update(this->dataPtr->camera);
+  _rhi.Update(this->dataPtr->camera);
 
   // Ray Query
   this->dataPtr->rayQuery = this->dataPtr->camera->Scene()->CreateRayQuery();
@@ -715,12 +716,6 @@ void GzRenderer::NewMouseEvent(const common::MouseEvent &_e)
     this->dataPtr->mouseEvents.pop_front();
   this->dataPtr->mouseEvents.push_back(_e);
   this->dataPtr->mouseDirty = true;
-}
-
-/////////////////////////////////////////////////
-void GzRenderer::TextureId(void* _texturePtr)
-{
-  this->dataPtr->rhi->TextureId(_texturePtr);
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -139,13 +139,16 @@ namespace plugins
 
     /// \param[in] _renderSync RenderSync to safely
     /// synchronize Qt and worker thread (this)
-    public: void Render(RenderSync *_renderSync);
+    /// \param[in] _renderThreadRhi Our caller
+    public: void Render(RenderSync *_renderSync,
+                        RenderThreadRhi &_renderThreadRhi);
 
     /// \brief Initialize the render engine and scene.
     /// On macOS this must be called on the main thread.
+    /// \param[in] _rhi our caller
     /// \return Error message if initialization failed. If empty, no errors
     /// occurred.
-    public: std::string Initialize();
+    public: std::string Initialize(RenderThreadRhi &_rhi);
 
     /// \brief Set the graphics API
     /// \param[in] _graphicsAPI The type of graphics API

--- a/src/plugins/minimal_scene/MinimalSceneRhi.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhi.hh
@@ -45,10 +45,6 @@ namespace plugins
     /// \brief Update the texture for a camera
     /// \param[in] _camera Pointer to the camera providing the texture
     public: virtual void Update(rendering::CameraPtr _camera) = 0;
-
-    /// \brief Get the graphics API texture Id
-    /// \param[out] _texturePtr Pointer to a texture Id
-    public: virtual void TextureId(void* _texturePtr) = 0;
   };
 
   /// \brief gz-rendering renderer.
@@ -89,6 +85,10 @@ namespace plugins
     /// \param[in] _renderSync RenderSync to safely
     /// synchronize Qt and worker thread (this)
     public: virtual void RenderNext(RenderSync *_renderSync) = 0;
+
+    /// \brief Update the texture for a camera
+    /// \param[in] _camera Pointer to the camera providing the texture
+    public: virtual void Update(rendering::CameraPtr _camera) = 0;
 
     /// \brief Return a pointer to the graphics API texture Id
     public: virtual void* TexturePtr() const = 0;

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
@@ -49,9 +49,6 @@ namespace plugins
     // Documentation inherited
     public: virtual void Update(rendering::CameraPtr _camera) override;
 
-    // Documentation inherited
-    public: virtual void TextureId(void* _texturePtr) override;
-
     /// \internal Pointer to private data
     private: std::unique_ptr<GzCameraTextureRhiMetalPrivate> dataPtr;
   };
@@ -71,6 +68,9 @@ namespace plugins
 
     // Documentation inherited
     public: virtual std::string Initialize() override;
+
+    // Documentation inherited
+    public: virtual void Update(rendering::CameraPtr _camera) override;
 
     // Documentation inherited
     public: virtual void RenderNext(RenderSync *_renderSync) override;

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
@@ -134,7 +134,7 @@ void RenderThreadRhiMetal::RenderNext(RenderSync *_renderSync)
 /////////////////////////////////////////////////
 void* RenderThreadRhiMetal::TexturePtr() const
 {
-  void *texturePtr = CFBridgingRetain(this->dataPtr->metalTexture);
+  void *texturePtr = (void *)CFBridgingRetain(this->dataPtr->metalTexture);
   return texturePtr;
 }
 

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
@@ -88,13 +88,6 @@ void GzCameraTextureRhiMetal::Update(rendering::CameraPtr _camera)
 }
 
 /////////////////////////////////////////////////
-void GzCameraTextureRhiMetal::TextureId(void* _texturePtr)
-{
-  *static_cast<void**>(_texturePtr) =
-      (void*)CFBridgingRetain(this->dataPtr->metalTexture);
-}
-
-/////////////////////////////////////////////////
 /////////////////////////////////////////////////
 RenderThreadRhiMetal::~RenderThreadRhiMetal() = default;
 
@@ -108,7 +101,16 @@ RenderThreadRhiMetal::RenderThreadRhiMetal(GzRenderer *_renderer)
 /////////////////////////////////////////////////
 std::string RenderThreadRhiMetal::Initialize()
 {
-  return this->dataPtr->renderer->Initialize();
+  return this->dataPtr->renderer->Initialize(*this);
+}
+
+/////////////////////////////////////////////////
+void RenderThreadRhiMetal::Update(rendering::CameraPtr _camera)
+{
+  void *texturePtr = nullptr;
+  _camera->RenderTextureMetalId(&texturePtr);
+  this->dataPtr->metalTexture = CFBridgingRelease(texturePtr);
+  this->dataPtr->texturePtr = this->dataPtr->metalTexture;
 }
 
 /////////////////////////////////////////////////
@@ -116,7 +118,7 @@ void RenderThreadRhiMetal::RenderNext(RenderSync *_renderSync)
 {
   if (!this->dataPtr->renderer->initialized)
   {
-    this->dataPtr->renderer->Initialize();
+    this->dataPtr->renderer->Initialize(*this);
   }
 
   // Check if engine has been successfully initialized
@@ -127,11 +129,7 @@ void RenderThreadRhiMetal::RenderNext(RenderSync *_renderSync)
   }
 
   // Call the renderer
-  this->dataPtr->renderer->Render(_renderSync);
-
-  // Get reference to the rendered texture
-  this->dataPtr->texturePtr = nullptr;
-  this->dataPtr->renderer->TextureId(&this->dataPtr->texturePtr);
+  this->dataPtr->renderer->Render(_renderSync, *this);
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
@@ -49,7 +49,7 @@ namespace plugins
   class RenderThreadRhiMetalPrivate
   {
     public: GzRenderer *renderer = nullptr;
-    public: void *texturePtr = nullptr;
+    public: id<MTLTexture> metalTexture = nil;
   };
 
   class TextureNodeRhiMetalPrivate
@@ -110,7 +110,6 @@ void RenderThreadRhiMetal::Update(rendering::CameraPtr _camera)
   void *texturePtr = nullptr;
   _camera->RenderTextureMetalId(&texturePtr);
   this->dataPtr->metalTexture = CFBridgingRelease(texturePtr);
-  this->dataPtr->texturePtr = this->dataPtr->metalTexture;
 }
 
 /////////////////////////////////////////////////
@@ -135,7 +134,8 @@ void RenderThreadRhiMetal::RenderNext(RenderSync *_renderSync)
 /////////////////////////////////////////////////
 void* RenderThreadRhiMetal::TexturePtr() const
 {
-  return this->dataPtr->texturePtr;
+  void *texturePtr = CFBridgingRetain(this->dataPtr->metalTexture);
+  return texturePtr;
 }
 
 /////////////////////////////////////////////////
@@ -148,8 +148,6 @@ QSize RenderThreadRhiMetal::TextureSize() const
 void RenderThreadRhiMetal::ShutDown()
 {
   this->dataPtr->renderer->Destroy();
-
-  this->dataPtr->texturePtr = nullptr;
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
@@ -49,9 +49,6 @@ namespace plugins
     // Documentation inherited
     public: virtual void Update(rendering::CameraPtr _camera) override;
 
-    // Documentation inherited
-    public: virtual void TextureId(void* _texturePtr) override;
-
     /// \internal Pointer to private data
     private: std::unique_ptr<GzCameraTextureRhiOpenGLPrivate> dataPtr;
   };
@@ -83,6 +80,9 @@ namespace plugins
 
     // Documentation inherited
     public: virtual std::string Initialize() override;
+
+    // Documentation inherited
+    public: virtual void Update(rendering::CameraPtr _camera) override;
 
     // Documentation inherited
     public: virtual void RenderNext(RenderSync *_renderSync) override;


### PR DESCRIPTION
# 🦟 Bug fix

No ticket has been assigned for this issue.

## Order in which PRs must be merged

1. gazebosim/gz-rendering#706
2. This PR.
    - or optionally, merge this one as part of the next one aka PR 467, which includes it
3. gazebosim/gz-gui#467
4. gazebosim/gz-sim#1735

## Summary

Until we get native API to Qt implemented, fallback system can be used
to transfer GPU (Ogre) -> CPU -> GPU (Qt)

This is important for getting APIs other than OpenGL to work with Qt.

This is slow, but it works.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Dependency

After the CI failed, I realized this PR depends on either ignitionrobotics/ign-rendering#553 or ignitionrobotics/ign-rendering#565 and thus cannot be merged until then.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
