### PR TITLE
Bash completion for flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,11 @@ set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
 #--------------------------------------
 # Find if ign command is available
-find_program(HAVE_IGN_TOOLS ign)
-if (HAVE_IGN_TOOLS)
-  set(IGN_TOOLS_VER 1)
+
+ign_find_package(ignition-tools QUIET)
+if (ignition-tools_FOUND)
+  set (HAVE_IGN_TOOLS TRUE)
+  set (IGN_TOOLS_VER 1)
 endif()
 
 #--------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,11 @@ ign_find_package(ignition-msgs5 REQUIRED)
 set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 
 #--------------------------------------
-# Find if ign command is available
-
-ign_find_package(ignition-tools QUIET)
-if (ignition-tools_FOUND)
-  set (HAVE_IGN_TOOLS TRUE)
-  set (IGN_TOOLS_VER 1)
-endif()
+# Find if command is available. This is used to enable tests.
+# Note that CLI files are installed regardless of whether the dependency is
+# available during build time
+find_program(HAVE_IGN_TOOLS ign)
+set (IGN_TOOLS_VER 1)
 
 #--------------------------------------
 # Find QT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
 #--------------------------------------
 # Find if ign command is available
 find_program(HAVE_IGN_TOOLS ign)
+if (HAVE_IGN_TOOLS)
+  set(IGN_TOOLS_VER 1)
+endif()
 
 #--------------------------------------
 # Find QT

--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -95,6 +95,12 @@ Popup {
   IgnSortFilterModel {
     id: filteredModel
 
+    lessThan: function(left, right) {
+      var leftStr = left.modelData.toLowerCase();
+      var rightStr = right.modelData.toLowerCase();
+      return leftStr < rightStr;
+    }
+
     filterAcceptsItem: function(item) {
       var itemStr = item.modelData.toLowerCase();
       var filterStr = searchField.text.toLowerCase();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ ign_build_tests(TYPE UNIT
 
 foreach(test ${gtest_targets})
   target_compile_definitions(${test} PRIVATE
-    "IGN_GUI_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
+    "GZ_GUI_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 endforeach()
 
 add_subdirectory(cmd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,14 @@ ign_build_tests(TYPE UNIT
                 LIB_DEPS
                   ${IGNITION-MATH_LIBRARIES}
                   TINYXML2::TINYXML2
+                TEST_LIST
+                  gtest_targets
 )
+
+foreach(test ${gtest_targets})
+  target_compile_definitions(${test} PRIVATE
+    "IGN_GUI_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
+endforeach()
 
 add_subdirectory(cmd)
 add_subdirectory(plugins)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,8 +56,21 @@ foreach(test ${gtest_targets})
 endforeach()
 
 if(TARGET UNIT_ign_TEST)
+  # Running `ign gazebo` on macOS has problems when run with /usr/bin/ruby
+  # due to System Integrity Protection (SIP). Try to find ruby from
+  # homebrew as a workaround.
+  if (APPLE)
+    find_program(BREW_RUBY ruby HINTS /usr/local/opt/ruby/bin)
+  endif()
+
+  target_compile_definitions(UNIT_ign_TEST PRIVATE
+      "BREW_RUBY=\"${BREW_RUBY} \"")
+
+  target_compile_definitions(UNIT_ign_TEST PRIVATE
+      "IGN_PATH=\"${IGNITION-TOOLS_BINARY_DIRS}\"")
+
   set(_env_vars)
-  list(APPEND _env_vars "IGN_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>")
+  list(APPEND _env_vars "IGN_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")
 
   set_tests_properties(UNIT_ign_TEST PROPERTIES
     ENVIRONMENT "${_env_vars}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ ign_build_tests(TYPE UNIT
 
 foreach(test ${gtest_targets})
   target_compile_definitions(${test} PRIVATE
-    "GZ_GUI_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
+    "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 endforeach()
 
 add_subdirectory(cmd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,5 +55,13 @@ foreach(test ${gtest_targets})
     "PROJECT_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 endforeach()
 
+if(TARGET UNIT_ign_TEST)
+  set(_env_vars)
+  list(APPEND _env_vars "IGN_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>")
+
+  set_tests_properties(UNIT_ign_TEST PROPERTIES
+    ENVIRONMENT "${_env_vars}")
+endif()
+
 add_subdirectory(cmd)
 add_subdirectory(plugins)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ if(TARGET UNIT_ign_TEST)
       "BREW_RUBY=\"${BREW_RUBY} \"")
 
   target_compile_definitions(UNIT_ign_TEST PRIVATE
-      "IGN_PATH=\"${IGNITION-TOOLS_BINARY_DIRS}\"")
+      "IGN_PATH=\"${HAVE_IGN_TOOLS}\"")
 
   set(_env_vars)
   list(APPEND _env_vars "IGN_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -12,5 +12,14 @@ configure_file(
 # Install the ruby command line library in an unversioned location.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb DESTINATION lib/ruby/ignition)
 
-# Install the bash completion script in an unversioned location.
-install(FILES gui.bash_completion.sh DESTINATION share/gz/gz.completion.d)
+# Tack version onto and install the bash completion script
+configure_file(
+  "gui.bash_completion.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.bash_completion.sh" @ONLY)
+if (HAVE_IGN_TOOLS)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.bash_completion.sh
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)
+endif()

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -13,4 +13,4 @@ configure_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb DESTINATION lib/ruby/ignition)
 
 # Install the bash completion script in an unversioned location.
-install(FILES gui.bash_completion.sh DESTINATION share/ignition/ignition.completion.d)
+install(FILES gui.bash_completion.sh DESTINATION share/gz/gz.completion.d)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Generate a the ruby script.
+# Generate the ruby script.
 # Note that the major version of the library is included in the name.
 if (APPLE)
   set(IGN_LIBRARY_NAME lib${PROJECT_NAME_LOWER}.dylib)
@@ -11,3 +11,6 @@ configure_file(
 
 # Install the ruby command line library in an unversioned location.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb DESTINATION lib/ruby/ignition)
+
+# Install the bash completion script in an unversioned location.
+install(FILES gui.bash_completion.sh DESTINATION share/ignition/ignition.completion.d)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -16,10 +16,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb DEST
 configure_file(
   "gui.bash_completion.sh"
     "${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.bash_completion.sh" @ONLY)
-if (HAVE_IGN_TOOLS)
-  install(
-    FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.bash_completion.sh
-    DESTINATION
-      ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)
-endif()
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.bash_completion.sh
+  DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)

--- a/src/cmd/gui.bash_completion.sh
+++ b/src/cmd/gui.bash_completion.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# bash tab-completion
+
+# This is a per-library function definition, used in conjunction with the
+# top-level entry point in ign-tools.
+
+function _ign_gui
+{
+  if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
+    # Specify options (-*) word list for this subcommand
+    COMPREPLY=($(compgen -W "
+      -l --list
+      -s --standalone
+      -c --config
+      -v --verbose
+      -h --help
+      --force-version
+      --versions
+      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    return
+  else
+    # Just use bash default auto-complete, because we never have two
+    # subcommands in the same line. If that is ever needed, change here to
+    # detect subsequent subcommands
+    COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
+    return
+  fi
+}

--- a/src/cmd/gui.bash_completion.sh
+++ b/src/cmd/gui.bash_completion.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # bash tab-completion
 

--- a/src/cmd/gui.bash_completion.sh
+++ b/src/cmd/gui.bash_completion.sh
@@ -20,19 +20,22 @@
 # This is a per-library function definition, used in conjunction with the
 # top-level entry point in ign-tools.
 
+GZ_GUI_COMPLETION_LIST="
+  -l --list
+  -s --standalone
+  -c --config
+  -v --verbose
+  -h --help
+  --force-version
+  --versions
+"
+
 function _gz_gui
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand
-    COMPREPLY=($(compgen -W "
-      -l --list
-      -s --standalone
-      -c --config
-      -v --verbose
-      -h --help
-      --force-version
-      --versions
-      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    COMPREPLY=($(compgen -W "$GZ_GUI_COMPLETION_LIST" \
+      -- "${COMP_WORDS[COMP_CWORD]}" ))
     return
   else
     # Just use bash default auto-complete, because we never have two
@@ -41,4 +44,11 @@ function _gz_gui
     COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
     return
   fi
+}
+
+function _gz_gui_flags
+{
+  for word in $GZ_GUI_COMPLETION_LIST; do
+    echo "$word"
+  done
 }

--- a/src/cmd/gui.bash_completion.sh
+++ b/src/cmd/gui.bash_completion.sh
@@ -5,7 +5,7 @@
 # This is a per-library function definition, used in conjunction with the
 # top-level entry point in ign-tools.
 
-function _ign_gui
+function _gz_gui
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -113,7 +113,7 @@ TEST(ignTest, GuiHelpVsCompletionFlags)
   EXPECT_NE(std::string::npos, output.find("--versions")) << output;
 
   // Flags in bash completion
-  std::string scriptPath = common::joinPaths(std::string(GZ_GUI_SOURCE_DIR),
+  std::string scriptPath = common::joinPaths(std::string(PROJECT_SOURCE_DIR),
     "src", "cmd", "gui.bash_completion.sh");
   std::ifstream scriptFile(scriptPath);
   std::string script((std::istreambuf_iterator<char>(scriptFile)),

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <fstream>
 #include <string>
 
 #include <ignition/common/Filesystem.hh>
@@ -95,4 +96,34 @@ TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
 
   EXPECT_TRUE(common::exists(common::joinPaths(this->kFakeHome, ".ignition",
       "gui")));
+}
+
+//////////////////////////////////////////////////
+/// \brief Check --help message and bash completion script for consistent flags
+TEST(ignTest, GuiHelpVsCompletionFlags)
+{
+  // Flags in help message
+  std::string output = custom_exec_str("ign gui --help");
+  EXPECT_NE(std::string::npos, output.find("--list")) << output;
+  EXPECT_NE(std::string::npos, output.find("--standalone")) << output;
+  EXPECT_NE(std::string::npos, output.find("--config")) << output;
+  EXPECT_NE(std::string::npos, output.find("--verbose")) << output;
+  EXPECT_NE(std::string::npos, output.find("--help")) << output;
+  EXPECT_NE(std::string::npos, output.find("--force-version")) << output;
+  EXPECT_NE(std::string::npos, output.find("--versions")) << output;
+
+  // Flags in bash completion
+  std::string scriptPath = common::joinPaths(std::string(IGN_GUI_SOURCE_DIR),
+    "src", "cmd", "gui.bash_completion.sh");
+  std::ifstream scriptFile(scriptPath);
+  std::string script((std::istreambuf_iterator<char>(scriptFile)),
+      std::istreambuf_iterator<char>());
+
+  EXPECT_NE(std::string::npos, script.find("--list")) << script;
+  EXPECT_NE(std::string::npos, script.find("--standalone")) << script;
+  EXPECT_NE(std::string::npos, script.find("--config")) << script;
+  EXPECT_NE(std::string::npos, script.find("--verbose")) << script;
+  EXPECT_NE(std::string::npos, script.find("--help")) << script;
+  EXPECT_NE(std::string::npos, script.find("--force-version")) << script;
+  EXPECT_NE(std::string::npos, script.find("--versions")) << script;
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -33,6 +33,9 @@
 #    define pclose _pclose
 #endif
 
+static const std::string kIgnCommand(
+    std::string(BREW_RUBY) + std::string(IGN_PATH) + "/ign ");
+
 /////////////////////////////////////////////////
 std::string custom_exec_str(std::string _cmd)
 {
@@ -103,7 +106,7 @@ TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
 TEST(ignTest, GuiHelpVsCompletionFlags)
 {
   // Flags in help message
-  std::string helpOutput = custom_exec_str("ign gui --help");
+  std::string helpOutput = custom_exec_str(kIgnCommand + " gui --help");
 
   // Call the output function in the bash completion script
   std::string scriptPath = common::joinPaths(std::string(PROJECT_SOURCE_DIR),

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -112,7 +112,6 @@ TEST(ignTest, GuiHelpVsCompletionFlags)
   // Equivalent to:
   // sh -c "bash -c \". /path/to/gui.bash_completion.sh; _gz_gui_flags\""
   std::string cmd = "bash -c \". " + scriptPath + "; _gz_gui_flags\"";
-  std::cout << "Running command [" << cmd << "]" << std::endl;
   std::string scriptOutput = custom_exec_str(cmd);
 
   // Tokenize script output

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -34,7 +34,7 @@
 #endif
 
 static const std::string kIgnCommand(
-    std::string(BREW_RUBY) + std::string(IGN_PATH) + "/ign ");
+    std::string(BREW_RUBY) + std::string(IGN_PATH));
 
 /////////////////////////////////////////////////
 std::string custom_exec_str(std::string _cmd)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -113,7 +113,7 @@ TEST(ignTest, GuiHelpVsCompletionFlags)
   EXPECT_NE(std::string::npos, output.find("--versions")) << output;
 
   // Flags in bash completion
-  std::string scriptPath = common::joinPaths(std::string(IGN_GUI_SOURCE_DIR),
+  std::string scriptPath = common::joinPaths(std::string(GZ_GUI_SOURCE_DIR),
     "src", "cmd", "gui.bash_completion.sh");
   std::ifstream scriptFile(scriptPath);
   std::string script((std::istreambuf_iterator<char>(scriptFile)),


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-tools/issues/1
Used together with https://github.com/ignitionrobotics/ign-tools/pull/87

## Summary

Bash completion script for flags available to this subcommand.
This is a standalone function that depends on a new script in https://github.com/ignitionrobotics/ign-tools/pull/87 to call this.

## Test it

After sourcing the dependent script in ign-tools, source the script in this PR:
```
. src/cmd/gui.bash_completion.sh
```

If you just tab, you get the default system tab-completion that shows the files in the current directory:
```
$ ign gui <tab>
```

If you type `-`, and then tab, you get the tab-completion for all the flags available for this subcommand:
```
$ ign gui -<tab>
--config         --help           --standalone     --versions       -h               -s               
--force-version  --list           --verbose        -c               -l               -v               
```

Then you can type partial flags, and it'll do tab-completion normally for you, such as
```
$ ign gui --ver
--verbose   --versions  
```

It also works for multiple flags, like `ign gui --<flag1> --<flag2> ...`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.