### PR TITLE
user camera FOV control in SDF files

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -998,6 +998,12 @@ void RenderWindowItem::SetSkyEnabled(const bool &_sky)
 }
 
 /////////////////////////////////////////////////
+void RenderWindowItem::SetCameraHFOV(const math::Angle &_fov)
+{
+  this->dataPtr->renderThread->ignRenderer.cameraHFOV = _fov;
+}
+
+/////////////////////////////////////////////////
 MinimalScene::MinimalScene()
   : Plugin(), dataPtr(utils::MakeUniqueImpl<Implementation>())
 {
@@ -1115,6 +1121,18 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       renderWindow->SetSkyEnabled(true);
       if (!elem->NoChildren())
         ignwarn << "Child elements of <sky> are not supported yet" << std::endl;
+    }
+  
+    elem = _pluginElem->FirstChildElement("fov");
+    if (nullptr != elem && nullptr != elem->GetText())
+    {
+	double fovDeg;
+	math::Angle fov;
+        std::stringstream fovStr;
+        fovStr << std::string(elem->GetText());
+        fovStr >> fovDeg;
+	fov.SetDegree(fovDeg);
+	renderWindow->SetCameraHFOV(fov);	
     }
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1122,17 +1122,17 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       if (!elem->NoChildren())
         ignwarn << "Child elements of <sky> are not supported yet" << std::endl;
     }
-  
+
     elem = _pluginElem->FirstChildElement("fov");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-	double fovDeg;
-	math::Angle fov;
-        std::stringstream fovStr;
-        fovStr << std::string(elem->GetText());
-        fovStr >> fovDeg;
-	fov.SetDegree(fovDeg);
-	renderWindow->SetCameraHFOV(fov);	
+      double fovDeg;
+      math::Angle fov;
+      std::stringstream fovStr;
+      fovStr << std::string(elem->GetText());
+      fovStr >> fovDeg;
+      fov.SetDegree(fovDeg);
+      renderWindow->SetCameraHFOV(fov);
     }
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1131,8 +1131,16 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       std::stringstream fovStr;
       fovStr << std::string(elem->GetText());
       fovStr >> fovDeg;
-      fov.SetDegree(fovDeg);
-      renderWindow->SetCameraHFOV(fov);
+      if (fovStr.fail())
+      {
+        ignerr << "Unable to set <fov> to '" << fovStr.str()
+               << "' using default fov 90" << std::endl;
+      }
+      else
+      {
+        fov.SetDegree(fovDeg);
+        renderWindow->SetCameraHFOV(fov);
+      }
     }
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1123,7 +1123,7 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         ignwarn << "Child elements of <sky> are not supported yet" << std::endl;
     }
 
-    elem = _pluginElem->FirstChildElement("fov");
+    elem = _pluginElem->FirstChildElement("horizontal_fov");
     if (nullptr != elem && nullptr != elem->GetText())
     {
       double fovDeg;
@@ -1133,8 +1133,8 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       fovStr >> fovDeg;
       if (fovStr.fail())
       {
-        ignerr << "Unable to set <fov> to '" << fovStr.str()
-               << "' using default fov 90" << std::endl;
+        ignerr << "Unable to set <horizontal_fov> to '" << fovStr.str()
+               << "' using default horizontal field of view" << std::endl;
       }
       else
       {

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -585,7 +585,7 @@ std::string IgnRenderer::Initialize()
   this->dataPtr->camera->SetImageWidth(this->textureSize.width());
   this->dataPtr->camera->SetImageHeight(this->textureSize.height());
   this->dataPtr->camera->SetAntiAliasing(8);
-  this->dataPtr->camera->SetHFOV(M_PI * 0.5);
+  this->dataPtr->camera->SetHFOV(this->cameraHFOV);
   // setting the size and calling PreRender should cause the render texture to
   // be rebuilt
   this->dataPtr->camera->PreRender();

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -61,7 +61,8 @@ namespace plugins
   ///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
   ///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
   /// * \<sky\> : If present, sky is enabled.
-  /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees, defaults to 90
+  /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
+  ///                        defaults to 90
   class MinimalScene : public Plugin
   {
     Q_OBJECT

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -61,6 +61,7 @@ namespace plugins
   ///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
   ///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
   /// * \<sky\> : If present, sky is enabled.
+  /// * \<fov\> : Horizontal FOV of the user camera in degrees, defaults to 90
   class MinimalScene : public Plugin
   {
     Q_OBJECT

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -236,6 +236,9 @@ namespace plugins
 
     /// \brief True if sky is enabled;
     public: bool skyEnable = false;
+    
+    /// \brief Horizontal FOV of the camera;
+    public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 
     /// \internal
     /// \brief Pointer to private data.
@@ -337,6 +340,10 @@ namespace plugins
     /// \brief Set if sky is enabled
     /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
+
+    /// \brief Set the Horizontal FOV of the camera
+    /// \param[in] _fov FOV of the camera in degree
+    public: void SetCameraHFOV(const ignition::math::Angle &_fov);
 
     /// \brief Slot called when thread is ready to be started
     public Q_SLOTS: void Ready();

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -236,7 +236,7 @@ namespace plugins
 
     /// \brief True if sky is enabled;
     public: bool skyEnable = false;
-    
+
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -61,7 +61,7 @@ namespace plugins
   ///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
   ///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
   /// * \<sky\> : If present, sky is enabled.
-  /// * \<fov\> : Horizontal FOV of the user camera in degrees, defaults to 90
+  /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees, defaults to 90
   class MinimalScene : public Plugin
   {
     Q_OBJECT

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -89,6 +89,7 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "  <near>0.1</near>"
       "  <far>5000</far>"
       "</camera_clip>"
+      "<fov>60</fov>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;
@@ -153,6 +154,8 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 1.57), camera->WorldPose());
   EXPECT_DOUBLE_EQ(0.1, camera->NearClipPlane());
   EXPECT_DOUBLE_EQ(5000.0, camera->FarClipPlane());
+
+  EXPECT_DOUBLE_EQ(60, camera->HFOV().Degree());
 
   // Cleanup
   auto plugins = win->findChildren<Plugin *>();

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -89,7 +89,7 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "  <near>0.1</near>"
       "  <far>5000</far>"
       "</camera_clip>"
-      "<fov>60</fov>"
+      "<horizontal_fov>60</horizontal_fov>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;


### PR DESCRIPTION
#  New feature

Part of gazebosim/gz-sim#421

## Summary
Users can now change the FOV of the user camera in SDF as follows:

## Test it

```
<sdf version="1.6">
    ...
    <gui fullscreen="0">

      <!-- 3D scene -->
      <plugin filename="MinimalScene" name="3D View">
        ...
        <fov>60</fov>
      </plugin>
      ...
    </gui>
```

Please enter the FOV in degree and by default ignition uses a FOV of 90

## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

