### PR TITLE
Suppress new Jammy warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,16 +16,16 @@ set (sources
 )
 
 set (gtest_sources
-  Application_TEST
-  Conversions_TEST
-  DragDropModel_TEST
-  Helpers_TEST
-  GuiEvents_TEST
-  ign_TEST
-  MainWindow_TEST
-  PlottingInterface_TEST
-  Plugin_TEST
-  SearchModel_TEST
+  Application_TEST.cc
+  Conversions_TEST.cc
+  DragDropModel_TEST.cc
+  Helpers_TEST.cc
+  GuiEvents_TEST.cc
+  ign_TEST.cc
+  MainWindow_TEST.cc
+  PlottingInterface_TEST.cc
+  Plugin_TEST.cc
+  SearchModel_TEST.cc
 )
 
 if (MSVC)


### PR DESCRIPTION
The test files should have always had extensions, newer CMake is just more strict about it.

Signed-off-by: Michael Carroll <michael@openrobotics.org>