### PR TITLE
Shortcut to search and auto highlight search bar

### DIFF
--- a/include/ignition/gui/qml/Main.qml
+++ b/include/ignition/gui/qml/Main.qml
@@ -151,6 +151,11 @@ ApplicationWindow
     onActivated: close()
   }
 
+  Shortcut {
+    sequence: "/"
+    onActivated: pluginMenu.open()
+  }
+
   /**
    * Top toolbar
    */

--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -38,14 +38,10 @@ Popup {
       Material.color(Material.Grey, Material.Shade200):
       Material.color(Material.Grey, Material.Shade900);
 
-  property bool pluginAdded: false
 
   onOpened: {
     searchField.forceActiveFocus()
-    if (pluginAdded) {
-      searchField.selectAll()
-      pluginAdded = false;
-    }
+    searchField.selectAll()
   }
 
   ColumnLayout {
@@ -118,7 +114,6 @@ Popup {
       onClicked: {
         MainWindow.OnAddPlugin(modelData);
         drawer.close()
-        pluginAdded = true
         pluginMenu.close()
       }
     }

--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -38,9 +38,14 @@ Popup {
       Material.color(Material.Grey, Material.Shade200):
       Material.color(Material.Grey, Material.Shade900);
 
+  property bool pluginAdded: false
+
   onOpened: {
     searchField.forceActiveFocus()
-    searchField.selectAll()
+    if (pluginAdded) {
+      searchField.selectAll()
+      pluginAdded = false;
+    }
   }
 
   ColumnLayout {
@@ -113,6 +118,7 @@ Popup {
       onClicked: {
         MainWindow.OnAddPlugin(modelData);
         drawer.close()
+        pluginAdded = true
         pluginMenu.close()
       }
     }

--- a/include/ignition/gui/qml/PluginMenu.qml
+++ b/include/ignition/gui/qml/PluginMenu.qml
@@ -38,7 +38,10 @@ Popup {
       Material.color(Material.Grey, Material.Shade200):
       Material.color(Material.Grey, Material.Shade900);
 
-  onOpened: searchField.forceActiveFocus()
+  onOpened: {
+    searchField.forceActiveFocus()
+    searchField.selectAll()
+  }
 
   ColumnLayout {
     anchors.fill: parent


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

# New feature(s)

## Summary
There are 2 features added in this PR. Both of them are small and are about the search bar/menu so I combine them into one PR.

Feature 1. When we close the search bar for adding plugins, the text in it will be preserved. If we want to add another plugin, we need to delete the first one. That's a little annoying. Now after adding a plugin, text in the search bar will be auto highlighted so the search bar can be cleared easier. 

No highlight if no plugin is added.

![demo_better_highligh](https://user-images.githubusercontent.com/50132891/170141423-5ae95966-c574-401a-a3c1-828edf839b06.gif)

Feature 2. Press `/` to open the plugin search bar

![demo_shortcut](https://user-images.githubusercontent.com/50132891/170141864-cf9aa655-1788-40bc-b8f3-a864feb4da12.gif)


## Test it
Try it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
