### PR TITLE
Example running a dialog before the main window

### DIFF
--- a/examples/standalone/start_dialog/CMakeLists.txt
+++ b/examples/standalone/start_dialog/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+project(gz-gui-start-dialog)
+
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 NEW)
+endif()
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(ignition-gui3 REQUIRED)
+set(GZ_GUI_VER ${ignition-gui3_VERSION_MAJOR})
+
+set(EXEC_NAME "start_dialog")
+
+QT5_ADD_RESOURCES(resources_RCC ${EXEC_NAME}.qrc)
+
+add_executable(${EXEC_NAME}
+  ${EXEC_NAME}.cc
+  ${resources_RCC}
+)
+target_link_libraries(${EXEC_NAME}
+  ignition-gui${GZ_GUI_VER}::ignition-gui${GZ_GUI_VER}
+)
+

--- a/examples/standalone/start_dialog/README.md
+++ b/examples/standalone/start_dialog/README.md
@@ -1,0 +1,16 @@
+Example for how to run a start dialog before the main window.
+
+## Build
+
+    cd <this directory>
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+## Run
+
+    cd <this directory>/build
+    ./start_dialog
+
+First the dialog shows up, and after that's closed, the main window shows up.

--- a/examples/standalone/start_dialog/start_dialog.cc
+++ b/examples/standalone/start_dialog/start_dialog.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+
+#include <ignition/gui/qt.h>
+#include <ignition/gui/Application.hh>
+#include <ignition/gui/Dialog.hh>
+#include <ignition/gui/MainWindow.hh>
+
+//////////////////////////////////////////////////
+int main(int _argc, char **_argv)
+{
+  // Increase verboosity so we see all messages
+  ignition::common::Console::SetVerbosity(4);
+
+  // Create app
+  ignition::gui::Application app(_argc, _argv, ignition::gui::WindowType::kDialog);
+
+  igndbg << "Open dialog" << std::endl;
+
+  // Add and display a dialog
+  auto dialog = new ignition::gui::Dialog();
+  dialog->QuickWindow();
+
+  std::string qmlFile(":start_dialog/start_dialog.qml");
+  if (!QFile(QString::fromStdString(qmlFile)).exists())
+  {
+    ignerr << "Can't find [" << qmlFile
+           << "]. Are you sure it was added to the .qrc file?" << std::endl;
+    return -1;
+  }
+
+  QQmlComponent dialogComponent(ignition::gui::App()->Engine(),
+      QString(QString::fromStdString(qmlFile)));
+  if (dialogComponent.isError())
+  {
+    std::stringstream errors;
+    errors << "Failed to instantiate QML file [" << qmlFile << "]."
+           << std::endl;
+    for (auto error : dialogComponent.errors())
+    {
+      errors << "* " << error.toString().toStdString() << std::endl;
+    }
+    ignerr << errors.str();
+    return -1;
+  }
+
+  auto dialogItem = qobject_cast<QQuickItem *>(dialogComponent.create());
+  if (!dialogItem)
+  {
+    ignerr << "Failed to instantiate QML file [" << qmlFile << "]." << std::endl
+           << "Are you sure the file is valid QML? "
+           << "You can check with the `qmlscene` tool" << std::endl;
+    return -1;
+  }
+
+  dialogItem->setParentItem(dialog->RootItem());
+
+  // Execute start dialog
+  app.exec();
+
+  // After dialog is shut, display the main window
+  igndbg << "Dialog closed, open main window" << std::endl;
+
+  // Create main window
+  // FIXME: use CreateMainWindow - currently complains with undefined reference
+  //app.CreateMainWindow();
+  app.InitializeMainWindow();
+
+  // Run main window
+  app.exec();
+
+  igndbg << "Main window closed" << std::endl;
+
+  return 0;
+}
+

--- a/examples/standalone/start_dialog/start_dialog.cc
+++ b/examples/standalone/start_dialog/start_dialog.cc
@@ -78,9 +78,7 @@ int main(int _argc, char **_argv)
   igndbg << "Dialog closed, open main window" << std::endl;
 
   // Create main window
-  // FIXME: use CreateMainWindow - currently complains with undefined reference
-  //app.CreateMainWindow();
-  app.InitializeMainWindow();
+  app.CreateMainWindow();
 
   // Run main window
   app.exec();

--- a/examples/standalone/start_dialog/start_dialog.qml
+++ b/examples/standalone/start_dialog/start_dialog.qml
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+Rectangle {
+  color: "green"
+  anchors.fill: parent
+  Text {
+    text: qsTr("Start\ndialog!")
+    font.pointSize: 30
+  }
+}

--- a/examples/standalone/start_dialog/start_dialog.qrc
+++ b/examples/standalone/start_dialog/start_dialog.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+  <qresource prefix="start_dialog/">
+    <file>start_dialog.qml</file>
+  </qresource>
+</RCC>

--- a/include/ignition/gui/Application.hh
+++ b/include/ignition/gui/Application.hh
@@ -181,8 +181,7 @@ namespace ignition
       /// \return True if successful
       /// \sa LoadConfig
       /// \sa LoadPlugin
-      // FIXME: this should be private and CreateMainWindow public
-      public: bool InitializeMainWindow();
+      private: bool InitializeMainWindow();
 
       /// \brief Create individual dialogs for all previously loaded plugins.
       /// This has no effect if no plugins have been loaded.

--- a/include/ignition/gui/Application.hh
+++ b/include/ignition/gui/Application.hh
@@ -53,7 +53,8 @@ namespace ignition
       /// plugins
       kMainWindow = 0,
 
-      /// \brief One independent dialog per plugin
+      /// \brief One independent dialog per plugin. Also useful to open a
+      /// startup dialog before the main window.
       kDialog = 1
     };
 
@@ -169,13 +170,19 @@ namespace ignition
       /// \brief Callback when user requests to close a plugin
       public slots: void OnPluginClose();
 
+      /// \brief Create a main window. Just calls InitializeMainWindow.
+      /// \return True if successful
+      /// \sa InitializeMainWindow
+      public: bool CreateMainWindow();
+
       /// \brief Create a main window, populate with previously loaded plugins
       /// and apply previously loaded configuration.
       /// An empty window will be created if no plugins have been loaded.
       /// \return True if successful
       /// \sa LoadConfig
       /// \sa LoadPlugin
-      private: bool InitializeMainWindow();
+      // FIXME: this should be private and CreateMainWindow public
+      public: bool InitializeMainWindow();
 
       /// \brief Create individual dialogs for all previously loaded plugins.
       /// This has no effect if no plugins have been loaded.

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -538,6 +538,12 @@ std::shared_ptr<Plugin> Application::PluginByName(
 }
 
 /////////////////////////////////////////////////
+bool Application::CreateMainWindow()
+{
+  return this->InitializeMainWindow();
+}
+
+/////////////////////////////////////////////////
 bool Application::InitializeMainWindow()
 {
   igndbg << "Create main window" << std::endl;

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -289,6 +289,19 @@ TEST(ApplicationTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(InitializeMainWindow))
     // Show window
     app.exec();
   }
+
+  // Start in dialog mode and create main window later
+  {
+    Application app(g_argc, g_argv, WindowType::kDialog);
+
+    auto win = App()->findChild<MainWindow *>();
+    EXPECT_EQ(nullptr, win);
+
+    app.CreateMainWindow();
+
+    win = App()->findChild<MainWindow *>();
+    ASSERT_NE(nullptr, win);
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/gazebosim/gz-sim/issues/1252

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Added a standalone example for how to run a custom dialog before opening the main window.

![image](https://user-images.githubusercontent.com/5751272/170776311-ba6bf5c6-bdc3-4f45-8cf5-e86dd3aa877f.png)


### TODO

~~I created the new `Application::CreateMainWindow` function as a public version of `InitializeMainWindow`, and I must be doing something silly wrong because the example fails to compile with "undefined reference". That needs to be sorted out before merging this PR.~~

The issue above fixed itself 🤷🏽‍♀️ 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Follow the instructions in the example's README

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] ~~Updated migration guide (as needed)~~
- [x] ~~Consider updating Python bindings (if the library has them)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
