### PR TITLE
Common widget GzColor (Citadel)

### DIFF
--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -18,6 +18,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.1
 import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
+import QtQuick.Controls.Material 2.1
 
 
 // RGBA using range 0 - 1.0
@@ -32,9 +33,7 @@ Item {
   property double b: 0.0
   property double a: 1.0
 
-  property bool useWhiteTheme: true
-
-  signal colorSet()
+  signal gzColorSet()
 
   Button {
     id: gzColorButton
@@ -46,28 +45,29 @@ Item {
       implicitWidth: 40
       implicitHeight: 40
       radius: 5
-      border.color: useWhiteTheme ? Qt.rgba(0,0,0,1) : Qt.rgba(1,1,1,1)
+      border.color: (Material.theme === Material.Light) ? Qt.rgba(0,0,0,1) : Qt.rgba(1,1,1,1)
       border.width: 2
       color: Qt.rgba(r,g,b,a)
     }
-    onClicked: colorDialog.open()
+    onClicked: gzColorDialog.open()
   }
 
   ColorDialog {
-    id: colorDialog
+    id: gzColorDialog
     title: "Choose a color"
     visible: false
     showAlphaChannel: true
+    modality: Qt.ApplicationModal
     onAccepted: {
-      r = colorDialog.color.r
-      g = colorDialog.color.g
-      b = colorDialog.color.b
-      a = colorDialog.color.a
-      gzColorRoot.colorSet()
-      colorDialog.close()
+      r = gzColorDialog.color.r
+      g = gzColorDialog.color.g
+      b = gzColorDialog.color.b
+      a = gzColorDialog.color.a
+      gzColorRoot.gzColorSet()
+      gzColorDialog.close()
     }
     onRejected: {
-      colorDialog.close()
+      gzColorDialog.close()
     }
   }
 }

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -32,12 +32,12 @@ GridLayout {
   property bool textVisible: false
 
   signal colorSet()
-  columns: 6
+  columns: 5
   columnSpacing: 10
 
   Text {
     Layout.row: 0
-    Layout.column: 2
+    Layout.column: 1
     Layout.alignment: Qt.AlignCenter
     text: "Red"
     color: "dimgrey"
@@ -51,14 +51,14 @@ GridLayout {
     value: 255 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 2
+    Layout.column: 1
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 3
+    Layout.column: 2
     Layout.alignment: Qt.AlignCenter
     text: "Green"
     color: "dimgrey"
@@ -72,14 +72,14 @@ GridLayout {
     value: 0 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 3
+    Layout.column: 2
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 4
+    Layout.column: 3
     Layout.alignment: Qt.AlignCenter
     text: "Blue"
     color: "dimgrey"
@@ -93,14 +93,14 @@ GridLayout {
     value: 0 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 4
+    Layout.column: 3
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 5
+    Layout.column: 4
     Layout.alignment: Qt.AlignCenter
     text: "Alpha"
     color: "dimgrey"
@@ -115,13 +115,13 @@ GridLayout {
     stepSize: 0.1
     decimals: 2
     Layout.row: 1
-    Layout.column: 5
+    Layout.column: 4
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
-    Layout.row: 1
+    Layout.row: 0
     Layout.column: 0
     Layout.alignment: Qt.AlignCenter
     text: parent.colorName
@@ -130,7 +130,8 @@ GridLayout {
   Button {
     id: ambientButton
     Layout.row: 1
-    Layout.column: 1
+    Layout.column: 0
+    Layout.alignment: Qt.AlignRight
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered
     ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -52,6 +52,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 2
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -72,6 +73,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 3
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -92,6 +94,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 4
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -113,6 +116,7 @@ GridLayout {
     decimals: 2
     Layout.row: 1
     Layout.column: 5
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,8 +20,11 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
-Item {
+Rectangle {
   id: gzColorRoot
+  
+  implicitWidth: 40
+  implicitHeight: 40
 
   property double r: 255
   property double g: 0
@@ -59,7 +62,6 @@ Item {
         a = colorDialog.color.a
         gzColorRoot.colorSet()
         colorDialog.close()
-        console.log(r,g,b,a)
       }
       onRejected: {
         colorDialog.close()

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,7 +20,7 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
-Rectangle {
+Item {
   id: gzColorRoot
   
   implicitWidth: 40
@@ -35,8 +35,6 @@ Rectangle {
 
   Button {
     id: colorButton
-    Layout.row: 1
-    Layout.column: 0
     Layout.leftMargin: 5
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,118 +20,21 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
-GridLayout {
-  id: root
-  property string colorName
+Item {
+  id: gzColorRoot
 
-  property alias r: r_spin.value
-  property alias g: g_spin.value
-  property alias b: b_spin.value
-  property alias a: a_spin.value
-
-  property bool textVisible: false
+  property double r: 255
+  property double g: 0
+  property double b: 0
+  property double a: 1.0
 
   signal colorSet()
-  columns: 5
-  columnSpacing: 10
-
-  Text {
-    Layout.row: 0
-    Layout.column: 1
-    Layout.alignment: Qt.AlignCenter
-    text: "Red"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "r_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 255 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 1
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 2
-    Layout.alignment: Qt.AlignCenter
-    text: "Green"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "g_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 0 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 2
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 3
-    Layout.alignment: Qt.AlignCenter
-    text: "Blue"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "b_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 0 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 3
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 4
-    Layout.alignment: Qt.AlignCenter
-    text: "Alpha"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "a_spin"
-    maximumValue: 1.0
-    minimumValue: 0
-    value: 1.0
-    stepSize: 0.1
-    decimals: 2
-    Layout.row: 1
-    Layout.column: 4
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 0
-    Layout.alignment: Qt.AlignCenter
-    text: parent.colorName
-  }
 
   Button {
-    id: ambientButton
+    id: colorButton
     Layout.row: 1
     Layout.column: 0
-    Layout.alignment: Qt.AlignRight
+    Layout.leftMargin: 5
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered
     ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
@@ -150,12 +53,13 @@ GridLayout {
       title: "Choose a color"
       visible: false
       onAccepted: {
-        r_spin.value = colorDialog.color.r * 255
-        g_spin.value = colorDialog.color.g * 255
-        b_spin.value = colorDialog.color.b * 255
-        a_spin.value = colorDialog.color.a
-        root.colorSet()
+        r = colorDialog.color.r * 255
+        g = colorDialog.color.g * 255
+        b = colorDialog.color.b * 255
+        a = colorDialog.color.a
+        gzColorRoot.colorSet()
         colorDialog.close()
+        console.log(r,g,b,a)
       }
       onRejected: {
         colorDialog.close()

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -16,7 +16,6 @@
 */
 import QtQuick 2.9
 import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
 import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
@@ -39,6 +38,7 @@ GridLayout {
   Text {
     Layout.row: 0
     Layout.column: 2
+    Layout.alignment: Qt.AlignCenter
     text: "Red"
     color: "dimgrey"
     visible: textVisible
@@ -58,6 +58,7 @@ GridLayout {
   Text {
     Layout.row: 0
     Layout.column: 3
+    Layout.alignment: Qt.AlignCenter
     text: "Green"
     color: "dimgrey"
     visible: textVisible
@@ -77,6 +78,7 @@ GridLayout {
   Text {
     Layout.row: 0
     Layout.column: 4
+    Layout.alignment: Qt.AlignCenter
     text: "Blue"
     color: "dimgrey"
     visible: textVisible
@@ -96,6 +98,7 @@ GridLayout {
   Text {
     Layout.row: 0
     Layout.column: 5
+    Layout.alignment: Qt.AlignCenter
     text: "Alpha"
     color: "dimgrey"
     visible: textVisible
@@ -116,6 +119,7 @@ GridLayout {
   Text {
     Layout.row: 1
     Layout.column: 0
+    Layout.alignment: Qt.AlignCenter
     text: parent.colorName
   }
 
@@ -138,7 +142,7 @@ GridLayout {
 
     ColorDialog {
       id: colorDialog
-      title: "Choose a grid color"
+      title: "Choose a color"
       visible: false
       onAccepted: {
         r_spin.value = colorDialog.color.r * 255

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,21 +20,24 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
+// RGBA using range 0 - 1.0
 Item {
   id: gzColorRoot
-  
+
   implicitWidth: 40
   implicitHeight: 40
 
-  property double r: 255
-  property double g: 0
-  property double b: 0
+  property double r: 1.0
+  property double g: 0.0
+  property double b: 0.0
   property double a: 1.0
+
+  property bool useWhiteTheme: true
 
   signal colorSet()
 
   Button {
-    id: colorButton
+    id: gzColorButton
     Layout.leftMargin: 5
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered
@@ -43,29 +46,29 @@ Item {
       implicitWidth: 40
       implicitHeight: 40
       radius: 5
-      border.color: Qt.rgba(r / 255, g / 255, b / 255, a)
+      border.color: useWhiteTheme ? Qt.rgba(0,0,0,1) : Qt.rgba(1,1,1,1)
       border.width: 2
-      color: Qt.rgba(r / 255, g / 255, b / 255, a)
+      color: Qt.rgba(r,g,b,a)
     }
     onClicked: colorDialog.open()
+  }
 
-    ColorDialog {
-      id: colorDialog
-      title: "Choose a color"
-      visible: false
-      onAccepted: {
-        r = colorDialog.color.r * 255
-        g = colorDialog.color.g * 255
-        b = colorDialog.color.b * 255
-        a = colorDialog.color.a
-        gzColorRoot.colorSet()
-        colorDialog.close()
-      }
-      onRejected: {
-        colorDialog.close()
-      }
+  ColorDialog {
+    id: colorDialog
+    title: "Choose a color"
+    visible: false
+    showAlphaChannel: true
+    onAccepted: {
+      r = colorDialog.color.r
+      g = colorDialog.color.g
+      b = colorDialog.color.b
+      a = colorDialog.color.a
+      gzColorRoot.colorSet()
+      colorDialog.close()
     }
-
+    onRejected: {
+      colorDialog.close()
+    }
   }
 }
 

--- a/include/ignition/gui/qml/GzColorRGB.qml
+++ b/include/ignition/gui/qml/GzColorRGB.qml
@@ -129,9 +129,9 @@ GridLayout {
       implicitWidth: 40
       implicitHeight: 40
       radius: 5
-      border.color: Qt.rgba(r / 256, g / 256, b / 256, a / 256)
+      border.color: Qt.rgba(r / 255, g / 255, b / 255, a / 255)
       border.width: 2
-      color: Qt.rgba(r / 256, g / 256, b / 256, a / 256)
+      color: Qt.rgba(r / 255, g / 255, b / 255, a / 255)
     }
     onClicked: colorDialog.open()
 
@@ -140,10 +140,10 @@ GridLayout {
       title: "Choose a grid color"
       visible: false
       onAccepted: {
-        r_spin.value = colorDialog.color.r * 256
-        g_spin.value = colorDialog.color.g * 256
-        b_spin.value = colorDialog.color.b * 256
-        a_spin.value = colorDialog.color.a * 256
+        r_spin.value = colorDialog.color.r * 255
+        g_spin.value = colorDialog.color.g * 255
+        b_spin.value = colorDialog.color.b * 255
+        a_spin.value = colorDialog.color.a * 255
         root.colorSet()
         colorDialog.close()
       }

--- a/include/ignition/gui/qml/GzColorRGB.qml
+++ b/include/ignition/gui/qml/GzColorRGB.qml
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 2.1
+import QtQuick.Controls.Material 2.1
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.3
+
+
+GridLayout {
+  id: root
+  property string colorName
+
+  property alias r: r_spin.value
+  property alias g: g_spin.value
+  property alias b: b_spin.value
+  property alias a: a_spin.value
+
+  property bool textVisible: false
+
+  signal colorSet()
+  columns: 6
+  columnSpacing: 10
+
+  Text {
+    Layout.row: 0
+    Layout.column: 2
+    text: "Red"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "r_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 255 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 2
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 3
+    text: "Green"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "g_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 0 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 3
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 4
+    text: "Blue"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "b_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 0 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 4
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 5
+    text: "Alpha"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "a_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 255
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 5
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 1
+    Layout.column: 0
+    text: parent.colorName
+  }
+
+  Button {
+    id: ambientButton
+    Layout.row: 1
+    Layout.column: 1
+    ToolTip.text: "Open color dialog"
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    background: Rectangle {
+      implicitWidth: 40
+      implicitHeight: 40
+      radius: 5
+      border.color: Qt.rgba(r / 256, g / 256, b / 256, a / 256)
+      border.width: 2
+      color: Qt.rgba(r / 256, g / 256, b / 256, a / 256)
+    }
+    onClicked: colorDialog.open()
+
+    ColorDialog {
+      id: colorDialog
+      title: "Choose a grid color"
+      visible: false
+      onAccepted: {
+        r_spin.value = colorDialog.color.r * 256
+        g_spin.value = colorDialog.color.g * 256
+        b_spin.value = colorDialog.color.b * 256
+        a_spin.value = colorDialog.color.a * 256
+        root.colorSet()
+        colorDialog.close()
+      }
+      onRejected: {
+        colorDialog.close()
+      }
+    }
+
+  }
+}
+

--- a/include/ignition/gui/qml/GzColorRGB.qml
+++ b/include/ignition/gui/qml/GzColorRGB.qml
@@ -103,10 +103,11 @@ GridLayout {
 
   IgnSpinBox {
     id: "a_spin"
-    maximumValue: 255
+    maximumValue: 1.0
     minimumValue: 0
-    value: 255
-    stepSize: 1
+    value: 1.0
+    stepSize: 0.1
+    decimals: 2
     Layout.row: 1
     Layout.column: 5
     onEditingFinished: root.colorSet()
@@ -129,9 +130,9 @@ GridLayout {
       implicitWidth: 40
       implicitHeight: 40
       radius: 5
-      border.color: Qt.rgba(r / 255, g / 255, b / 255, a / 255)
+      border.color: Qt.rgba(r / 255, g / 255, b / 255, a)
       border.width: 2
-      color: Qt.rgba(r / 255, g / 255, b / 255, a / 255)
+      color: Qt.rgba(r / 255, g / 255, b / 255, a)
     }
     onClicked: colorDialog.open()
 
@@ -143,7 +144,7 @@ GridLayout {
         r_spin.value = colorDialog.color.r * 255
         g_spin.value = colorDialog.color.g * 255
         b_spin.value = colorDialog.color.b * 255
-        a_spin.value = colorDialog.color.a * 255
+        a_spin.value = colorDialog.color.a
         root.colorSet()
         colorDialog.close()
       }

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -2,6 +2,7 @@
 <qresource>
   <file>qtquickcontrols2.conf</file>
 
+  <file>qml/GzColorRGB.qml</file>
   <file>qml/IgnCard.qml</file>
   <file>qml/IgnCardSettings.qml</file>
   <file>qml/IgnHelpers.qml</file>

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -2,7 +2,7 @@
 <qresource>
   <file>qtquickcontrols2.conf</file>
 
-  <file>qml/GzColorRGB.qml</file>
+  <file>qml/GzColor.qml</file>
   <file>qml/IgnCard.qml</file>
   <file>qml/IgnCardSettings.qml</file>
   <file>qml/IgnHelpers.qml</file>
@@ -26,6 +26,7 @@
     <!-- This qmldir file defines a QML module that can be imported -->
     <file alias="qmldir">qml/qmldir</file>
     <!-- Add any QML components referenced in the qmldir file here -->
+    <file alias="GzColor.qml">qml/GzColor.qml</file>
     <file alias="IgnSnackBar.qml">qml/IgnSnackBar.qml</file>
     <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
 </qresource>

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -286,7 +286,7 @@ GridLayout {
   }
 
 
-  GzColorRGB {
+  GzColor {
     id: gzcolor
     Layout.columnSpan: 4
     onColorSet: Grid3D.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -52,10 +52,10 @@ GridLayout {
       roll.value = _rot.x;
       pitch.value = _rot.y;
       yaw.value = _rot.z;
-      gzcolor.r = _color.r * 255;
-      gzcolor.g = _color.g * 255;
-      gzcolor.b = _color.b * 255;
-      gzcolor.a = _color.a;
+      gzColorGrid.r = _color.r;
+      gzColorGrid.g = _color.g;
+      gzColorGrid.b = _color.b;
+      gzColorGrid.a = _color.a;
     }
   }
 
@@ -292,12 +292,13 @@ GridLayout {
   }
 
   GzColor { 
-    id: gzcolor
+    id: gzColorGrid
     Layout.columnSpan: 2
     Layout.alignment: Qt.AlignRight
     Layout.bottomMargin: 5
     Layout.rightMargin: 20
-    onColorSet: Grid3D.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
+    useWhiteTheme: Material.theme == Material.Light
+    onColorSet: Grid3D.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
   }
 }
 

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -55,7 +55,7 @@ GridLayout {
       gzcolor.r = _color.r * 255;
       gzcolor.g = _color.g * 255;
       gzcolor.b = _color.b * 255;
-      gzcolor.a = _color.a * 255;
+      gzcolor.a = _color.a;
     }
   }
 
@@ -289,7 +289,7 @@ GridLayout {
   GzColorRGB {
     id: gzcolor
     Layout.columnSpan: 4
-    onColorSet: Grid3D.SetColor(r / 255.0, g / 255.0, b / 255.0, a / 255.0)
+    onColorSet: Grid3D.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
     textVisible: true
   }
 

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -297,8 +297,7 @@ GridLayout {
     Layout.alignment: Qt.AlignRight
     Layout.bottomMargin: 5
     Layout.rightMargin: 20
-    useWhiteTheme: Material.theme == Material.Light
-    onColorSet: Grid3D.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
+    onGzColorSet: Grid3D.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
   }
 }
 

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -52,10 +52,10 @@ GridLayout {
       roll.value = _rot.x;
       pitch.value = _rot.y;
       yaw.value = _rot.z;
-      r.value = _color.r;
-      g.value = _color.g;
-      b.value = _color.b;
-      a.value = _color.a;
+      gzcolor.r = _color.r * 256;
+      gzcolor.g = _color.g * 256;
+      gzcolor.b = _color.b * 256;
+      gzcolor.a = _color.a * 256;
     }
   }
 
@@ -285,99 +285,13 @@ GridLayout {
     font.bold: true
   }
 
-  Text {
-    text: "R"
-    color: "dimgrey"
-  }
 
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: r
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(r.width)
-    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "G"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: g
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(g.width)
-    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "B"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: b
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(b.width)
-    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "A"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: a
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 1.0
-    stepSize: 0.01
-    decimals: getDecimals(a.width)
-    onEditingFinished: Grid3D.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Button {
-    Layout.alignment: Qt.AlignHCenter
+  GzColorRGB {
+    id: gzcolor
     Layout.columnSpan: 4
-    id: color
-    text: qsTr("Custom Color")
-    onClicked: colorDialog.open()
-
-    ColorDialog {
-      id: colorDialog
-      title: "Choose a grid color"
-      visible: false
-      onAccepted: {
-        r.value = colorDialog.color.r
-        g.value = colorDialog.color.g
-        b.value = colorDialog.color.b
-        a.value = colorDialog.color.a
-        Grid3D.SetColor(colorDialog.color.r, colorDialog.color.g, colorDialog.color.b, colorDialog.color.a)
-        colorDialog.close()
-      }
-      onRejected: {
-        colorDialog.close()
-      }
-    }
+    onColorSet: Grid3D.SetColor(r / 256.0, g / 256.0, b / 256.0, a / 256.0)
+    textVisible: true
   }
 
-  // Bottom spacer
-  Item {
-    Layout.columnSpan: 4
-    Layout.fillHeight: true
-  }
 }
 

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -285,13 +285,19 @@ GridLayout {
     font.bold: true
   }
 
-
-  GzColor {
-    id: gzcolor
-    Layout.columnSpan: 4
-    onColorSet: Grid3D.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
-    textVisible: true
+  Text {
+    Layout.columnSpan: 2
+    color: "dimgrey"
+    text: "Grid Color"
   }
 
+  GzColor { 
+    id: gzcolor
+    Layout.columnSpan: 2
+    Layout.alignment: Qt.AlignRight
+    Layout.bottomMargin: 5
+    Layout.rightMargin: 20
+    onColorSet: Grid3D.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
+  }
 }
 

--- a/src/plugins/grid_3d/Grid3D.qml
+++ b/src/plugins/grid_3d/Grid3D.qml
@@ -52,10 +52,10 @@ GridLayout {
       roll.value = _rot.x;
       pitch.value = _rot.y;
       yaw.value = _rot.z;
-      gzcolor.r = _color.r * 256;
-      gzcolor.g = _color.g * 256;
-      gzcolor.b = _color.b * 256;
-      gzcolor.a = _color.a * 256;
+      gzcolor.r = _color.r * 255;
+      gzcolor.g = _color.g * 255;
+      gzcolor.b = _color.b * 255;
+      gzcolor.a = _color.a * 255;
     }
   }
 
@@ -289,7 +289,7 @@ GridLayout {
   GzColorRGB {
     id: gzcolor
     Layout.columnSpan: 4
-    onColorSet: Grid3D.SetColor(r / 256.0, g / 256.0, b / 256.0, a / 256.0)
+    onColorSet: Grid3D.SetColor(r / 255.0, g / 255.0, b / 255.0, a / 255.0)
     textVisible: true
   }
 


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->


#  New feature

* Part of #310

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Pack RGB color GUI into a common widget `GzColorRGB.qml`

Replace the color GUI in `Grid3d` with the common widget


## Test it

(New)
![demo_grid3d_new](https://user-images.githubusercontent.com/50132891/173459812-e3fcf9b1-b61c-4cb0-920c-ff6d2a811d43.gif)

(Deprecated)
![demo_gzcolor_grid3d](https://user-images.githubusercontent.com/50132891/171893545-e4a35638-c818-4a63-9c6f-78054b630c2f.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

