### PR TITLE
Common widget GzColor (Fortress)

### DIFF
--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -32,12 +32,12 @@ GridLayout {
   property bool textVisible: false
 
   signal colorSet()
-  columns: 6
+  columns: 5
   columnSpacing: 10
 
   Text {
     Layout.row: 0
-    Layout.column: 2
+    Layout.column: 1
     Layout.alignment: Qt.AlignCenter
     text: "Red"
     color: "dimgrey"
@@ -51,14 +51,14 @@ GridLayout {
     value: 255 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 2
+    Layout.column: 1
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 3
+    Layout.column: 2
     Layout.alignment: Qt.AlignCenter
     text: "Green"
     color: "dimgrey"
@@ -72,14 +72,14 @@ GridLayout {
     value: 0 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 3
+    Layout.column: 2
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 4
+    Layout.column: 3
     Layout.alignment: Qt.AlignCenter
     text: "Blue"
     color: "dimgrey"
@@ -93,14 +93,14 @@ GridLayout {
     value: 0 
     stepSize: 1
     Layout.row: 1
-    Layout.column: 4
+    Layout.column: 3
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
     Layout.row: 0
-    Layout.column: 5
+    Layout.column: 4
     Layout.alignment: Qt.AlignCenter
     text: "Alpha"
     color: "dimgrey"
@@ -115,22 +115,22 @@ GridLayout {
     stepSize: 0.1
     decimals: 2
     Layout.row: 1
-    Layout.column: 5
+    Layout.column: 4
     Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
   Text {
-    Layout.row: 1
+    Layout.row: 0
     Layout.column: 0
-    Layout.alignment: Qt.AlignCenter
     text: parent.colorName
   }
 
   Button {
     id: ambientButton
     Layout.row: 1
-    Layout.column: 1
+    Layout.column: 0
+    Layout.leftMargin: 5
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered
     ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -52,6 +52,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 2
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -72,6 +73,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 3
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -92,6 +94,7 @@ GridLayout {
     stepSize: 1
     Layout.row: 1
     Layout.column: 4
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 
@@ -113,6 +116,7 @@ GridLayout {
     decimals: 2
     Layout.row: 1
     Layout.column: 5
+    Layout.fillWidth: true
     onEditingFinished: root.colorSet()
   }
 

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,114 +20,21 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
-GridLayout {
-  id: root
-  property string colorName
+Rectangle {
+  id: gzColorRoot
+  
+  implicitWidth: 40
+  implicitHeight: 40
 
-  property alias r: r_spin.value
-  property alias g: g_spin.value
-  property alias b: b_spin.value
-  property alias a: a_spin.value
-
-  property bool textVisible: false
+  property double r: 255
+  property double g: 0
+  property double b: 0
+  property double a: 1.0
 
   signal colorSet()
-  columns: 5
-  columnSpacing: 10
-
-  Text {
-    Layout.row: 0
-    Layout.column: 1
-    Layout.alignment: Qt.AlignCenter
-    text: "Red"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "r_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 255 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 1
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 2
-    Layout.alignment: Qt.AlignCenter
-    text: "Green"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "g_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 0 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 2
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 3
-    Layout.alignment: Qt.AlignCenter
-    text: "Blue"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "b_spin"
-    maximumValue: 255
-    minimumValue: 0
-    value: 0 
-    stepSize: 1
-    Layout.row: 1
-    Layout.column: 3
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 4
-    Layout.alignment: Qt.AlignCenter
-    text: "Alpha"
-    color: "dimgrey"
-    visible: textVisible
-  }
-
-  IgnSpinBox {
-    id: "a_spin"
-    maximumValue: 1.0
-    minimumValue: 0
-    value: 1.0
-    stepSize: 0.1
-    decimals: 2
-    Layout.row: 1
-    Layout.column: 4
-    Layout.fillWidth: true
-    onEditingFinished: root.colorSet()
-  }
-
-  Text {
-    Layout.row: 0
-    Layout.column: 0
-    text: parent.colorName
-  }
 
   Button {
-    id: ambientButton
+    id: colorButton
     Layout.row: 1
     Layout.column: 0
     Layout.leftMargin: 5
@@ -149,11 +56,11 @@ GridLayout {
       title: "Choose a color"
       visible: false
       onAccepted: {
-        r_spin.value = colorDialog.color.r * 255
-        g_spin.value = colorDialog.color.g * 255
-        b_spin.value = colorDialog.color.b * 255
-        a_spin.value = colorDialog.color.a
-        root.colorSet()
+        r = colorDialog.color.r * 255
+        g = colorDialog.color.g * 255
+        b = colorDialog.color.b * 255
+        a = colorDialog.color.a
+        gzColorRoot.colorSet()
         colorDialog.close()
       }
       onRejected: {

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -20,7 +20,7 @@ import QtQuick.Dialogs 1.0
 import QtQuick.Layouts 1.3
 
 
-Rectangle {
+Item {
   id: gzColorRoot
   
   implicitWidth: 40
@@ -35,8 +35,6 @@ Rectangle {
 
   Button {
     id: colorButton
-    Layout.row: 1
-    Layout.column: 0
     Layout.leftMargin: 5
     ToolTip.text: "Open color dialog"
     ToolTip.visible: hovered

--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 2.1
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.3
+
+
+GridLayout {
+  id: root
+  property string colorName
+
+  property alias r: r_spin.value
+  property alias g: g_spin.value
+  property alias b: b_spin.value
+  property alias a: a_spin.value
+
+  property bool textVisible: false
+
+  signal colorSet()
+  columns: 6
+  columnSpacing: 10
+
+  Text {
+    Layout.row: 0
+    Layout.column: 2
+    Layout.alignment: Qt.AlignCenter
+    text: "Red"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "r_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 255 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 2
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 3
+    Layout.alignment: Qt.AlignCenter
+    text: "Green"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "g_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 0 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 3
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 4
+    Layout.alignment: Qt.AlignCenter
+    text: "Blue"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "b_spin"
+    maximumValue: 255
+    minimumValue: 0
+    value: 0 
+    stepSize: 1
+    Layout.row: 1
+    Layout.column: 4
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 5
+    Layout.alignment: Qt.AlignCenter
+    text: "Alpha"
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: "a_spin"
+    maximumValue: 1.0
+    minimumValue: 0
+    value: 1.0
+    stepSize: 0.1
+    decimals: 2
+    Layout.row: 1
+    Layout.column: 5
+    onEditingFinished: root.colorSet()
+  }
+
+  Text {
+    Layout.row: 1
+    Layout.column: 0
+    Layout.alignment: Qt.AlignCenter
+    text: parent.colorName
+  }
+
+  Button {
+    id: ambientButton
+    Layout.row: 1
+    Layout.column: 1
+    ToolTip.text: "Open color dialog"
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    background: Rectangle {
+      implicitWidth: 40
+      implicitHeight: 40
+      radius: 5
+      border.color: Qt.rgba(r / 255, g / 255, b / 255, a)
+      border.width: 2
+      color: Qt.rgba(r / 255, g / 255, b / 255, a)
+    }
+    onClicked: colorDialog.open()
+
+    ColorDialog {
+      id: colorDialog
+      title: "Choose a color"
+      visible: false
+      onAccepted: {
+        r_spin.value = colorDialog.color.r * 255
+        g_spin.value = colorDialog.color.g * 255
+        b_spin.value = colorDialog.color.b * 255
+        a_spin.value = colorDialog.color.a
+        root.colorSet()
+        colorDialog.close()
+      }
+      onRejected: {
+        colorDialog.close()
+      }
+    }
+
+  }
+}
+

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -3,6 +3,7 @@
   <file>qtquickcontrols2.conf</file>
 
   <file>qml/Chart.qml</file>
+  <file>qml/GzColor.qml</file>
   <file>qml/IgnCard.qml</file>
   <file>qml/IgnCardSettings.qml</file>
   <file>qml/IgnHelpers.qml</file>
@@ -28,6 +29,7 @@
     <!-- This qmldir file defines a QML module that can be imported -->
     <file alias="qmldir">qml/qmldir</file>
     <!-- Add any QML components referenced in the qmldir file here -->
+    <file alias="GzColor.qml">qml/GzColor.qml</file>
     <file alias="IgnSnackBar.qml">qml/IgnSnackBar.qml</file>
     <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
 </qresource>

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -52,10 +52,10 @@ GridLayout {
       roll.value = _rot.x;
       pitch.value = _rot.y;
       yaw.value = _rot.z;
-      r.value = _color.r;
-      g.value = _color.g;
-      b.value = _color.b;
-      a.value = _color.a;
+      gzcolor.r = _color.r * 255;
+      gzcolor.g = _color.g * 255;
+      gzcolor.b = _color.b * 255;
+      gzcolor.a = _color.a;
     }
   }
 
@@ -285,99 +285,12 @@ GridLayout {
     font.bold: true
   }
 
-  Text {
-    text: "R"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: r
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(r.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "G"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: g
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(g.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "B"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: b
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(b.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "A"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: a
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 1.0
-    stepSize: 0.01
-    decimals: getDecimals(a.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Button {
-    Layout.alignment: Qt.AlignHCenter
+  GzColor {
+    id: gzcolor
     Layout.columnSpan: 4
-    id: color
-    text: qsTr("Custom Color")
-    onClicked: colorDialog.open()
-
-    ColorDialog {
-      id: colorDialog
-      title: "Choose a grid color"
-      visible: false
-      onAccepted: {
-        r.value = colorDialog.color.r
-        g.value = colorDialog.color.g
-        b.value = colorDialog.color.b
-        a.value = colorDialog.color.a
-        GridConfig.SetColor(colorDialog.color.r, colorDialog.color.g, colorDialog.color.b, colorDialog.color.a)
-        colorDialog.close()
-      }
-      onRejected: {
-        colorDialog.close()
-      }
-    }
+    onColorSet: GridConfig.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
+    textVisible: true
   }
 
-  // Bottom spacer
-  Item {
-    Layout.columnSpan: 4
-    Layout.fillHeight: true
-  }
 }
 

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -285,11 +285,19 @@ GridLayout {
     font.bold: true
   }
 
-  GzColor {
+  Text {
+    Layout.columnSpan: 2
+    color: "dimgrey"
+    text: "Grid Color"
+  }
+
+  GzColor { 
     id: gzcolor
-    Layout.columnSpan: 4
+    Layout.columnSpan: 2
+    Layout.alignment: Qt.AlignRight
+    Layout.bottomMargin: 5
+    Layout.rightMargin: 20
     onColorSet: GridConfig.SetColor(1.0 * r / 255.0, 1.0 * g / 255.0, 1.0 * b / 255.0, a)
-    textVisible: true
   }
 
 }


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->


#  New feature

* Part of #310

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Pack RGB color GUI into a common widget `GzColor.qml`

Replace the color GUI in `GridConfig` with the common widget

**TODO: Also replace `Lights.qml` and `Material.qml` in component inspector**

## Test it


![demo_gzcolor_gridconfig](https://user-images.githubusercontent.com/50132891/171964261-2c1bfd84-dc5d-45f1-9c67-d872d4bf3853.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

