### PR TITLE
Disable failing test on Citadel

### DIFF
--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -82,7 +82,8 @@ class CmdLine : public ::testing::Test
 };
 
 // See https://github.com/ignitionrobotics/ign-gui/issues/75
-TEST_F(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(list))
+// See https://github.com/gazebosim/gz-gui/issues/415
+TEST_F(CmdLine, DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(list))
 {
   // Clear home if it exists
   common::removeAll(this->kFakeHome);


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

## Summary
Temporary disabling test described on #415 to help with https://github.com/gazebo-tooling/release-tools/issues/398

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> Actually disables a test.
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers