### PR TITLE
Improve workflow tests robustness

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -10,7 +10,7 @@ export IGN_CONFIG_PATH=/usr/local/share/ignition
 export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
 
 # For rendering / window tests
-Xvfb :1 -screen 0 1280x1024x24 &
+Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 &
 export DISPLAY=:1.0
 export RENDER_ENGINE_VALUES=ogre2
 export MESA_GL_VERSION_OVERRIDE=3.3


### PR DESCRIPTION
Attempts to fix #58, WIP

## Summary
Before trying to change the underlying virtual buffer used to run GUI tests, this PR changes the arguments passed to the after_make.sh script to make it more robust.

This is already done in gz-rendering, see: https://github.com/gazebosim/gz-rendering/pull/255

Running CI a couple of times before asking for reviews.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> potentially fixes tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
