### PR TITLE
Add common widget for vector3

### DIFF
--- a/include/ignition/gui/qml/GzVector3.qml
+++ b/include/ignition/gui/qml/GzVector3.qml
@@ -31,7 +31,7 @@ import QtQuick.Layouts 1.3
  *    xName: "Red"
  *    yName: "Green"
  *    zName: "Blue"
- *    unit: ""
+ *    gzUnit: ""
  *    readOnly: false
  *    xValue: xValueFromCPP
  *    yValue: yValueFromCPP
@@ -53,8 +53,11 @@ Rectangle {
   property double zValue
 
   /**
-   * Useful only when readOnly == false. User should read spinbox values from
-   * its parameters.
+   * Used to read spinbox values
+   * @params: _x, _y, _z: corresponding spinBoxes values
+   * @note: When readOnly == false, user should read spinbox value from its
+   *        parameters.
+   *        When readOnly == true, this signal is unused.
    */
   signal gzVectorSet(double _x, double _y, double _z)
 
@@ -65,8 +68,10 @@ Rectangle {
 
   // Units, defaults to meters.
   // Set to "" to omit the parentheses.
-  property string unit: "m"
+  property string gzUnit: "m"
 
+
+  /*** The following are private variables: ***/
   // Show Pose bar (used to control expand)
   property bool show: true
 
@@ -102,6 +107,7 @@ Rectangle {
       return 4
     }
   }
+  /*** Private variables end: ***/
 
   /**
    * Used to create a spin box
@@ -140,7 +146,7 @@ Rectangle {
   Rectangle {
     id: gzVectorContent
     width: parent.width
-    height: show ? grid.height : 0
+    height: show ? gzVectorGrid.height : 0
     clip: true
     color: "transparent"
 
@@ -152,7 +158,7 @@ Rectangle {
     }
 
     GridLayout {
-      id: grid
+      id: gzVectorGrid
       width: parent.width
       columns: 4
 
@@ -163,7 +169,7 @@ Rectangle {
       }
 
       Text {
-        text: unit == "" ? xName : xName + ' (' + unit + ')'
+        text: gzUnit == "" ? xName : xName + ' (' + gzUnit + ')'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -190,7 +196,7 @@ Rectangle {
       }
 
       Text {
-        text: unit == "" ? yName : yName + ' (' + unit + ')'
+        text: gzUnit == "" ? yName : yName + ' (' + gzUnit + ')'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -211,7 +217,7 @@ Rectangle {
       }
 
       Text {
-        text: unit == "" ? zName : zName + ' (' + unit + ')'
+        text: gzUnit == "" ? zName : zName + ' (' + gzUnit + ')'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12

--- a/include/ignition/gui/qml/GzVector3.qml
+++ b/include/ignition/gui/qml/GzVector3.qml
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Layouts 1.3
+
+GridLayout {
+  id: gzVectorRoot
+
+  property alias xSpin: x_spin
+  property alias ySpin: y_spin
+  property alias zSpin: z_spin
+
+  property string xName: ""
+  property string yName: ""
+  property string zName: ""
+
+  property bool textVisible: true
+
+  signal gzVectorSet()
+
+  columns: 5
+  columnSpacing: 10
+  property double spinMax: 1000000
+
+  IgnHelpers {
+    id: gzHelper
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 1
+    Layout.alignment: Qt.AlignCenter
+    text: xName
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: x_spin
+    maximumValue: spinMax
+    minimumValue: -spinMax
+    decimals: gzHelper.getDecimals(x_spin.width)
+    Layout.row: 1
+    Layout.column: 1
+    Layout.fillWidth: true
+    onEditingFinished: gzVectorRoot.gzVectorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 2
+    Layout.alignment: Qt.AlignCenter
+    text: yName
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: y_spin
+    maximumValue: spinMax
+    minimumValue: -spinMax
+    stepSize: 1
+    decimals: gzHelper.getDecimals(y_spin.width)
+    Layout.row: 1
+    Layout.column: 2
+    Layout.fillWidth: true
+    onEditingFinished: gzVectorRoot.gzVectorSet()
+  }
+
+  Text {
+    Layout.row: 0
+    Layout.column: 3
+    Layout.alignment: Qt.AlignCenter
+    text: zName
+    color: "dimgrey"
+    visible: textVisible
+  }
+
+  IgnSpinBox {
+    id: z_spin
+    maximumValue: spinMax
+    minimumValue: -spinMax
+    stepSize: 1
+    decimals: gzHelper.getDecimals(z_spin.width)
+    Layout.row: 1
+    Layout.column: 3
+    Layout.fillWidth: true
+    onEditingFinished: gzVectorRoot.gzVectorSet()
+  }
+}

--- a/include/ignition/gui/qml/GzVector3.qml
+++ b/include/ignition/gui/qml/GzVector3.qml
@@ -44,7 +44,7 @@ import QtQuick.Layouts 1.3
 Item {
   id: gzVectorRoot
 
-  // Readn-only / write
+  // Read-only / write
   property bool readOnly: true
 
   // User input value
@@ -67,18 +67,17 @@ Item {
   property string zName: "Z"
 
   // Units, defaults to meters.
-  // Set to "" to omit the parentheses.
+  // Set to "" to omit units & the parentheses.
   property string gzUnit: "m"
 
   // Expand/Collapse of this widget
   property bool expand: true
 
+  // Maximum spinbox value
+  property double spinMax: Number.MAX_VALUE
 
   /*** The following are private variables: ***/
   height: gzVectorContent.height
-
-  // Maximum spinbox value
-  property double spinMax: Number.MAX_VALUE
 
   // local variables to store spinbox values
   property var xItem: {}

--- a/include/ignition/gui/qml/GzVector3.qml
+++ b/include/ignition/gui/qml/GzVector3.qml
@@ -21,7 +21,7 @@ import QtQuick.Layouts 1.3
 /**
  *  Item displaying a 3D vector
  *
- *  Users should load values to xValues, yValues, and zValues.
+ *  Users can set values to xValue, yValue, and zValue.
  *  If readOnly == False,
  *  users can read from signal parameters of GzVectorSet: _x, _y, and _z
  *
@@ -41,7 +41,7 @@ import QtQuick.Layouts 1.3
  *    }
  *  }
 **/
-Rectangle {
+Item {
   id: gzVectorRoot
 
   // Readn-only / write
@@ -70,21 +70,15 @@ Rectangle {
   // Set to "" to omit the parentheses.
   property string gzUnit: "m"
 
+  // Expand/Collapse of this widget
+  property bool expand: true
+
 
   /*** The following are private variables: ***/
-  // Show Pose bar (used to control expand)
-  property bool show: true
-
   height: gzVectorContent.height
 
-  // Left indentation
-  property int indentation: 10
-
-  // Horizontal margins
-  property int margin: 5
-
   // Maximum spinbox value
-  property double spinMax: 1000000
+  property double spinMax: Number.MAX_VALUE
 
   // local variables to store spinbox values
   property var xItem: {}
@@ -94,18 +88,6 @@ Rectangle {
   // Dummy component to use its functions.
   IgnHelpers {
     id: gzHelper
-
-    // Temperary getDecimals()
-    // Remove after merging gz-gui/common_widget_pose
-    function getDecimals(_width) {
-      if (_width <= 0 || _width > 110)
-        return 6
-
-      if (_width <= 80)
-        return 2
-
-      return 4
-    }
   }
   /*** Private variables end: ***/
 
@@ -146,7 +128,7 @@ Rectangle {
   Rectangle {
     id: gzVectorContent
     width: parent.width
-    height: show ? gzVectorGrid.height : 0
+    height: expand ? gzVectorGrid.height : 0
     clip: true
     color: "transparent"
 
@@ -160,13 +142,7 @@ Rectangle {
     GridLayout {
       id: gzVectorGrid
       width: parent.width
-      columns: 4
-
-      // Left spacer
-      Item {
-        Layout.rowSpan: 3
-        width: indentation + margin
-      }
+      columns: 2
 
       Text {
         text: gzUnit == "" ? xName : xName + ' (' + gzUnit + ')'
@@ -187,12 +163,6 @@ Rectangle {
             xItem = xLoader.item
           }
         }
-      }
-
-      // Right spacer
-      Item {
-        Layout.rowSpan: 3
-        width: margin
       }
 
       Text {

--- a/include/ignition/gui/resources.qrc
+++ b/include/ignition/gui/resources.qrc
@@ -3,6 +3,7 @@
   <file>qtquickcontrols2.conf</file>
 
   <file>qml/GzColor.qml</file>
+  <file>qml/GzVector3.qml</file>
   <file>qml/IgnCard.qml</file>
   <file>qml/IgnCardSettings.qml</file>
   <file>qml/IgnHelpers.qml</file>
@@ -27,6 +28,7 @@
     <file alias="qmldir">qml/qmldir</file>
     <!-- Add any QML components referenced in the qmldir file here -->
     <file alias="GzColor.qml">qml/GzColor.qml</file>
+    <file alias="GzVector3.qml">qml/GzVector3.qml</file>
     <file alias="IgnSnackBar.qml">qml/IgnSnackBar.qml</file>
     <file alias="IgnSpinBox.qml">qml/IgnSpinBox.qml</file>
 </qresource>


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

* Part of https://github.com/gazebosim/gz-gui/issues/310
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# New feature

## Summary
Add common widget for vector3

## Test it
Use the following test QML to test: 
```
import QtQuick 2.9
import QtQuick.Layouts 1.3

GzVector3 {
  id: gzVector
  property double xModel: 120
  property double yModel: 110
  property double zModel: 100
  xName: "Red"
  yName: "Green"
  zName: "Blue"
  xSpin.value: xModel
  ySpin.value: yModel
  zSpin.value: zModel
  onGzVectorSet: {
    xModel = xSpin.value
    yModel = ySpin.value
    zModel = zSpin.value
    console.log(xModel, yModel, zModel)
  }
}
```
Then use
```
qmlscene Test.qml
```
to test
## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
