### PR TITLE
Use stepping field in message

### DIFF
--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -256,7 +256,7 @@ void WorldControl::ProcessMsg()
   const auto &header = this->dataPtr->msg.header();
   if (this->dataPtr->msg.stepping() ||
       // Remove this check in Gazebo H
-      (header.data_size() > 0) && (header.data(0).key() == "step"))
+      ((header.data_size() > 0) && (header.data(0).key() == "step")))
   {
     return;
   }

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -254,8 +254,12 @@ void WorldControl::ProcessMsg()
 
   // ignore the message if it's associated with a step
   const auto &header = this->dataPtr->msg.header();
-  if ((header.data_size() > 0) && (header.data(0).key() == "step"))
+  if (this->dataPtr->msg.stepping() ||
+      // Remove this check in Gazebo H
+      (header.data_size() > 0) && (header.data(0).key() == "step"))
+  {
     return;
+  }
 
   // If the pause state of the message doesn't match the pause state of this
   // plugin, then play/pause must have occurred elsewhere (for example, the

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -255,7 +255,7 @@ void WorldControl::ProcessMsg()
   // ignore the message if it's associated with a step
   const auto &header = this->dataPtr->msg.header();
   if (this->dataPtr->msg.stepping() ||
-      // Remove this check in Gazebo H
+      // (deprecated) Remove this check in Gazebo H
       ((header.data_size() > 0) && (header.data(0).key() == "step")))
   {
     return;


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

Use the `stepping` field in the world statistics message that became available in https://github.com/gazebosim/gz-msgs/pull/199.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.