### PR TITLE
Dialog read attribute: don't create a file

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,10 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition GUI 3.10 to 3.11
+
+* `Dialog::ReadConfigAttribute` doesn't create a missing file anymore.
+
 ## Ignition GUI 3.6 to 3.7
 
 * The `Application::PluginAdded` signal used to send empty strings. Now it

--- a/include/ignition/gui/Dialog.hh
+++ b/include/ignition/gui/Dialog.hh
@@ -69,9 +69,9 @@ namespace ignition
         const std::string &_path, const std::string &_attribute,
         const bool _value) const;
 
-      /// \brief Gets a config attribute value, if not found in config
-      /// write the default in the config and get it.
-      /// creates config file if it doesn't exist.
+      /// \brief Gets a config attribute value.
+      /// It will return an empty string if the config file or the attribute
+      /// don't exist.
       /// \param[in] _path config path
       /// \param[in] _attribute attribute name
       /// \return attribute value as string

--- a/src/Dialog_TEST.cc
+++ b/src/Dialog_TEST.cc
@@ -47,23 +47,23 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   auto dialog = new Dialog;
   ASSERT_NE(nullptr, dialog);
 
-  // Read attribute value when the default the config is not set
+  // Read attribute value when the default the config doesn't exist
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
     std::string allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
       "allow");
     EXPECT_EQ(allow, "");
 
-    // Config file is created when a read is attempted
-    EXPECT_TRUE(common::exists(kTestConfigFile));
-
-    // Delete file
-    std::remove(kTestConfigFile.c_str());
+    // Config file still doesn't exist
+    EXPECT_FALSE(common::exists(kTestConfigFile));
   }
 
   // Read a non existing attribute
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
+
+    // TODO create file
+
     dialog->setObjectName("quick_menu");
     dialog->SetDefaultConfig(std::string(
       "<dialog name=\"quick_menu\" show=\"true\"/>"));

--- a/src/Dialog_TEST.cc
+++ b/src/Dialog_TEST.cc
@@ -33,26 +33,26 @@ char* g_argv[] =
 
 using namespace ignition;
 using namespace gui;
-using namespace std::chrono_literals;
 
 /////////////////////////////////////////////////
 TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
 {
-  ignition::common::Console::SetVerbosity(4);
-  Application app(g_argc, g_argv, ignition::gui::WindowType::kDialog);
-
-  // Change default config path
-  App()->SetDefaultConfigPath(kTestConfigFile);
+  common::Console::SetVerbosity(4);
+  Application app(g_argc, g_argv, WindowType::kDialog);
 
   auto dialog = new Dialog;
   ASSERT_NE(nullptr, dialog);
+  dialog->setObjectName("quick_menu");
 
-  // Read attribute value when the default the config doesn't exist
+  // Start without a file
+  std::remove(kTestConfigFile.c_str());
+
+  // Read attribute value when the config doesn't exist
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
-    std::string allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
+    std::string allow = dialog->ReadConfigAttribute(kTestConfigFile,
       "allow");
-    EXPECT_EQ(allow, "");
+    EXPECT_TRUE(allow.empty());
 
     // Config file still doesn't exist
     EXPECT_FALSE(common::exists(kTestConfigFile));
@@ -62,17 +62,15 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 
-    // TODO create file
-
-    dialog->setObjectName("quick_menu");
-    dialog->SetDefaultConfig(std::string(
-      "<dialog name=\"quick_menu\" show=\"true\"/>"));
-    std::string allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
-      "allow");
-    EXPECT_EQ(allow, "");
-
-    // Config file is created when a read is attempted
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<dialog name='quick_menu'/>";
+    configFile.close();
     EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    std::string allow = dialog->ReadConfigAttribute(kTestConfigFile,
+      "allow");
+    EXPECT_TRUE(allow.empty());
 
     // Delete file
     std::remove(kTestConfigFile.c_str());
@@ -81,12 +79,16 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   // Read an existing attribute
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
-    std::string show = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
+
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<dialog name='quick_menu' show='true'/>";
+    configFile.close();
+    EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    std::string show = dialog->ReadConfigAttribute(kTestConfigFile,
       "show");
     EXPECT_EQ(show, "true");
-
-    // Config file is created when a read is attempted
-    EXPECT_TRUE(common::exists(kTestConfigFile));
 
     // Delete file
     std::remove(kTestConfigFile.c_str());
@@ -96,19 +98,18 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 
-    // Call a read to create config file
-    std::string allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
-      "allow");
-
-    // Empty string for a non existing attribute
-    EXPECT_EQ(allow, "");
-    dialog->UpdateConfigAttribute(app.DefaultConfigPath(), "allow", true);
-    allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
-      "allow");
-    EXPECT_EQ(allow, "true");
-
-    // Config file is created when a read is attempted
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<dialog name='quick_menu'/>";
+    configFile.close();
     EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    // Update value
+    dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true);
+
+    // Read value
+    auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
+    EXPECT_EQ(allow, "true");
 
     // Delete file
     std::remove(kTestConfigFile.c_str());
@@ -118,16 +119,18 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 
-    // Call a read to create config file
-    std::string allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
-      "allow");
-    dialog->UpdateConfigAttribute(app.DefaultConfigPath(), "allow", false);
-    allow = dialog->ReadConfigAttribute(app.DefaultConfigPath(),
-      "allow");
-    EXPECT_EQ(allow, "false");
-
-    // Config file is created when a read is attempted
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<dialog name='quick_menu' show='true'/>";
+    configFile.close();
     EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    // Update value
+    dialog->UpdateConfigAttribute(kTestConfigFile, "allow", false);
+
+    // Read value
+    auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
+    EXPECT_EQ(allow, "false");
 
     // Delete file
     std::remove(kTestConfigFile.c_str());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `ReadConfigAttribute` function was doing more than reading, it was also creating a file if it didn't exist, which wasn't very convenient. Since this is a brand-new function, I think it's ok to change its behavior. I documented it on the migration guide just in case.

* This is needed by https://github.com/gazebosim/gz-sim/pull/1536

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
