### PR TITLE
Fix attribute update when <dialog> isn't present

### DIFF
--- a/include/ignition/gui/Dialog.hh
+++ b/include/ignition/gui/Dialog.hh
@@ -67,8 +67,8 @@ namespace ignition
       ///
       /// `<dialog name="dialog_name" attribute="value"/>`
       ///
-      /// If a dialog elentn with this dialog's name doesn't exist yet, one will
-      /// be created.
+      /// If a dialog element with this dialog's name doesn't exist yet, one
+      /// will be created.
       ///
       /// \param[in] _path File path. File must already exist, this function
       /// will not create a new file.

--- a/include/ignition/gui/Dialog.hh
+++ b/include/ignition/gui/Dialog.hh
@@ -58,23 +58,35 @@ namespace ignition
 
       /// \brief Store dialog default config
       /// \param[in] _config XML config as string
+      /// \deprecated Introduce deprecation warnings on v7.
       public: void SetDefaultConfig(const std::string &_config);
 
-      /// \brief Write dialog config
-      /// \param[in] _path config path
+      /// \brief Update an attribute on an XML file. The attribute belongs to
+      /// a `<dialog>` element that has a `name` attrbute matching this dialog's
+      /// name, i.e.
+      ///
+      /// `<dialog name="dialog_name" attribute="value"/>`
+      ///
+      /// If a dialog elentn with this dialog's name doesn't exist yet, one will
+      /// be created.
+      ///
+      /// \param[in] _path File path. File must already exist, this function
+      /// will not create a new file.
       /// \param[in] _attribute XMLElement attribute name
       /// \param[in] _value XMLElement attribute value
-      /// \return true if written to config file
+      /// \return True if written to config file
       public: bool UpdateConfigAttribute(
         const std::string &_path, const std::string &_attribute,
         const bool _value) const;
 
-      /// \brief Gets a config attribute value.
-      /// It will return an empty string if the config file or the attribute
+      /// \brief Gets an attribute value from an XML file. The attribute belongs
+      /// to a `<dialog>` element that has a `name` attribute matching this
+      /// dialog's name.
+      /// It will return an empty string if the file or the attribute
       /// don't exist.
-      /// \param[in] _path config path
+      /// \param[in] _path File path
       /// \param[in] _attribute attribute name
-      /// \return attribute value as string
+      /// \return Attribute value as string
       public: std::string ReadConfigAttribute(const std::string &_path,
         const std::string &_attribute) const;
 

--- a/src/Dialog.cc
+++ b/src/Dialog.cc
@@ -27,9 +27,6 @@ namespace ignition
   {
     class DialogPrivate
     {
-      /// \brief default dialog config
-      public: std::string config{""};
-
       /// \brief Pointer to quick window
       public: QQuickWindow *quickWindow{nullptr};
     };
@@ -51,9 +48,11 @@ Dialog::Dialog()
       App()->Engine()->rootObjects().value(0));
   if (!this->dataPtr->quickWindow)
   {
+    // We'd only get here if the QML file is malformed
+    // LCOV_EXCL_START
     ignerr << "Internal error: Failed to instantiate QML file [" << qmlFile
            << "]" << std::endl;
-    return;
+    // LCOV_EXCL_STOP
   }
 }
 
@@ -74,7 +73,10 @@ QQuickItem *Dialog::RootItem() const
   auto dialogItem = this->dataPtr->quickWindow->findChild<QQuickItem *>();
   if (!dialogItem)
   {
+    // We'd only get here if the QML file is malformed
+    // LCOV_EXCL_START
     ignerr << "Internal error: Null dialog root item!" << std::endl;
+    // LCOV_EXCL_STOP
   }
 
   return dialogItem;
@@ -84,7 +86,7 @@ QQuickItem *Dialog::RootItem() const
 bool Dialog::UpdateConfigAttribute(const std::string &_path,
   const std::string &_attribute, const bool _value) const
 {
-  if (_path.empty())
+  if (!common::exists(_path))
   {
     ignerr << "Missing config file" << std::endl;
     return false;
@@ -101,37 +103,43 @@ bool Dialog::UpdateConfigAttribute(const std::string &_path,
   }
 
   // Update attribute value for the correct dialog
+  bool updated{false};
   for (auto dialogElem = doc.FirstChildElement("dialog");
     dialogElem != nullptr;
     dialogElem = dialogElem->NextSiblingElement("dialog"))
   {
-    if(dialogElem->Attribute("name") == this->objectName().toStdString())
+    if (dialogElem->Attribute("name") == this->objectName().toStdString())
     {
       dialogElem->SetAttribute(_attribute.c_str(), _value);
+      updated = true;
     }
   }
 
-  // Write config file
-  tinyxml2::XMLPrinter printer;
-  doc.Print(&printer);
-
-  std::string config = printer.CStr();
-  std::ofstream out(_path.c_str(), std::ios::out);
-  if (!out)
+  // Create new <dialog> if missing
+  if (!updated)
   {
-    ignerr << "Unable to open file: " << _path
-           << ".\nCheck file permissions.\n";
+    auto dialogElem = doc.NewElement("dialog");
+    dialogElem->SetAttribute("name", this->objectName().toStdString().c_str());
+    dialogElem->SetAttribute(_attribute.c_str(), _value);
+    doc.InsertEndChild(dialogElem);
   }
-  else
-    out << config;
+
+  // Write config file
+  if (!doc.SaveFile(_path.c_str()))
+  {
+    // LCOV_EXCL_START
+    ignerr << "Failed to save file: " << _path
+           << ".\nCheck file permissions.\n";
+    // LCOV_EXCL_STOP
+  }
 
   return true;
 }
 
 /////////////////////////////////////////////////
-void Dialog::SetDefaultConfig(const std::string &_config)
+void Dialog::SetDefaultConfig(const std::string &)
 {
-  this->dataPtr->config = _config;
+  ignwarn << "Dialog::SetDefaultConfig has no effect." << std::endl;
 }
 
 /////////////////////////////////////////////////

--- a/src/Dialog_TEST.cc
+++ b/src/Dialog_TEST.cc
@@ -177,7 +177,7 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
     std::remove(kTestConfigFile.c_str());
   }
 
-  // Update a file without a <dialog>
+  // Update a file with a different <dialog>
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 
@@ -198,7 +198,7 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
     std::remove(kTestConfigFile.c_str());
   }
 
-  // Update a file with a different <dialog>
+  // Update a file without a <dialog>
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 

--- a/src/Dialog_TEST.cc
+++ b/src/Dialog_TEST.cc
@@ -35,6 +35,19 @@ using namespace ignition;
 using namespace gui;
 
 /////////////////////////////////////////////////
+TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Accessors))
+{
+  common::Console::SetVerbosity(4);
+  Application app(g_argc, g_argv, WindowType::kDialog);
+
+  auto dialog = new Dialog;
+  ASSERT_NE(nullptr, dialog);
+
+  EXPECT_NE(nullptr, dialog->RootItem());
+  EXPECT_NE(nullptr, dialog->QuickWindow());
+}
+
+/////////////////////////////////////////////////
 TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
 {
   common::Console::SetVerbosity(4);
@@ -44,10 +57,13 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
   ASSERT_NE(nullptr, dialog);
   dialog->setObjectName("quick_menu");
 
+  // Call deprecated function for test coverage
+  dialog->SetDefaultConfig("");
+
   // Start without a file
   std::remove(kTestConfigFile.c_str());
 
-  // Read attribute value when the config doesn't exist
+  // The file doesn't exist
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
     std::string allow = dialog->ReadConfigAttribute(kTestConfigFile,
@@ -56,6 +72,31 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
 
     // Config file still doesn't exist
     EXPECT_FALSE(common::exists(kTestConfigFile));
+
+    EXPECT_FALSE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true));
+
+    // Config file still doesn't exist
+    EXPECT_FALSE(common::exists(kTestConfigFile));
+  }
+
+  // Malformed file
+  {
+    EXPECT_FALSE(common::exists(kTestConfigFile));
+
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "banana";
+    configFile.close();
+    EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    std::string allow = dialog->ReadConfigAttribute(kTestConfigFile,
+      "allow");
+    EXPECT_TRUE(allow.empty());
+
+    EXPECT_FALSE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true));
+
+    // Delete file
+    std::remove(kTestConfigFile.c_str());
   }
 
   // Read a non existing attribute
@@ -105,7 +146,7 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
     EXPECT_TRUE(common::exists(kTestConfigFile));
 
     // Update value
-    dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true);
+    EXPECT_TRUE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true));
 
     // Read value
     auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
@@ -115,22 +156,64 @@ TEST(DialogTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(UpdateDialogConfig))
     std::remove(kTestConfigFile.c_str());
   }
 
-  // Update a existing attribute
+  // Update an existing attribute
   {
     EXPECT_FALSE(common::exists(kTestConfigFile));
 
     // Create file
     std::ofstream configFile(kTestConfigFile);
-    configFile << "<dialog name='quick_menu' show='true'/>";
+    configFile << "<dialog name='quick_menu' allow='true'/>";
     configFile.close();
     EXPECT_TRUE(common::exists(kTestConfigFile));
 
     // Update value
-    dialog->UpdateConfigAttribute(kTestConfigFile, "allow", false);
+    EXPECT_TRUE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", false));
 
     // Read value
     auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
     EXPECT_EQ(allow, "false");
+
+    // Delete file
+    std::remove(kTestConfigFile.c_str());
+  }
+
+  // Update a file without a <dialog>
+  {
+    EXPECT_FALSE(common::exists(kTestConfigFile));
+
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<dialog name='banana' allow='false'/>";
+    configFile.close();
+    EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    // Update value
+    EXPECT_TRUE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true));
+
+    // Read value
+    auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
+    EXPECT_EQ(allow, "true");
+
+    // Delete file
+    std::remove(kTestConfigFile.c_str());
+  }
+
+  // Update a file with a different <dialog>
+  {
+    EXPECT_FALSE(common::exists(kTestConfigFile));
+
+    // Create file
+    std::ofstream configFile(kTestConfigFile);
+    configFile << "<banana/>";
+    configFile.close();
+    EXPECT_TRUE(common::exists(kTestConfigFile));
+
+    // Update value
+    EXPECT_TRUE(dialog->UpdateConfigAttribute(kTestConfigFile, "allow", true));
+
+    // Read value
+    auto allow = dialog->ReadConfigAttribute(kTestConfigFile, "allow");
+    EXPECT_EQ(allow, "true");
 
     // Delete file
     std::remove(kTestConfigFile.c_str());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This fixes a situation when a file doesn't have a `<dialog>` element yet, and we need to create one to update its value.

I also increased the `Dialog`'s test coverage to 100% and pre-deprecated a function that's no longer needed.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
