### PR TITLE
Fix main window moving with ColorDialogue of GzColor

### DIFF
--- a/include/ignition/gui/qml/GzColor.qml
+++ b/include/ignition/gui/qml/GzColor.qml
@@ -57,7 +57,6 @@ Item {
     title: "Choose a color"
     visible: false
     showAlphaChannel: true
-    modality: Qt.ApplicationModal
     onAccepted: {
       r = gzColorDialog.color.r
       g = gzColorDialog.color.g


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Bug: dragging the color dialogue will cause the main window to move with the dialogue window, which was not the behavior before the common widget GzColor was added.

![gzcolor_bug_demo](https://user-images.githubusercontent.com/50132891/183519971-416779d2-8449-4876-8636-10914506a721.gif)

With this fix:

![gzcolor_bugfix_demo](https://user-images.githubusercontent.com/50132891/183519997-cd77c418-cb23-4ef8-b058-38fda431e8d9.gif)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
