### PR TITLE
Replace color and pose for GridConfig with GzColor and GzPose

### DIFF
--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -32,7 +32,7 @@ GridLayout {
 
   // Dummy item for using getDecimals()
   IgnHelpers {
-    id: ignhelper
+    id: ignHelper
   }
 
   Connections {
@@ -156,7 +156,7 @@ GridLayout {
     maximumValue: Number.MAX_VALUE
     minimumValue: 0.0000001
     value: 1.00
-    decimals: ignhelper.getDecimals(cellLength.width)
+    decimals: ignHelper.getDecimals(cellLength.width)
     stepSize: 0.01
     onEditingFinished: GridConfig.UpdateCellLength(cellLength.value)
   }
@@ -193,7 +193,7 @@ GridLayout {
       // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
       // from gz-gui GzPose.qml
       GridConfig.SetPose(_x, _y, _z, _roll, _pitch, _yaw)
-      }
+    }
     expand: true
     gzPlotEnabled: false
   }

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -30,14 +30,9 @@ GridLayout {
   anchors.leftMargin: 10
   anchors.rightMargin: 10
 
-  // Get number of decimal digits based on a widget's width
-  // TODO(chapulina) Move this to a common place so all widgets can use it
-  function getDecimals(_width) {
-    if (_width <= 80)
-      return 2;
-    else if (_width <= 100)
-      return 4;
-    return 6;
+  // Dummy item for using getDecimals()
+  IgnHelpers {
+    id: ignhelper
   }
 
   Connections {
@@ -52,10 +47,10 @@ GridLayout {
       gzPoseInstance.rollValue = _rot.x;
       gzPoseInstance.pitchValue = _rot.y;
       gzPoseInstance.yawValue = _rot.z;
-      r.value = _color.r;
-      g.value = _color.g;
-      b.value = _color.b;
-      a.value = _color.a;
+      gzColorGrid.r = _color.r;
+      gzColorGrid.g = _color.g;
+      gzColorGrid.b = _color.b;
+      gzColorGrid.a = _color.a;
     }
   }
 
@@ -161,7 +156,7 @@ GridLayout {
     maximumValue: Number.MAX_VALUE
     minimumValue: 0.0000001
     value: 1.00
-    decimals: getDecimals(cellLength.width)
+    decimals: ignhelper.getDecimals(cellLength.width)
     stepSize: 0.01
     onEditingFinished: GridConfig.UpdateCellLength(cellLength.value)
   }
@@ -211,92 +206,18 @@ GridLayout {
   }
 
   Text {
-    text: "R"
+    Layout.columnSpan: 2
     color: "dimgrey"
+    text: "Grid Color"
   }
 
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: r
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(r.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "G"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: g
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(g.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "B"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: b
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 0.7
-    stepSize: 0.01
-    decimals: getDecimals(b.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Text {
-    text: "A"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: a
-    maximumValue: 1.00
-    minimumValue: 0.00
-    value: 1.0
-    stepSize: 0.01
-    decimals: getDecimals(a.width)
-    onEditingFinished: GridConfig.SetColor(r.value, g.value, b.value, a.value)
-  }
-
-  Button {
-    Layout.alignment: Qt.AlignHCenter
-    Layout.columnSpan: 4
-    id: color
-    text: qsTr("Custom Color")
-    onClicked: colorDialog.open()
-
-    ColorDialog {
-      id: colorDialog
-      title: "Choose a grid color"
-      visible: false
-      onAccepted: {
-        r.value = colorDialog.color.r
-        g.value = colorDialog.color.g
-        b.value = colorDialog.color.b
-        a.value = colorDialog.color.a
-        GridConfig.SetColor(colorDialog.color.r, colorDialog.color.g, colorDialog.color.b, colorDialog.color.a)
-        colorDialog.close()
-      }
-      onRejected: {
-        colorDialog.close()
-      }
-    }
+  GzColor {
+    id: gzColorGrid
+    Layout.columnSpan: 2
+    Layout.alignment: Qt.AlignRight
+    Layout.bottomMargin: 5
+    Layout.rightMargin: 20
+    onGzColorSet: GridConfig.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
   }
 
   // Bottom spacer

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -215,15 +215,9 @@ GridLayout {
     id: gzColorGrid
     Layout.columnSpan: 2
     Layout.alignment: Qt.AlignRight
-    Layout.bottomMargin: 5
+    Layout.bottomMargin: 10
     Layout.rightMargin: 20
     onGzColorSet: GridConfig.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
-  }
-
-  // Bottom spacer
-  Item {
-    Layout.columnSpan: 4
-    Layout.fillHeight: true
   }
 }
 

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -46,12 +46,12 @@ GridLayout {
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;
-      x.value = _pos.x;
-      y.value = _pos.y;
-      z.value = _pos.z;
-      roll.value = _rot.x;
-      pitch.value = _rot.y;
-      yaw.value = _rot.z;
+      gzPoseInstance.xValue = _pos.x;
+      gzPoseInstance.yValue = _pos.y;
+      gzPoseInstance.zValue = _pos.z;
+      gzPoseInstance.rollValue = _rot.x;
+      gzPoseInstance.pitchValue = _rot.y;
+      gzPoseInstance.yawValue = _rot.z;
       r.value = _color.r;
       g.value = _color.g;
       b.value = _color.b;
@@ -182,100 +182,25 @@ GridLayout {
     font.bold: true
   }
 
-  Text {
-    text: "X"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
+  GzPose {
+    id: gzPoseInstance
+    Layout.columnSpan: 4
     Layout.fillWidth: true
-    id: x
-    value: 0.00
-    maximumValue: Number.MAX_VALUE
-    minimumValue: -Number.MAX_VALUE
-    decimals: getDecimals(x.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
-  }
+    readOnly: false
+    xValue: 0.00
+    yValue: 0.00
+    zValue: 0.00
+    rollValue: 0.00
+    pitchValue: 0.00
+    yawValue: 0.00
 
-  Text {
-    text: "Roll"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: roll
-    maximumValue: 6.28
-    minimumValue: 0.00
-    value: 0.00
-    decimals: getDecimals(roll.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
-  }
-
-  Text {
-    text: "Y"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: y
-    value: 0.00
-    maximumValue: Number.MAX_VALUE
-    minimumValue: -Number.MAX_VALUE
-    decimals: getDecimals(y.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
-  }
-
-  Text {
-    text: "Pitch"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: pitch
-    maximumValue: 6.28
-    minimumValue: 0.00
-    value: 0.00
-    decimals: getDecimals(pitch.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
-  }
-
-  Text {
-    text: "Z"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: z
-    value: 0.00
-    maximumValue: Number.MAX_VALUE
-    minimumValue: -Number.MAX_VALUE
-    decimals: getDecimals(z.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
-  }
-
-  Text {
-    text: "Yaw"
-    color: "dimgrey"
-  }
-
-  IgnSpinBox {
-    Layout.fillWidth: true
-    id: yaw
-    maximumValue: 6.28
-    minimumValue: 0.00
-    value: 0.00
-    decimals: getDecimals(yaw.width)
-    stepSize: 0.01
-    onEditingFinished: GridConfig.SetPose(x.value, y.value, z.value, roll.value, pitch.value, yaw.value)
+    onGzPoseSet: {
+      // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
+      // from gz-gui GzPose.qml
+      GridConfig.SetPose(_x, _y, _z, _roll, _pitch, _yaw)
+      }
+    expand: true
+    gzPlotEnabled: false
   }
 
   Text {


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

As title. The behavior should be exactly the same as before.

![gridconfig_replace_demo](https://user-images.githubusercontent.com/50132891/184009524-713a0a67-e280-4c17-8e99-d38baffd82fc.gif)

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
