### PR TITLE
Fix warnings on Jammy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,17 +16,17 @@ set (sources
 )
 
 set (gtest_sources
-  Application_TEST
-  Conversions_TEST
-  Dialog_TEST
-  DragDropModel_TEST
-  Helpers_TEST
-  GuiEvents_TEST
-  ign_TEST
-  MainWindow_TEST
-  PlottingInterface_TEST
-  Plugin_TEST
-  SearchModel_TEST
+  Application_TEST.cc
+  Conversions_TEST.cc
+  Dialog_TEST.cc
+  DragDropModel_TEST.cc
+  Helpers_TEST.cc
+  GuiEvents_TEST.cc
+  gz_TEST.cc
+  MainWindow_TEST.cc
+  PlottingInterface_TEST.cc
+  Plugin_TEST.cc
+  SearchModel_TEST.cc
 )
 
 if (MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ set (gtest_sources
   DragDropModel_TEST.cc
   Helpers_TEST.cc
   GuiEvents_TEST.cc
-  gz_TEST.cc
+  ign_TEST.cc
   MainWindow_TEST.cc
   PlottingInterface_TEST.cc
   Plugin_TEST.cc

--- a/src/PlottingInterface_TEST.cc
+++ b/src/PlottingInterface_TEST.cc
@@ -172,8 +172,7 @@ TEST(PlottingInterfaceTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Transport))
 
   auto transport = Transport();
 
-  double time = 10;
-  std::shared_ptr<double> timeRef(&time);
+  auto timeRef = std::make_shared<double>(10);
 
   transport.Subscribe("/collision_topic", "pose-position-x", 1, timeRef);
   transport.Subscribe("/collision_topic", "pose-position-z", 1, timeRef);


### PR DESCRIPTION
# 🦟 Bug fix

* Backport #428

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

We also support Fortress on Jammy, and these have been showing up.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
