### PR TITLE
Add Vulkan QML backend

### DIFF
--- a/include/gz/gui/Application.hh
+++ b/include/gz/gui/Application.hh
@@ -70,8 +70,11 @@ namespace gz
       /// \param[in] _argc Argument count.
       /// \param[in] _argv Argument values.
       /// \param[in] _type Window type, by default it's a main window.
+      /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
+      /// option
       public: Application(int &_argc, char **_argv,
-          const WindowType _type = WindowType::kMainWindow);
+          const WindowType _type = WindowType::kMainWindow,
+          const char *_renderEngineGuiApiBackend = nullptr);
 
       /// \brief Destructor
       public: virtual ~Application();

--- a/include/gz/gui/Helpers.hh
+++ b/include/gz/gui/Helpers.hh
@@ -89,6 +89,15 @@ namespace gz
     GZ_GUI_VISIBLE
     std::string renderEngineName();
 
+    /// \brief Just like renderEngineName(), but valid entries are:
+    ///  - opengl (default)
+    ///  - metal (Apple only)
+    ///  - vulkan
+    /// \return Name of API backend used on the GUI, as stored in the
+    /// `MainWindow`'s "renderEngineBackendApiName" property.
+    GZ_GUI_VISIBLE
+    std::string renderEngineBackendApiName();
+
     /// \brief Import path for gz-gui QML modules added to the Qt resource
     /// system. This helper function returns the QRC resource path where custom
     /// Gazebo QML modules can be imported from. To import a Gazebo QML

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -89,9 +89,18 @@ namespace gz
 using namespace gz;
 using namespace gui;
 
+enum class GZ_COMMON_HIDDEN AvailableAPIs
+{
+  OpenGL,
+  Vulkan,
+  Metal
+};
+
 /////////////////////////////////////////////////
-Application::Application(int &_argc, char **_argv, const WindowType _type)
-  : QApplication(_argc, _argv), dataPtr(new ApplicationPrivate)
+Application::Application(int &_argc, char **_argv, const WindowType _type,
+                         const char *_renderEngineGuiApiBackend) :
+  QApplication(_argc, _argv),
+  dataPtr(new ApplicationPrivate)
 {
   gzdbg << "Initializing application." << std::endl;
 
@@ -99,10 +108,29 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
   this->setOrganizationDomain("gazebosim.org");
   this->setApplicationName("Gazebo GUI");
 
-#if __APPLE__
-  // Use the Metal graphics API on macOS.
-  gzdbg << "Qt using Metal graphics interface" << std::endl;
-  QQuickWindow::setSceneGraphBackend(QSGRendererInterface::MetalRhi);
+#ifdef __APPLE__
+  AvailableAPIs api = AvailableAPIs::Metal;
+#else
+  AvailableAPIs api = AvailableAPIs::OpenGL;
+#endif
+  if (_renderEngineGuiApiBackend)
+  {
+    const std::string renderEngineGuiApiBackend = _renderEngineGuiApiBackend;
+    if (renderEngineGuiApiBackend == "vulkan")
+      api = AvailableAPIs::Vulkan;
+#ifdef __APPLE__
+    if (renderEngineGuiApiBackend == "metal")
+      api = AvailableAPIs::Metal;
+#endif
+  }
+
+#ifdef __APPLE__
+  if (api == AvailableAPIs::Metal)
+  {
+    // Use the Metal graphics API on macOS.
+    gzdbg << "Qt using Metal graphics interface" << std::endl;
+    QQuickWindow::setSceneGraphBackend(QSGRendererInterface::MetalRhi);
+  }
 
   // TODO(srmainwaring): implement facility for overriding the default
   //    graphics API in macOS, in which case there are restrictions on
@@ -120,9 +148,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
 #else
   // Otherwise use OpenGL (or Vulkan when supported and requested)
 
-  const bool useVulkan = true;  // TODO(anyone)
-
-  if (useVulkan)
+  if (api == AvailableAPIs::Vulkan)
   {
     gzdbg << "Qt using Vulkan graphics interface" << std::endl;
 
@@ -180,10 +206,20 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
     }
     else
     {
-      if (useVulkan)
+      switch (api)
       {
+      case AvailableAPIs::OpenGL:
+        this->dataPtr->mainWin->setProperty("renderEngineBackendApiName",
+                                            "opengl");
+        break;
+      case AvailableAPIs::Vulkan:
         this->dataPtr->mainWin->setProperty("renderEngineBackendApiName",
                                             "vulkan");
+        break;
+      case AvailableAPIs::Metal:
+        this->dataPtr->mainWin->setProperty("renderEngineBackendApiName",
+                                            "metal");
+        break;
       }
     }
   }

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -208,6 +208,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
     {
       switch (api)
       {
+      default:
       case AvailableAPIs::OpenGL:
         this->dataPtr->mainWin->setProperty("renderEngineBackendApiName",
                                             "opengl");

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -164,7 +164,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
 #  endif
     );
 
-#  if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+#  if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
     QQuickWindow::setSceneGraphBackend(QSGRendererInterface::VulkanRhi);
 #  endif
   }

--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -196,6 +196,20 @@ std::string gz::gui::renderEngineName()
 }
 
 /////////////////////////////////////////////////
+std::string gz::gui::renderEngineBackendApiName()
+{
+  auto win = App()->findChild<MainWindow *>();
+  if (nullptr == win)
+    return {};
+
+  auto renderEngineNameVariant = win->property("renderEngineBackendApiName");
+  if (!renderEngineNameVariant.isValid())
+    return {};
+
+  return renderEngineNameVariant.toString().toStdString();
+}
+
+/////////////////////////////////////////////////
 const QString gz::gui::qmlQrcImportPath()
 {
   return "qrc:/gz-gui-qml/";

--- a/src/plugins/minimal_scene/CMakeLists.txt
+++ b/src/plugins/minimal_scene/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
   MinimalScene.cc
   MinimalSceneRhi.cc
   MinimalSceneRhiOpenGL.cc
+  MinimalSceneRhiVulkan.cc
   EngineToQtInterface.cc
 )
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -22,6 +22,7 @@
 #include "MinimalSceneRhi.hh"
 #include "MinimalSceneRhiMetal.hh"
 #include "MinimalSceneRhiOpenGL.hh"
+#include "MinimalSceneRhiVulkan.hh"
 
 #include <algorithm>
 #include <list>
@@ -39,6 +40,7 @@
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RayQuery.hh>
 #include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 #include <gz/rendering/Utils.hh>
@@ -49,6 +51,10 @@
 #include "gz/gui/GuiEvents.hh"
 #include "gz/gui/Helpers.hh"
 #include "gz/gui/MainWindow.hh"
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+#  include <QVulkanInstance>
+#endif
 
 Q_DECLARE_METATYPE(gz::gui::plugins::RenderSync*)
 
@@ -298,8 +304,19 @@ void RenderSync::Shutdown()
 GzRenderer::GzRenderer()
   : dataPtr(utils::MakeUniqueImpl<Implementation>())
 {
-  // Set default graphics API to OpenGL
-  this->SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
+  const std::string backendApiName = gz::gui::renderEngineBackendApiName();
+  if (backendApiName == "vulkan")
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::VULKAN);
+  }
+  else if (backendApiName == "metal")
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::METAL);
+  }
+  else
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
+  }
 }
 
 /////////////////////////////////////////////////
@@ -562,6 +579,87 @@ void GzRenderer::BroadcastKeyPress()
 }
 
 /////////////////////////////////////////////////
+rendering::CameraPtr GzRenderer::Camera()
+{
+  return this->dataPtr->camera;
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+/////////////////////////////////////////////////
+/// \brief fillQtInstanceExtensionsToOgre
+/// Extract Vulkan Instance extension information to be sent to OgreNext
+/// \param[in] inst Qt's Vulkan Instance to extract
+/// \param[out] externalInstance Data to be sent to OgreNext
+static void fillQtInstanceExtensionsToOgre(
+  const QVulkanInstance *inst,
+  rendering::GzVulkanExternalInstance &externalInstance)
+{
+  {
+    QByteArrayList extensions = inst->extensions();
+
+    for (const auto &ext : extensions)
+    {
+      externalInstance.instanceExtensions.push_back(VkExtensionProperties{});
+      VkExtensionProperties &extProp =
+        externalInstance.instanceExtensions.back();
+      strncpy(extProp.extensionName, ext.constData(),
+              VK_MAX_EXTENSION_NAME_SIZE);
+      extProp.extensionName[VK_MAX_EXTENSION_NAME_SIZE - 1u] = 0;
+    }
+  }
+
+  {
+    QByteArrayList layers = inst->layers();
+
+    for (const auto &layer : layers)
+    {
+      externalInstance.instanceLayers.push_back(VkLayerProperties{});
+      VkLayerProperties &layerProp = externalInstance.instanceLayers.back();
+      strncpy(layerProp.layerName, layer.constData(),
+              VK_MAX_EXTENSION_NAME_SIZE);
+      layerProp.layerName[VK_MAX_EXTENSION_NAME_SIZE - 1u] = 0;
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+/// \brief fillQtDeviceExtensionsToOgre
+/// Extract Vulkan Device extension info to be sent to OgreNext
+/// This data is obtained from Environment variables
+/// \param[out] externalDevice Data to be sent to OgreNext
+static void fillQtDeviceExtensionsToOgre(
+  rendering::GzVulkanExternalDevice &externalDevice)
+{
+  // We know Qt adds these by looking at
+  //  qt-everywhere-src-5.15.2/qtbase/src/gui/rhi/qrhivulkan.cpp
+  QVector<QString> deviceExtensions;
+  deviceExtensions.append( "VK_KHR_swapchain" );
+
+  QByteArray envExts = qgetenv( "QT_VULKAN_DEVICE_EXTENSIONS" );
+  if( !envExts.isEmpty() )
+  {
+    QByteArrayList envExtList = envExts.split( ';' );
+    for( const auto &ext : envExtList )
+    {
+      if( !ext.isEmpty() )
+      {
+        deviceExtensions.append( ext );
+      }
+    }
+  }
+
+  for( const auto &ext : deviceExtensions )
+  {
+    externalDevice.deviceExtensions.push_back( VkExtensionProperties{} );
+    VkExtensionProperties &extProp = externalDevice.deviceExtensions.back();
+    strncpy(extProp.extensionName, ext.toStdString().c_str(),
+            VK_MAX_EXTENSION_NAME_SIZE);
+    extProp.extensionName[VK_MAX_EXTENSION_NAME_SIZE - 1u] = 0;
+  }
+}
+#endif
+
+/////////////////////////////////////////////////
 std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
 {
   if (this->initialized)
@@ -574,9 +672,51 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   // Load engine if there's no engine yet
   if (loadedEngines.empty())
   {
-    this->dataPtr->rhiParams["winID"] = std::to_string(
-        gz::gui::App()->findChild<gz::gui::MainWindow *>()->
-        QuickWindow()->winId());
+    QQuickWindow *quickWindow =
+      gz::gui::App()->findChild<gz::gui::MainWindow *>()->QuickWindow();
+
+    this->dataPtr->rhiParams["winID"] = std::to_string(quickWindow->winId());
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+    // externalInstance & externalDevice MUST be declared at this scope
+    // because we save their stack addresses into this->dataPtr->rhiParams
+    // and must be alive until rendering::engine() returns.
+    rendering::GzVulkanExternalInstance externalInstance;
+    rendering::GzVulkanExternalDevice externalDevice;
+    if (this->dataPtr->rhiParams.find("vulkan") !=
+        this->dataPtr->rhiParams.end())
+    {
+      QSGRendererInterface *qtRenderInterface =
+        quickWindow->rendererInterface();
+
+      const QVulkanInstance *inst = reinterpret_cast<const QVulkanInstance *>(
+        qtRenderInterface->getResource(
+          quickWindow, QSGRendererInterface::VulkanInstanceResource));
+      GZ_ASSERT(inst && inst->isValid(), "Invalid QVulkanInstance!");
+
+      externalInstance.instance = inst->vkInstance();
+
+      externalDevice.physicalDevice =
+        *reinterpret_cast<VkPhysicalDevice *>(qtRenderInterface->getResource(
+          quickWindow, QSGRendererInterface::PhysicalDeviceResource));
+      externalDevice.device =
+        *reinterpret_cast<VkDevice *>(qtRenderInterface->getResource(
+          quickWindow, QSGRendererInterface::DeviceResource));
+      externalDevice.graphicsQueue =
+        *reinterpret_cast<VkQueue *>(qtRenderInterface->getResource(
+          quickWindow, QSGRendererInterface::CommandQueueResource));
+      externalDevice.presentQueue = externalDevice.graphicsQueue;
+
+      fillQtInstanceExtensionsToOgre(inst, externalInstance);
+      fillQtDeviceExtensionsToOgre(externalDevice);
+
+      this->dataPtr->rhiParams["external_instance"] =
+        std::to_string(reinterpret_cast<uintptr_t>(&externalInstance));
+      this->dataPtr->rhiParams["external_device"] =
+        std::to_string(reinterpret_cast<uintptr_t>(&externalDevice));
+    }
+#endif
+
     engine = rendering::engine(this->engineName, this->dataPtr->rhiParams);
   }
   else
@@ -659,6 +799,12 @@ void GzRenderer::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
     this->dataPtr->rhiParams["useCurrentGLContext"] = "1";
     this->dataPtr->rhi = std::make_unique<GzCameraTextureRhiOpenGL>();
   }
+  else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
+  {
+    gzdbg << "Creating gz-rendering interface for Vulkan" << std::endl;
+    this->dataPtr->rhiParams["vulkan"] = "1";
+    this->dataPtr->rhi = std::make_unique<GzCameraTextureRhiVulkan>();
+  }
 #ifdef __APPLE__
   else if (_graphicsAPI == rendering::GraphicsAPI::METAL)
   {
@@ -722,7 +868,19 @@ void GzRenderer::NewMouseEvent(const common::MouseEvent &_e)
 RenderThread::RenderThread()
 {
   // Set default graphics API to OpenGL
-  this->SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
+  const std::string backendApiName = gz::gui::renderEngineBackendApiName();
+  if (backendApiName == "vulkan")
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::VULKAN);
+  }
+  else if (backendApiName == "metal")
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::METAL);
+  }
+  else
+  {
+    this->SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
+  }
 
   RenderWindowItem::Implementation::threads << this;
   qRegisterMetaType<RenderSync*>("RenderSync*");
@@ -808,6 +966,11 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
     gzdbg << "Creating render thread interface for OpenGL" << std::endl;
     this->rhi = std::make_unique<RenderThreadRhiOpenGL>(&this->gzRenderer);
   }
+  else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
+  {
+    gzdbg << "Creating render thread interface for Vulkan" << std::endl;
+    this->rhi = std::make_unique<RenderThreadRhiVulkan>(&this->gzRenderer);
+  }
 #ifdef __APPLE__
   else if (_graphicsAPI == rendering::GraphicsAPI::METAL)
   {
@@ -829,10 +992,10 @@ std::string RenderThread::Initialize()
 }
 
 /////////////////////////////////////////////////
-TextureNode::TextureNode(
-    QQuickWindow *_window,
+TextureNode::TextureNode(QQuickWindow *_window,
     RenderSync &_renderSync,
-    const rendering::GraphicsAPI &_graphicsAPI)
+    const rendering::GraphicsAPI &_graphicsAPI,
+    rendering::CameraPtr &_camera)
     : renderSync(_renderSync) , window(_window)
 {
   if (_graphicsAPI == rendering::GraphicsAPI::OPENGL)
@@ -840,6 +1003,13 @@ TextureNode::TextureNode(
     gzdbg << "Creating texture node render interface for OpenGL" << std::endl;
     this->rhi = std::make_unique<TextureNodeRhiOpenGL>(_window);
   }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+  else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
+  {
+    gzdbg << "Creating texture node render interface for Vulkan" << std::endl;
+    this->rhi = std::make_unique<TextureNodeRhiVulkan>(_window, _camera);
+  }
+#endif
 #ifdef __APPLE__
   else if (_graphicsAPI == rendering::GraphicsAPI::METAL)
   {
@@ -1016,7 +1186,8 @@ QSGNode *RenderWindowItem::updatePaintNode(QSGNode *_node,
       // Initialize on main thread
       QMetaObject::invokeMethod(this, "Ready", Qt::QueuedConnection);
     }
-    else if (this->dataPtr->graphicsAPI == rendering::GraphicsAPI::METAL)
+    else if (this->dataPtr->graphicsAPI == rendering::GraphicsAPI::METAL ||
+             this->dataPtr->graphicsAPI == rendering::GraphicsAPI::VULKAN)
     {
       // Initialize on main thread
       QMetaObject::invokeMethod(this, "Ready", Qt::QueuedConnection);
@@ -1033,8 +1204,9 @@ QSGNode *RenderWindowItem::updatePaintNode(QSGNode *_node,
 
   if (!node)
   {
+    auto camera = this->dataPtr->renderThread->gzRenderer.Camera();
     node = new TextureNode(this->window(), this->dataPtr->renderSync,
-        this->dataPtr->graphicsAPI);
+                           this->dataPtr->graphicsAPI, camera);
 
     // Set up connections to get the production of render texture in sync with
     // vsync on the rendering thread.
@@ -1275,6 +1447,20 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       if (!elem->NoChildren())
         gzwarn << "Child elements of <sky> are not supported yet"
                 << std::endl;
+    }
+
+    const std::string backendApiName = gz::gui::renderEngineBackendApiName();
+    if (backendApiName == "vulkan")
+    {
+      renderWindow->SetGraphicsAPI(rendering::GraphicsAPI::VULKAN);
+    }
+    else if (backendApiName == "metal")
+    {
+      renderWindow->SetGraphicsAPI(rendering::GraphicsAPI::METAL);
+    }
+    else
+    {
+      renderWindow->SetGraphicsAPI(rendering::GraphicsAPI::OPENGL);
     }
 
     elem = _pluginElem->FirstChildElement("graphics_api");

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -653,7 +653,7 @@ static void fillQtDeviceExtensionsToOgre(
     externalDevice.deviceExtensions.push_back(VkExtensionProperties{});
     VkExtensionProperties &extProp = externalDevice.deviceExtensions.back();
     strncpy(extProp.extensionName, ext.toStdString().c_str(),
-            VK_MAX_EXTENSION_NAME_SIZE);
+            VK_MAX_EXTENSION_NAME_SIZE - 1u);
     extProp.extensionName[VK_MAX_EXTENSION_NAME_SIZE - 1u] = 0;
   }
 }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -975,7 +975,7 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
     gzdbg << "Creating render thread interface for OpenGL" << std::endl;
     this->rhi = std::make_unique<RenderThreadRhiOpenGL>(&this->gzRenderer);
   }
-#if QT_VERSION > QT_VERSION_CHECK(5, 15, 2)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
   else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
   {
     gzdbg << "Creating render thread interface for Vulkan" << std::endl;

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -771,6 +771,8 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   this->dataPtr->camera->SetFarClipPlane(this->cameraFarClip);
   this->dataPtr->camera->SetImageWidth(this->textureSize.width());
   this->dataPtr->camera->SetImageHeight(this->textureSize.height());
+  this->dataPtr->camera->SetImageFormat(this->dataPtr->camera->ImageFormat(),
+                                        true);
   this->dataPtr->camera->SetAntiAliasing(8);
   this->dataPtr->camera->SetHFOV(this->cameraHFOV);
   // setting the size and calling PreRender should cause the render texture to

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -633,24 +633,24 @@ static void fillQtDeviceExtensionsToOgre(
   // We know Qt adds these by looking at
   //  qt-everywhere-src-5.15.2/qtbase/src/gui/rhi/qrhivulkan.cpp
   QVector<QString> deviceExtensions;
-  deviceExtensions.append( "VK_KHR_swapchain" );
+  deviceExtensions.append("VK_KHR_swapchain");
 
-  QByteArray envExts = qgetenv( "QT_VULKAN_DEVICE_EXTENSIONS" );
-  if( !envExts.isEmpty() )
+  QByteArray envExts = qgetenv("QT_VULKAN_DEVICE_EXTENSIONS");
+  if (!envExts.isEmpty())
   {
-    QByteArrayList envExtList = envExts.split( ';' );
-    for( const auto &ext : envExtList )
+    QByteArrayList envExtList = envExts.split(';');
+    for (const auto &ext : envExtList)
     {
-      if( !ext.isEmpty() )
+      if (!ext.isEmpty())
       {
-        deviceExtensions.append( ext );
+        deviceExtensions.append(ext);
       }
     }
   }
 
-  for( const auto &ext : deviceExtensions )
+  for (const auto &ext : deviceExtensions)
   {
-    externalDevice.deviceExtensions.push_back( VkExtensionProperties{} );
+    externalDevice.deviceExtensions.push_back(VkExtensionProperties{});
     VkExtensionProperties &extProp = externalDevice.deviceExtensions.back();
     strncpy(extProp.extensionName, ext.toStdString().c_str(),
             VK_MAX_EXTENSION_NAME_SIZE);

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -209,12 +209,6 @@ namespace plugins
     /// \brief Broadcasts a key press event within the scene
     private: void BroadcastKeyPress();
 
-    /// Values is constantly constantly cycled/swapped/changed
-    /// from a worker thread
-    /// Don't read this directly
-    /// \param[out] _texturePtr Pointer to a texture Id
-    public: void TextureId(void* _texturePtr);
-
     /// \brief Render engine to use
     public: std::string engineName = "ogre";
 
@@ -253,6 +247,10 @@ namespace plugins
 
     /// \brief View controller type
     public: std::string cameraViewController{""};
+
+    /// \brief Retrieves the internal camera.
+    /// TODO(darksylinc): Remove this hack.
+    public: rendering::CameraPtr Camera();
 
     /// \internal
     /// \brief Pointer to private data.
@@ -446,9 +444,11 @@ namespace plugins
     /// \param[in] _renderSync RenderSync to safely
     /// synchronize Qt (this) and worker thread
     /// \param[in] _graphicsAPI The type of graphics API
+    /// \param[in] _camera Camera owning the Texture Handle
     public: explicit TextureNode(QQuickWindow *_window,
                                  RenderSync &_renderSync,
-                                 const rendering::GraphicsAPI &_graphicsAPI);
+                                 const rendering::GraphicsAPI &_graphicsAPI,
+                                 rendering::CameraPtr &_camera);
 
     /// \brief Destructor
     public: ~TextureNode() override;

--- a/src/plugins/minimal_scene/MinimalSceneRhi.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhi.hh
@@ -37,6 +37,10 @@ namespace plugins
   //
   /// Each supported graphics API must implement this interface
   /// to provide access to the underlying render system's texture.
+  ///
+  /// TODO(anyone): This class doesn't seem to be doing anything at all
+  /// Anyone should try to remove it, and if nothing bad happens
+  /// (on Ubuntu & macOS) it should be deprecated and removed
   class GzCameraTextureRhi
   {
     /// \brief Destructor

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
@@ -64,7 +64,7 @@ namespace plugins
 
     /// \brief Constructor
     /// \param[in] _renderer The gz-rendering renderer
-    public: RenderThreadRhiMetal(GzRenderer *_renderer);
+    public: explicit RenderThreadRhiMetal(GzRenderer *_renderer);
 
     // Documentation inherited
     public: virtual std::string Initialize() override;
@@ -105,7 +105,7 @@ namespace plugins
 
     /// \brief Constructor
     /// \param[in] _window Window to display the texture
-    public: TextureNodeRhiMetal(QQuickWindow *_window);
+    public: explicit TextureNodeRhiMetal(QQuickWindow *_window);
 
     // Documentation inherited
     public: virtual QSGTexture *Texture() const override;

--- a/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.cc
@@ -155,12 +155,12 @@ void RenderThreadRhiOpenGL::RenderNext(RenderSync *_renderSync)
   if (!this->dataPtr->renderer->initialized)
   {
     this->Initialize();
-  }
 
-  if (!this->dataPtr->renderer->initialized)
-  {
-    gzerr << "Unable to initialize renderer" << std::endl;
-    return;
+    if (!this->dataPtr->renderer->initialized)
+    {
+      gzerr << "Unable to initialize renderer" << std::endl;
+      return;
+    }
   }
 
   // Call the renderer

--- a/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
@@ -64,7 +64,7 @@ namespace plugins
 
     /// \brief Constructor
     /// \param[in] _renderer The gz-rendering renderer
-    public: RenderThreadRhiOpenGL(GzRenderer *_renderer);
+    public: explicit RenderThreadRhiOpenGL(GzRenderer *_renderer);
 
     // Documentation inherited
     public: virtual QOffscreenSurface *Surface() const override;
@@ -117,7 +117,7 @@ namespace plugins
 
     /// \brief Constructor
     /// \param[in] _window Window to display the texture
-    public: TextureNodeRhiOpenGL(QQuickWindow *_window);
+    public: explicit TextureNodeRhiOpenGL(QQuickWindow *_window);
 
     // Documentation inherited
     public: virtual QSGTexture *Texture() const override;

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -17,6 +17,8 @@
 
 #include "MinimalSceneRhiVulkan.hh"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+
 #include "EngineToQtInterface.hh"
 #include "MinimalScene.hh"
 
@@ -257,3 +259,4 @@ void TextureNodeRhiVulkan::PrepareNode()
 #endif
   }
 }
+#endif

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -182,7 +182,11 @@ TextureNodeRhiVulkan::~TextureNodeRhiVulkan()
 
 /////////////////////////////////////////////////
 TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
-                                           rendering::CameraPtr &_camera) :
+                                           rendering::CameraPtr &
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+                                             _camera
+#endif
+                                           ) :
   dataPtr(std::make_unique<TextureNodeRhiVulkanPrivate>())
 {
   this->dataPtr->window = _window;

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -183,7 +183,7 @@ TextureNodeRhiVulkan::~TextureNodeRhiVulkan()
 /////////////////////////////////////////////////
 TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
                                            rendering::CameraPtr &
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
                                              _camera
 #endif
                                            ) :
@@ -191,7 +191,7 @@ TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
 {
   this->dataPtr->window = _window;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
   // It says Metal but it also works for Vulkan in the exact same way
   _camera->RenderTextureMetalId(&this->dataPtr->textureId);
   this->dataPtr->lastCamera = _camera;
@@ -247,7 +247,7 @@ void TextureNodeRhiVulkan::PrepareNode()
     delete this->dataPtr->texture;
     this->dataPtr->texture = nullptr;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
     this->dataPtr->texture =
         this->dataPtr->window->createTextureFromNativeObject(
             QQuickWindow::NativeObjectTexture,

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -137,12 +137,12 @@ void RenderThreadRhiVulkan::RenderNext(RenderSync *_renderSync)
   if (!this->dataPtr->renderer->initialized)
   {
     this->Initialize();
-  }
 
-  if (!this->dataPtr->renderer->initialized)
-  {
-    gzerr << "Unable to initialize renderer" << std::endl;
-    return;
+    if (!this->dataPtr->renderer->initialized)
+    {
+      gzerr << "Unable to initialize renderer" << std::endl;
+      return;
+    }
   }
 
   // Call the renderer

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "MinimalSceneRhiVulkan.hh"
+
+#include "EngineToQtInterface.hh"
+#include "MinimalScene.hh"
+
+#include <gz/common/Console.hh>
+#include <gz/rendering/Camera.hh>
+
+#include <QMutex>
+#include <QQuickWindow>
+#include <QSGTexture>
+#include <QSize>
+
+#include <vulkan/vulkan_core.h>
+
+#include <memory>
+#include <string>
+
+/////////////////////////////////////////////////
+namespace gz
+{
+namespace gui
+{
+namespace plugins
+{
+  class GzCameraTextureRhiVulkanPrivate
+  {
+    public: VkImage textureId = 0;
+  };
+
+  class RenderThreadRhiVulkanPrivate
+  {
+    public: GzRenderer *renderer = nullptr;
+    public: void *texturePtr = nullptr;
+    public: QOffscreenSurface *surface = nullptr;
+  };
+
+  class TextureNodeRhiVulkanPrivate
+  {
+    public: VkImage textureId = 0;
+    public: VkImage newTextureId = 0;
+    public: QSize size {0, 0};
+    public: QSize newSize {0, 0};
+    public: QMutex mutex;
+    public: QSGTexture *texture = nullptr;
+    public: QQuickWindow *window = nullptr;
+  };
+}
+}
+}
+
+using namespace gz;
+using namespace gui;
+using namespace plugins;
+
+/////////////////////////////////////////////////
+GzCameraTextureRhiVulkan::~GzCameraTextureRhiVulkan() = default;
+
+/////////////////////////////////////////////////
+GzCameraTextureRhiVulkan::GzCameraTextureRhiVulkan()
+  : dataPtr(std::make_unique<GzCameraTextureRhiVulkanPrivate>())
+{
+}
+
+/////////////////////////////////////////////////
+void GzCameraTextureRhiVulkan::Update(rendering::CameraPtr _camera)
+{
+  // It says Metal but it also works for Vulkan in the exact same way
+  _camera->RenderTextureMetalId(&this->dataPtr->textureId);
+}
+
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+RenderThreadRhiVulkan::~RenderThreadRhiVulkan() = default;
+
+/////////////////////////////////////////////////
+RenderThreadRhiVulkan::RenderThreadRhiVulkan(GzRenderer *_renderer)
+    : dataPtr(std::make_unique<RenderThreadRhiVulkanPrivate>())
+{
+  this->dataPtr->renderer = _renderer;
+}
+
+/////////////////////////////////////////////////
+QOffscreenSurface *RenderThreadRhiVulkan::Surface() const
+{
+  return this->dataPtr->surface;
+}
+
+/////////////////////////////////////////////////
+void RenderThreadRhiVulkan::SetSurface(QOffscreenSurface *_surface)
+{
+  this->dataPtr->surface = _surface;
+}
+
+/////////////////////////////////////////////////
+std::string RenderThreadRhiVulkan::Initialize()
+{
+  auto loadingError = this->dataPtr->renderer->Initialize(*this);
+  if (!loadingError.empty())
+  {
+    return loadingError;
+  }
+
+  return std::string();
+}
+
+/////////////////////////////////////////////////
+void RenderThreadRhiVulkan::Update(rendering::CameraPtr _camera)
+{
+  // It says Metal but it also works for Vulkan in the exact same way
+  _camera->RenderTextureMetalId(&this->dataPtr->texturePtr);
+}
+
+/////////////////////////////////////////////////
+void RenderThreadRhiVulkan::RenderNext(RenderSync *_renderSync)
+{
+  if (!this->dataPtr->renderer->initialized)
+  {
+    this->Initialize();
+  }
+
+  if (!this->dataPtr->renderer->initialized)
+  {
+    gzerr << "Unable to initialize renderer" << std::endl;
+    return;
+  }
+
+  // Call the renderer
+  this->dataPtr->renderer->Render(_renderSync, *this);
+}
+
+/////////////////////////////////////////////////
+void* RenderThreadRhiVulkan::TexturePtr() const
+{
+  return this->dataPtr->texturePtr;
+}
+
+/////////////////////////////////////////////////
+QSize RenderThreadRhiVulkan::TextureSize() const
+{
+  return this->dataPtr->renderer->textureSize;
+}
+
+/////////////////////////////////////////////////
+void RenderThreadRhiVulkan::ShutDown()
+{
+  this->dataPtr->renderer->Destroy();
+
+  this->dataPtr->texturePtr = nullptr;
+
+  // Schedule this to be deleted only after we're done cleaning up
+  if (this->dataPtr->surface)
+  {
+    this->dataPtr->surface->deleteLater();
+  }
+}
+
+/////////////////////////////////////////////////
+TextureNodeRhiVulkan::~TextureNodeRhiVulkan()
+{
+  delete this->dataPtr->texture;
+  this->dataPtr->texture = nullptr;
+}
+
+/////////////////////////////////////////////////
+TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
+                                           rendering::CameraPtr &_camera) :
+  dataPtr(std::make_unique<TextureNodeRhiVulkanPrivate>())
+{
+  this->dataPtr->window = _window;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+  // It says Metal but it also works for Vulkan in the exact same way
+  _camera->RenderTextureMetalId(&this->dataPtr->textureId);
+
+  this->dataPtr->texture = this->dataPtr->window->createTextureFromNativeObject(
+    QQuickWindow::NativeObjectTexture,
+    static_cast<void *>(&this->dataPtr->textureId),  //
+    0,                                               //
+    QSize(static_cast<int>(_camera->ImageWidth()),
+          static_cast<int>(_camera->ImageHeight())));
+#endif
+}
+
+/////////////////////////////////////////////////
+QSGTexture *TextureNodeRhiVulkan::Texture() const
+{
+  return this->dataPtr->texture;
+}
+
+/////////////////////////////////////////////////
+bool TextureNodeRhiVulkan::HasNewTexture() const
+{
+  return (this->dataPtr->newTextureId != 0);
+}
+
+/////////////////////////////////////////////////
+void TextureNodeRhiVulkan::NewTexture(
+    void* _texturePtr, const QSize &_size)
+{
+  this->dataPtr->mutex.lock();
+  this->dataPtr->textureId = reinterpret_cast<VkImage>(_texturePtr);
+  this->dataPtr->size = _size;
+  this->dataPtr->mutex.unlock();
+}
+
+/////////////////////////////////////////////////
+void TextureNodeRhiVulkan::PrepareNode()
+{
+  this->dataPtr->mutex.lock();
+  this->dataPtr->newTextureId = this->dataPtr->textureId;
+  this->dataPtr->newSize = this->dataPtr->size;
+  this->dataPtr->textureId = 0;
+  this->dataPtr->mutex.unlock();
+
+  if (this->dataPtr->newTextureId)
+  {
+    delete this->dataPtr->texture;
+    this->dataPtr->texture = nullptr;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2)
+    this->dataPtr->texture =
+        this->dataPtr->window->createTextureFromNativeObject(
+            QQuickWindow::NativeObjectTexture,
+            static_cast<void*>(&this->dataPtr->newTextureId),
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            this->dataPtr->newSize);
+#endif
+  }
+}

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
@@ -65,7 +65,7 @@ namespace plugins
 
     /// \brief Constructor
     /// \param[in] _renderer The gz-rendering renderer
-    public: RenderThreadRhiVulkan(GzRenderer *_renderer);
+    public: explicit RenderThreadRhiVulkan(GzRenderer *_renderer);
 
     // Documentation inherited
     public: virtual QOffscreenSurface *Surface() const override;
@@ -113,8 +113,8 @@ namespace plugins
     /// \brief Constructor
     /// \param[in] _window Window to display the texture
     /// \param[in] _camera Camera owning the API texture handle
-    public: TextureNodeRhiVulkan(QQuickWindow *_window,
-                                 rendering::CameraPtr &_camera);
+    public: explicit TextureNodeRhiVulkan(QQuickWindow *_window,
+                                          rendering::CameraPtr &_camera);
 
     // Documentation inherited
     public: virtual QSGTexture *Texture() const override;

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHIVULKAN_HH_
+#define GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHIVULKAN_HH_
+
+#include "MinimalSceneRhi.hh"
+#include "gz/gui/Plugin.hh"
+
+#include <QQuickWindow>
+#include <QSGTexture>
+#include <QSize>
+
+#include <memory>
+#include <string>
+
+namespace gz
+{
+namespace gui
+{
+namespace plugins
+{
+  /// \brief Private data for GzCameraTextureRhiVulkan
+  class GzCameraTextureRhiVulkanPrivate;
+
+  /// \brief Implementation of GzCameraTextureRhi for the Vulkan graphics API
+  class GzCameraTextureRhiVulkan : public GzCameraTextureRhi
+  {
+    // Documentation inherited
+    public: virtual ~GzCameraTextureRhiVulkan() override;
+
+    /// \brief Constructor
+    public: GzCameraTextureRhiVulkan();
+
+    // Documentation inherited
+    public: virtual void Update(rendering::CameraPtr _camera) override;
+
+    /// \internal Pointer to private data
+    private: std::unique_ptr<GzCameraTextureRhiVulkanPrivate> dataPtr;
+  };
+
+  /// \brief Private data for RenderThreadRhiVulkanPrivate
+  class RenderThreadRhiVulkanPrivate;
+
+  /// \brief Implementation of RenderThreadRhi for the Vulkan graphics API
+  class RenderThreadRhiVulkan : public RenderThreadRhi
+  {
+    // Documentation inherited
+    public: virtual ~RenderThreadRhiVulkan() override;
+
+    /// \brief Constructor
+    /// \param[in] _renderer The gz-rendering renderer
+    public: RenderThreadRhiVulkan(GzRenderer *_renderer);
+
+    // Documentation inherited
+    public: virtual QOffscreenSurface *Surface() const override;
+
+    // Documentation inherited
+    public: virtual void SetSurface(QOffscreenSurface *_surface) override;
+
+    // Documentation inherited
+    public: virtual std::string Initialize() override;
+
+    // Documentation inherited
+    public: virtual void Update(rendering::CameraPtr _camera) override;
+
+    // Documentation inherited
+    public: virtual void RenderNext(RenderSync *_renderSync) override;
+
+    // Documentation inherited
+    public: virtual void* TexturePtr() const override;
+
+    // Documentation inherited
+    public: virtual QSize TextureSize() const override;
+
+    // Documentation inherited
+    public: virtual void ShutDown() override;
+
+    /// \internal Prevent copy and assignment
+    private: RenderThreadRhiVulkan(
+        const RenderThreadRhiVulkan &_other) = delete;
+    private: RenderThreadRhiVulkan& operator=(
+        const RenderThreadRhiVulkan &_other) = delete;
+
+    /// \internal Pointer to private data
+    private: std::unique_ptr<RenderThreadRhiVulkanPrivate> dataPtr;
+  };
+
+  /// \brief Private data for TextureNodeRhiVulkan
+  class TextureNodeRhiVulkanPrivate;
+
+  /// \brief Implementation of TextureNodeRhi for the Vulkan graphics API
+  class TextureNodeRhiVulkan : public TextureNodeRhi
+  {
+    // Documentation inherited
+    public: virtual ~TextureNodeRhiVulkan() override;
+
+    /// \brief Constructor
+    /// \param[in] _window Window to display the texture
+    /// \param[in] _camera Camera owning the API texture handle
+    public: TextureNodeRhiVulkan(QQuickWindow *_window,
+                                 rendering::CameraPtr &_camera);
+
+    // Documentation inherited
+    public: virtual QSGTexture *Texture() const override;
+
+    // Documentation inherited
+    public: virtual bool HasNewTexture() const override;
+
+    // Documentation inherited
+    public: virtual void NewTexture(
+        void* _texturePtr, const QSize &_size) override;
+
+    // Documentation inherited
+    public: virtual void PrepareNode() override;
+
+    /// \internal Prevent copy and assignment
+    private: TextureNodeRhiVulkan(
+        const TextureNodeRhiVulkan &_other) = delete;
+    private: TextureNodeRhiVulkan& operator=(
+        const TextureNodeRhiVulkan &_other) = delete;
+
+    /// \internal Pointer to private data
+    private: std::unique_ptr<TextureNodeRhiVulkanPrivate> dataPtr;
+   };
+}
+}
+}
+
+#endif

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
 namespace gz
 {
 namespace gui
@@ -140,5 +141,7 @@ namespace plugins
 }
 }
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
# 🎉 New feature

## Order in which PRs must be merged

1. gazebosim/gz-rendering#706
2. gazebosim/gz-gui#357
    - or optionally, merge this one as part of the next one aka PR 467, which includes it
3. This PR.
4. gazebosim/gz-sim#1735

## Summary

> **_Note:_** This PR depends on gazebosim/gz-rendering#706

> **_Note:_** This PR is polluted with changes that are supposed to be merged by PR #357 

This PR adds native Vulkan backend using Qt's QML Vulkan RHI.

I couldn't believe it so I opened it up on RenderDoc and indeed it's using Vulkan:

![Screenshot_2022-08-14_19-51-44](https://user-images.githubusercontent.com/3395130/184558009-33764523-eceb-43e5-92ca-1f5f93f3aad9.jpg)

This PR breaks ABI slightly, so it's best if it targets post-Garden.

With a few global variables we could workaround it and backport it to Garden though. Note that Garden supports Vulkan via a fallback that is very slow. This PR offers native, full speed integration.

> **_Note:_** Qt 5.14 is the minimum requirement, which means it's not available on Ubuntu 20.04 but rather Ubuntu 22.04. I put macros to use at least 5.15.2 because that's what I tested against.

> **_Note:_** Qt 5 considers Vulkan QML interface to be 'experimental' and I've submitted a [patch to Qt](https://bugreports.qt.io/browse/QTBUG-105158) to improve compliance with the Vulkan standard. Ideally Gazebo should eventually migrate to Qt 6.

## Missing tasks:

- [x] Ensure code compiles without Qt 5.15.2+
- [x] Ensure code compiles when Vulkan isn't available
- [x] Gazebo needs to tell OgreNext to make a layout transition / synchronization for Qt (via BarrierSolver).
- [x] Run Vulkan validations to catch any potential issue
    - Done. Only validation errors show up on shutdown, but that's difficult to debug right now because gz-gui crashes on shutdown due to infamous crash at shutdown (can't find the ticket now) that could be the cause. May also be a side effect of #17 
- [ ] Add vulkan toggle via command line


## Test it

This PR can be tested once gazebosim/gz-sim#1735 (which comes after this PR) is merged, which adds the capability to enable the features in this PR via CLI.

### Testing it in Ubuntu 20.04

It is possible to build with Ubuntu 20.04 against Qt 5.15.2. You need the following:

1. Install Qt 5.15.2 using the [online installer](https://download.qt.io/official_releases/online_installers/)
2. [Compile Gazebo](https://gazebosim.org/docs/garden/install_ubuntu_src) with: `colcon build --cmake-args -DCMAKE_PREFIX_PATH=/opt/Qt/5.15.2/gcc_64 -DQT_QMAKE_EXECUTABLE=/opt/Qt/5.15.2/gcc_64/bin/qmake --merge-install`
3. To run gazebo go to the install folder and do:
```bash
export LD_LIBRARY_PATH=/opt/Qt/5.15.2/gcc_64/lib
. setup.bash
gz sim shapes.sdf
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
