### PR TITLE
Fix crash at exit of gz-sim by using RTLD_NODELETE=true when loading libraries

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -489,7 +489,7 @@ bool Application::LoadPlugin(const std::string &_filename,
   // Load plugin
   plugin::Loader pluginLoader;
 
-  auto pluginNames = pluginLoader.LoadLib(pathToLib);
+  auto pluginNames = pluginLoader.LoadLib(pathToLib, true);
   if (pluginNames.empty())
   {
     gzerr << "Failed to load plugin [" << _filename <<


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/725, https://github.com/gazebosim/gz-sim/issues/1443

Relates to: https://github.com/gazebosim/gz-common/pull/367, https://github.com/gazebosim/gz-plugin/pull/102

## Summary

Gazebo Garden [crashes](https://github.com/gazebosim/gz-sim/issues/1443) at exit because the destructor for an `EventT` object created by a gui plugin is accesses after the plugin is unloaded. This fix uses the new gz-plugin API that allows setting `RTLD_NODELETE=true` when loading the library.

Requires:
*  https://github.com/gazebosim/gz-plugin/pull/102


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
