### PR TITLE
Fix mistaken dialog error message

### DIFF
--- a/src/Dialog.cc
+++ b/src/Dialog.cc
@@ -125,7 +125,7 @@ bool Dialog::UpdateConfigAttribute(const std::string &_path,
   }
 
   // Write config file
-  if (!doc.SaveFile(_path.c_str()))
+  if (doc.SaveFile(_path.c_str()) != tinyxml2::XML_SUCCESS)
   {
     // LCOV_EXCL_START
     ignerr << "Failed to save file: " << _path


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

When closing Gazebo Sim's quick start dialog, you'll currently see an error message like this:

```
[GUI] [Err] [Dialog.cc:131] Failed to save file: /home/chapulina/.ignition/gazebo/gui.config.
Check file permissions.
```

Which is mistaken, because the file was in fact correctly chosen. The issue was treating the return value of `SaveFile` as a boolean instead of checking for the error code. See the [SaveFile API](https://leethomason.github.io/tinyxml2/classtinyxml2_1_1_x_m_l_document.html#a73ac416b4a2aa0952e841220eb3da18f).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
