### PR TITLE
Add degree as an optional unit for rotation in GzPose

### DIFF
--- a/include/ignition/gui/qml/GzPose.qml
+++ b/include/ignition/gui/qml/GzPose.qml
@@ -31,6 +31,7 @@ import QtQuick.Controls.Styles 1.4
  *  GzPose {
  *    id: gzPose
  *    readOnly: false
+ *    useRadian: true
  *    xValue: xValueFromCPP
  *    yValue: yValueFromCPP
  *    zValue: zValueFromCPP
@@ -48,6 +49,9 @@ Item {
 
   // Read-only / write
   property bool readOnly: false
+
+  // Radian / Degree as the unit for Rotation
+  property bool useRadian: true
 
   // User input value.
   property double xValue
@@ -165,7 +169,7 @@ Item {
       }
 
       Text {
-        text: 'Roll (rad)'
+        text: useRadian ? 'Roll (rad)' : 'Roll (deg)'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -207,7 +211,7 @@ Item {
       }
 
       Text {
-        text: 'Pitch (rad)'
+        text: useRadian ? 'Pitch (rad)' : 'Pitch (deg)'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -249,7 +253,7 @@ Item {
       }
 
       Text {
-        text: 'Yaw (rad)'
+        text: useRadian ? 'Roll (rad)' : 'Roll (deg)'
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12

--- a/include/ignition/gui/qml/GzPose.qml
+++ b/include/ignition/gui/qml/GzPose.qml
@@ -169,7 +169,7 @@ Item {
       }
 
       Text {
-        text: useRadian ? 'Roll (rad)' : 'Roll (deg)'
+        text: 'Roll ' + (useRadian ? '(rad)' : '(deg)')
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -211,7 +211,7 @@ Item {
       }
 
       Text {
-        text: useRadian ? 'Pitch (rad)' : 'Pitch (deg)'
+        text: 'Pitch ' + (useRadian ? '(rad)' : '(deg)')
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12
@@ -253,7 +253,7 @@ Item {
       }
 
       Text {
-        text: useRadian ? 'Roll (rad)' : 'Roll (deg)'
+        text: 'Yaw ' + (useRadian ? '(rad)' : '(deg)')
         leftPadding: 5
         color: Material.theme == Material.Light ? "#444444" : "#bbbbbb"
         font.pointSize: 12


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add degree as an optional unit for rotation in GzPose. Radian is set to default.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Can be tested with https://github.com/gazebosim/gz-sim/pull/1642

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
