### PR TITLE
Update cmd/CMakeLists to conform with all other gz libraries

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,20 +1,23 @@
-set(ign_library_path "${CMAKE_BINARY_DIR}/src/cmd/cmdgui${PROJECT_VERSION_MAJOR}")
+# Used only for internal testing.
+set(ign_library_path "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
 # Generate a configuration file for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: gui0.yaml
 configure_file(
-  "gui.yaml.in"
-    "${CMAKE_BINARY_DIR}/test/conf/gui${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+  "${GZ_DESIGNATION}.yaml.in"
+    "${CMAKE_BINARY_DIR}/test/conf/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
 
-set(ign_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmdgui${PROJECT_VERSION_MAJOR}")
+# Used for the installed version.
+set(ign_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
-# Generate a configuration file.
+# Generate the configuration file that is installed.
 # Note that the major version of the library is included in the name.
 # Ex: gui0.yaml
 configure_file(
-  "gui.yaml.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+  "${GZ_DESIGNATION}.yaml.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
 
 # Install the yaml configuration files in an unversioned location.
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gui${PROJECT_VERSION_MAJOR}.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,5 +77,7 @@ if(TARGET UNIT_ign_TEST)
     ENVIRONMENT "${_env_vars}")
 endif()
 
-add_subdirectory(cmd)
+if(NOT WIN32)
+  add_subdirectory(cmd)
+endif()
 add_subdirectory(plugins)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,7 +1,7 @@
 #===============================================================================
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
-# Ex: cmdtransport0.rb
+# Ex: cmdgui3.rb
 set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_script_configured_test "${cmd_script_generated_test}.configured")
 
@@ -23,7 +23,7 @@ file(GENERATE
 # Used for the installed version.
 # Generate the ruby script that gets installed.
 # Note that the major version of the library is included in the name.
-# Ex: cmdtransport0.rb
+# Ex: cmdgui3.rb
 set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_script_configured "${cmd_script_generated}.configured")
 

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,16 +1,47 @@
-# Generate the ruby script.
+#===============================================================================
+# Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
-if (APPLE)
-  set(IGN_LIBRARY_NAME lib${PROJECT_NAME_LOWER}.dylib)
-else()
-  set(IGN_LIBRARY_NAME lib${PROJECT_NAME_LOWER}.so)
-endif()
+# Ex: cmdtransport0.rb
+set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_script_configured_test "${cmd_script_generated_test}.configured")
+
+# Set the library_location variable to the full path of the library file within
+# the build directory.
+set(library_location "$<TARGET_FILE:${PROJECT_LIBRARY_TARGET_NAME}>")
+
 configure_file(
-  "cmdgui.rb.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb" @ONLY)
+  "cmd${GZ_DESIGNATION}.rb.in"
+  "${cmd_script_configured_test}"
+  @ONLY)
+
+file(GENERATE
+  OUTPUT "${cmd_script_generated_test}"
+  INPUT  "${cmd_script_configured_test}")
+
+
+#===============================================================================
+# Used for the installed version.
+# Generate the ruby script that gets installed.
+# Note that the major version of the library is included in the name.
+# Ex: cmdtransport0.rb
+set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_script_configured "${cmd_script_generated}.configured")
+
+# Set the library_location variable to the relative path to the library file
+# within the install directory structure.
+set(library_location "../../../${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${PROJECT_LIBRARY_TARGET_NAME}>")
+
+configure_file(
+  "cmd${GZ_DESIGNATION}.rb.in"
+  "${cmd_script_configured}"
+  @ONLY)
+
+file(GENERATE
+  OUTPUT "${cmd_script_generated}"
+  INPUT  "${cmd_script_configured}")
 
 # Install the ruby command line library in an unversioned location.
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmdgui${PROJECT_VERSION_MAJOR}.rb DESTINATION lib/ruby/ignition)
+install(FILES ${cmd_script_generated} DESTINATION lib/ruby/ignition)
 
 # Tack version onto and install the bash completion script
 configure_file(

--- a/src/cmd/cmdgui.rb.in
+++ b/src/cmd/cmdgui.rb.in
@@ -28,7 +28,7 @@ end
 require 'optparse'
 
 # Constants.
-LIBRARY_NAME = '@IGN_LIBRARY_NAME@'
+LIBRARY_NAME = '@library_location@'
 LIBRARY_VERSION = '@PROJECT_VERSION_FULL@'
 COMMON_OPTIONS =
                "  -h [ --help ]              Print this help message.\n"\
@@ -134,7 +134,15 @@ class Cmd
     # puts options
 
     # Read the plugin that handles the command.
-    plugin = LIBRARY_NAME
+    if LIBRARY_NAME[0] == '/'
+      # If the first character is a slash, we'll assume that we've been given an
+      # absolute path to the library. This is only used during test mode.
+      plugin = LIBRARY_NAME
+    else
+      # We're assuming that the library path is relative to the current
+      # location of this script.
+      plugin = File.expand_path(File.join(File.dirname(__FILE__), LIBRARY_NAME))
+    end
     conf_version = LIBRARY_VERSION
 
     begin


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The updated cmake file is now similar to other gz libraries, eg. https://github.com/gazebosim/gz-transport/blob/9ba73b74f6ba9717d33429ebf93ef1500c7958f4/src/cmd/CMakeLists.txt

An outcome of updating the cmake files is that it fixes the library path obtained by cmdgui.rb such that it points to the .so file contained in the non-dev debian package.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
