### PR TITLE
Clean up library.hh headers

### DIFF
--- a/include/gz/gui/Conversions.hh
+++ b/include/gz/gui/Conversions.hh
@@ -18,13 +18,8 @@
 #ifndef GZ_GUI_CONVERSIONS_HH_
 #define GZ_GUI_CONVERSIONS_HH_
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/time.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+
 #include <gz/common/KeyEvent.hh>
 #include <gz/common/MouseEvent.hh>
 #include <gz/math/Color.hh>

--- a/include/gz/gui/PlottingInterface.hh
+++ b/include/gz/gui/PlottingInterface.hh
@@ -22,7 +22,8 @@
 #include <QMap>
 #include <QVariant>
 #ifdef _MSC_VER
-#pragma warning(push, 0)
+#pragma warning(push)
+#pragma warning(disable: 4251)
 #endif
 #include <google/protobuf/message.h>
 #include <google/protobuf/descriptor.h>

--- a/src/PlottingInterface_TEST.cc
+++ b/src/PlottingInterface_TEST.cc
@@ -16,15 +16,14 @@
 */
 #include <gtest/gtest.h>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+#include <gz/msgs/collision.pb.h>
+#include <gz/msgs/header.pb.h>
+#include <gz/msgs/int32.pb.h>
+#include <gz/msgs/pose.pb.h>
+#include <gz/msgs/time.pb.h>
+#include <gz/msgs/vector3d.pb.h>
 
-#include <gz/transport.hh>
+#include <gz/transport/Node.hh>
 #include <gz/common/Console.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 #include "test_config.hh"  // NOLINT(build/include)

--- a/src/PlottingInterface_TEST.cc
+++ b/src/PlottingInterface_TEST.cc
@@ -23,9 +23,10 @@
 #include <gz/msgs/time.pb.h>
 #include <gz/msgs/vector3d.pb.h>
 
-#include <gz/transport/Node.hh>
 #include <gz/common/Console.hh>
+#include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.hh"  // NOLINT(build/include)
 #include "gz/gui/Enums.hh"
 #include "gz/gui/PlottingInterface.hh"

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -18,17 +18,17 @@
 #include <mutex>
 #include <string>
 
+#include <gz/msgs/stringmsg.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
+#include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
 
-// TODO(anyone) Remove these pragmas once gz-rendering and gz-msgs
-// are disabling the warnings
+// TODO(anyone) Remove these pragmas once gz-rendering is disabling the warnings
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif
-#include <gz/msgs/stringmsg.pb.h>
-#include <gz/msgs/Utility.hh>
 
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/MoveToHelper.hh>

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -24,20 +24,10 @@
 #include <gz/common/Profiler.hh>
 #include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
-
-// TODO(anyone) Remove these pragmas once gz-rendering is disabling the warnings
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/MoveToHelper.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "gz/gui/Application.hh"
 #include "gz/gui/Conversions.hh"

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -26,7 +26,9 @@
 #include <gz/plugin/Register.hh>
 #include <gz/math/Color.hh>
 #include <gz/math/Pose3.hh>
-#include <gz/rendering.hh>
+#include <gz/rendering/Grid.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
 
 #include "GridConfig.hh"
 

--- a/src/plugins/grid_config/GridConfig.hh
+++ b/src/plugins/grid_config/GridConfig.hh
@@ -21,7 +21,6 @@
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
-#include <gz/rendering.hh>
 
 namespace gz
 {

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <gz/msgs/image.pb.h>
+
 #include "ImageDisplay.hh"
 
 #include <QQuickImageProvider>
@@ -27,6 +29,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Image.hh>
+#include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -19,13 +19,7 @@
 #define GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_
 
 #include <memory>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/image.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "gz/gui/Plugin.hh"
 

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -15,6 +15,9 @@
  *
  */
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+
 #include <string>
 #include <mutex>
 

--- a/src/plugins/key_publisher/KeyPublisher.cc
+++ b/src/plugins/key_publisher/KeyPublisher.cc
@@ -15,13 +15,7 @@
  *
 */
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/int32.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <string>
 

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -22,19 +22,16 @@
 
 #include <QQmlProperty>
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/marker.pb.h>
+#include <gz/msgs/marker_v.pb.h>
+#include <gz/msgs/world_stats.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/common/StringUtils.hh>
 
 #include <gz/math/Rand.hh>
-
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <gz/plugin/Register.hh>
 
@@ -42,6 +39,7 @@
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/transport/Node.hh>
 
 #include "gz/gui/Application.hh"

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -32,23 +32,12 @@
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
-
-// TODO(louise) Remove these pragmas once gz-rendering
-// is disabling the warnings
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RayQuery.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 #include <gz/rendering/Utils.hh>
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "gz/gui/Application.hh"
 #include "gz/gui/Conversions.hh"

--- a/src/plugins/navsat_map/NavSatMap.hh
+++ b/src/plugins/navsat_map/NavSatMap.hh
@@ -19,13 +19,8 @@
 #define GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_
 
 #include <memory>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
+
 #include <gz/msgs/navsat.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "gz/gui/Plugin.hh"
 

--- a/src/plugins/point_cloud/PointCloud.hh
+++ b/src/plugins/point_cloud/PointCloud.hh
@@ -20,14 +20,8 @@
 
 #include <memory>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/float_v.pb.h>
 #include <gz/msgs/pointcloud_packed.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "gz/gui/Plugin.hh"
 

--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -16,14 +16,8 @@
 */
 
 #include <iostream>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #include <gz/common/Console.hh>
+#include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/plugins/publisher/Publisher_TEST.cc
+++ b/src/plugins/publisher/Publisher_TEST.cc
@@ -16,13 +16,8 @@
 */
 
 #include <gtest/gtest.h>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/stringmsg.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 

--- a/src/plugins/screenshot/Screenshot.cc
+++ b/src/plugins/screenshot/Screenshot.cc
@@ -22,18 +22,10 @@
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Image.hh>
 #include <gz/plugin/Register.hh>
-
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #include <gz/transport/Node.hh>
 
 #include "gz/gui/Application.hh"

--- a/src/plugins/screenshot/Screenshot.hh
+++ b/src/plugins/screenshot/Screenshot.hh
@@ -17,14 +17,8 @@
 #ifndef GZ_GUI_PLUGINS_SCREENSHOT_HH_
 #define GZ_GUI_PLUGINS_SCREENSHOT_HH_
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <memory>
 

--- a/src/plugins/screenshot/Screenshot_TEST.cc
+++ b/src/plugins/screenshot/Screenshot_TEST.cc
@@ -14,15 +14,9 @@
  * limitations under the License.
  *
 */
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
+
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
-#include <gz/rendering.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <gtest/gtest.h>
 #include <string>

--- a/src/plugins/shutdown_button/ShutdownButton_TEST.cc
+++ b/src/plugins/shutdown_button/ShutdownButton_TEST.cc
@@ -17,6 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/server_control.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>

--- a/src/plugins/teleop/Teleop.cc
+++ b/src/plugins/teleop/Teleop.cc
@@ -16,17 +16,11 @@
 */
 
 #include <iostream>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
+#include <string>
+
 #include <gz/msgs/twist.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "Teleop.hh"
-
-#include <string>
 
 #include <gz/plugin/Register.hh>
 

--- a/src/plugins/teleop/Teleop_TEST.cc
+++ b/src/plugins/teleop/Teleop_TEST.cc
@@ -16,13 +16,9 @@
 */
 
 #include <gtest/gtest.h>
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
+
 #include <gz/msgs/stringmsg.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+#include <gz/msgs/twist.pb.h>
 
 #include <gz/utils/ExtraTestMacros.hh>
 

--- a/src/plugins/topic_echo/TopicEcho.hh
+++ b/src/plugins/topic_echo/TopicEcho.hh
@@ -19,7 +19,8 @@
 #define GZ_GUI_PLUGINS_TOPICECHO_HH_
 
 #ifdef _MSC_VER
-#pragma warning(push, 0)
+#pragma warning(push)
+#pragma warning(disable: 4251)
 #endif
 #include <google/protobuf/message.h>
 #ifdef _MSC_VER

--- a/src/plugins/topic_echo/TopicEcho_TEST.cc
+++ b/src/plugins/topic_echo/TopicEcho_TEST.cc
@@ -18,13 +18,7 @@
 #include <gtest/gtest.h>
 #include <QRegExp>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/msgs/stringmsg.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>

--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -24,14 +24,14 @@
 #include <string>
 #include <vector>
 
+#include <gz/common/Console.hh>
 #include <gz/gui/Application.hh>
-
+#include <gz/plugin/Register.hh>
+#include <gz/msgs/Factory.hh>
 #include <gz/transport/MessageInfo.hh>
 #include <gz/transport/Node.hh>
 #include <gz/transport/Publisher.hh>
 
-#include <gz/common/Console.hh>
-#include <gz/plugin/Register.hh>
 #include "TopicViewer.hh"
 
 #define NAME_KEY "name"

--- a/src/plugins/topic_viewer/TopicViewer_TEST.cc
+++ b/src/plugins/topic_viewer/TopicViewer_TEST.cc
@@ -16,6 +16,9 @@
 */
 #include <gtest/gtest.h>
 
+#include <gz/msgs/collision.pb.h>
+#include <gz/msgs/int32.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -38,22 +38,12 @@
 #include <gz/common/MeshManager.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/math/Vector3.hh>
+#include <gz/msgs/Utility.hh>
 #include <gz/plugin/Register.hh>
-
-// TODO(louise) Remove these pragmas once gz-rendering is disabling the warnings
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
 #include <gz/rendering/Capsule.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
-#include <gz/msgs/Utility.hh>
 #include <gz/transport/Node.hh>
 #include <gz/transport/TopicUtils.hh>
 

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -24,19 +24,26 @@
 
 #include <QQmlProperty>
 
+#include <gz/msgs/geometry.pb.h>
+#include <gz/msgs/light.pb.h>
+#include <gz/msgs/link.pb.h>
+#include <gz/msgs/material.pb.h>
+#include <gz/msgs/model.pb.h>
+#include <gz/msgs/pose_v.pb.h>
+#include <gz/msgs/scene.pb.h>
+#include <gz/msgs/uint32_v.pb.h>
+#include <gz/msgs/visual.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
 
-// TODO(louise) Remove these pragmas once gz-rendering and gz-msgs
-// are disabling the warnings
+// TODO(louise) Remove these pragmas once gz-rendering is disabling the warnings
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif
-#include <gz/msgs.hh>
-
 #include <gz/rendering/Capsule.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
@@ -46,6 +53,7 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/msgs/Utility.hh>
 #include <gz/transport/Node.hh>
 #include <gz/transport/TopicUtils.hh>
 

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -19,9 +19,14 @@
 
 #include <string>
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/world_control.pb.h>
+#include <gz/msgs/world_stats.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/StringUtils.hh>
 #include <gz/plugin/Register.hh>
+#include <gz/transport/Node.hh>
 
 #include "gz/gui/Application.hh"
 #include "gz/gui/Helpers.hh"

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -20,14 +20,7 @@
 
 #include <memory>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-#include <gz/transport.hh>
+#include <gz/msgs/world_stats.pb.h>
 
 #include "gz/gui/Plugin.hh"
 

--- a/src/plugins/world_control/WorldControl_TEST.cc
+++ b/src/plugins/world_control/WorldControl_TEST.cc
@@ -17,6 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/world_control.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -19,9 +19,13 @@
 
 #include <string>
 
+#include <gz/msgs/world_stats.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/StringUtils.hh>
+#include <gz/math/Helpers.hh>
 #include <gz/plugin/Register.hh>
+#include <gz/transport/Node.hh>
 
 #include "gz/gui/Helpers.hh"
 

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -20,14 +20,7 @@
 
 #include <memory>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-#include <gz/transport.hh>
+#include <gz/msgs/world_stats.pb.h>
 
 #include "gz/gui/Export.hh"
 #include "gz/gui/Plugin.hh"

--- a/test/integration/camera_tracking.cc
+++ b/test/integration/camera_tracking.cc
@@ -17,17 +17,15 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/pose.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/vector3d.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/math/Pose3.hh>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/msgs/pose.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
+#include <gz/msgs/Utility.hh>
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>

--- a/test/integration/marker_manager.cc
+++ b/test/integration/marker_manager.cc
@@ -18,8 +18,9 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif
-#include <gz/msgs.hh>
-#include <gz/rendering.hh>
+#include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -27,8 +28,13 @@
 #include <gtest/gtest.h>
 #include <string>
 
+#include <gz/msgs/world_stats.pb.h>
+#include <gz/msgs/marker.pb.h>
+#include <gz/msgs/material.pb.h>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
+#include <gz/msgs/Utility.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 

--- a/test/integration/marker_manager.cc
+++ b/test/integration/marker_manager.cc
@@ -15,16 +15,6 @@
  *
 */
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include <gz/rendering/RenderEngine.hh>
-#include <gz/rendering/RenderingIface.hh>
-#include <gz/rendering/Scene.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #include <gtest/gtest.h>
 #include <string>
 
@@ -35,6 +25,9 @@
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
 #include <gz/msgs/Utility.hh>
+#include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 

--- a/test/integration/transport_scene_manager.cc
+++ b/test/integration/transport_scene_manager.cc
@@ -22,6 +22,7 @@
 #include <gz/math/Pose3.hh>
 #include <gz/msgs/pose_v.pb.h>
 #include <gz/msgs/scene.pb.h>
+#include <gz/msgs/uint32_v.pb.h>
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>


### PR DESCRIPTION
# 🦟 Bug fix

* Needed by https://github.com/gazebosim/gz-transport/pull/315

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

* Include strictly necessary headers instead of `library.hh`.
* Remove Windows warning suppressions that aren't needed anymore.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
