### PR TITLE
Fixes warnings about onFoo connections in Qt QML

### DIFF
--- a/include/gz/gui/qml/Main.qml
+++ b/include/gz/gui/qml/Main.qml
@@ -101,11 +101,11 @@ ApplicationWindow
   // C++ signals to QML slots
   Connections {
     target: MainWindow
-    onNotify: {
+    function onNotify(_message) {
       notificationDialog.setTextDuration(_message, 0)
     }
-    onNotifyWithDuration: {
-      notificationDialog.setTextDuration(_message, _duration)
+    function onNotifyWithDuration(_message_, _duration) {
+      notificationDialog.setTextDuration(_message, _duration);
     }
   }
 

--- a/include/gz/gui/qml/PluginMenu.qml
+++ b/include/gz/gui/qml/PluginMenu.qml
@@ -26,7 +26,7 @@ Popup {
 
   Connections {
     target: MainWindow
-    onConfigChanged: {
+    function onConfigChanged() {
       filteredModel.model = MainWindow.PluginListModel()
     }
   }

--- a/include/gz/gui/qml/StyleDialog.qml
+++ b/include/gz/gui/qml/StyleDialog.qml
@@ -97,21 +97,21 @@ Dialog {
   // Connections (C++ signal to QML slot)
   Connections {
     target: MainWindow
-    onMaterialThemeChanged: {
+    function onMaterialThemeChanged() {
       updateTheme(MainWindow.materialTheme);
     }
   }
 
   Connections {
     target: MainWindow
-    onMaterialPrimaryChanged: {
+    function onMaterialPrimaryChanged() {
       updatePrimary(MainWindow.materialPrimary);
     }
   }
 
   Connections {
     target: MainWindow
-    onMaterialAccentChanged: {
+    function onMaterialAccentChanged () {
       updateAccent(MainWindow.materialAccent);
     }
   }

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -42,7 +42,7 @@ GridLayout {
 
   Connections {
     target: GridConfig
-    onNewParams: {
+    onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -49,7 +49,9 @@ Rectangle {
 
   Connections {
     target: ImageDisplay
-    onNewImage: image.reload();
+    function onNewImage() {
+      image.reload();
+    }
   }
 
   ColumnLayout {

--- a/src/plugins/world_control/WorldControl.qml
+++ b/src/plugins/world_control/WorldControl.qml
@@ -29,10 +29,10 @@ RowLayout {
 
   Connections {
     target: WorldControl
-    onPlaying: {
+    function onPlaying() {
       paused = false;
     }
-    onPaused: {
+    function onPaused() {
       paused = true;
     }
   }


### PR DESCRIPTION
# 🦟 Bug fix

Partially fixes https://github.com/gazebosim/gz-gui/issues/481
Split from #404 

## Summary

Cleans up warnings from Qt in the style of:

```
QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
```

## Checklist
- [x] Signed all commits for DCO
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.