### PR TITLE
Tries to fix a scenario when a user sends a malformed point cloud

### DIFF
--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -406,8 +406,7 @@ void PointCloudPrivate::PublishMarkers()
   {
     // Value from float vector, if available. Otherwise publish all data as
     // zeroes.
-    float dataVal = 0.0;
-    dataVal = this->floatVMsg.data(ptIdx);
+    float dataVal = this->floatVMsg.data(ptIdx);
 
     // Don't visualize NaN
     if (std::isnan(dataVal))

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -17,6 +17,7 @@
 
 #include "gz/msgs/pointcloud_packed.pb.h"
 
+#include <algorithm>
 #include <limits>
 #include <string>
 #include <utility>

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -400,8 +400,7 @@ void PointCloudPrivate::PublishMarkers()
     gzwarn << "Mal-formatted pointcloud" << std::endl;
   }
 
-  for (; ptIdx < std::min<unsigned int>(
-    this->floatVMsg.data().size(), num_points);
+  for (; ptIdx < std::min<int>(this->floatVMsg.data().size(), num_points);
     ++iterX, ++iterY, ++iterZ, ++ptIdx)
   {
     // Value from float vector, if available. Otherwise publish all data as

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -391,7 +391,7 @@ void PointCloudPrivate::PublishMarkers()
   auto floatRange = this->maxFloatV - this->minFloatV;
   auto num_points =
     this->pointCloudMsg.data().size() / this->pointCloudMsg.point_step();
-  if (num_points != this->floatVMsg.data().size())
+  if (static_cast<int>(num_points) != this->floatVMsg.data().size())
   {
     gzwarn << "Float message and pointcloud are not of the same size,"
       <<" visualization may not be accurate" << std::endl;

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -407,6 +407,7 @@ void PointCloudPrivate::PublishMarkers()
     // Value from float vector, if available. Otherwise publish all data as
     // zeroes.
     float dataVal = 0.0;
+    dataVal = this->floatVMsg.data(ptIdx);
 
     // Don't visualize NaN
     if (std::isnan(dataVal))

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -388,7 +388,20 @@ void PointCloudPrivate::PublishMarkers()
   auto minC = this->minColor;
   auto maxC = this->maxColor;
   auto floatRange = this->maxFloatV - this->minFloatV;
-  for (; ptIdx < this->floatVMsg.data().size();
+  auto num_points =
+    this->pointCloudMsg.data().size() / this->pointCloudMsg.point_step();
+  if (num_points != this->floatVMsg.data().size())
+  {
+    gzwarn << "Float message and pointcloud are not of the same size,"
+      <<" visualization may not be accurate" << std::endl;
+  }
+  if (this->pointCloudMsg.data().size() % this->pointCloudMsg.point_step() != 0)
+  {
+    gzwarn << "Mal-formatted pointcloud" << std::endl;
+  }
+
+  for (; ptIdx < std::min<unsigned int>(
+    this->floatVMsg.data().size(), num_points);
     ++iterX, ++iterY, ++iterZ, ++ptIdx)
   {
     // Value from float vector, if available. Otherwise publish all data as

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -388,17 +388,16 @@ void PointCloudPrivate::PublishMarkers()
   auto minC = this->minColor;
   auto maxC = this->maxColor;
   auto floatRange = this->maxFloatV - this->minFloatV;
-  for (; iterX != iterX.End() &&
-         iterY != iterY.End() &&
-         iterZ != iterZ.End(); ++iterX, ++iterY, ++iterZ, ++ptIdx)
+  for (; ptIdx < this->floatVMsg.data().size();
+    ++iterX, ++iterY, ++iterZ, ++ptIdx)
   {
     // Value from float vector, if available. Otherwise publish all data as
     // zeroes.
     float dataVal = 0.0;
-    if (this->floatVMsg.data().size() > ptIdx)
-    {
-      dataVal = this->floatVMsg.data(ptIdx);
-    }
+    //if (this->floatVMsg.data().size() > ptIdx)
+    //{
+    //  dataVal = this->floatVMsg.data(ptIdx);
+    //}
 
     // Don't visualize NaN
     if (std::isnan(dataVal))
@@ -413,7 +412,6 @@ void PointCloudPrivate::PublishMarkers()
     };
 
     gz::msgs::Set(marker.add_materials()->mutable_diffuse(), color);
-
     gz::msgs::Set(marker.add_point(), gz::math::Vector3d(
       *iterX,
       *iterY,

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -394,10 +394,6 @@ void PointCloudPrivate::PublishMarkers()
     // Value from float vector, if available. Otherwise publish all data as
     // zeroes.
     float dataVal = 0.0;
-    //if (this->floatVMsg.data().size() > ptIdx)
-    //{
-    //  dataVal = this->floatVMsg.data(ptIdx);
-    //}
 
     // Don't visualize NaN
     if (std::isnan(dataVal))


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This PR fixes a rather odd bug. Essentially if a user were to malform a pointcloud by claiming the point cloud to contain only "x,y,z" fields but has a datasize larger than that, the condition `iterX == iterX.End() && iterY == iterY.End() && iterZ == iterZ.End();` does not get met. Thus the system will keep iterating till a segfault comes along. This PR enforces better check to make sure we do not segfault.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
