### PR TITLE
Add view control reference visual

### DIFF
--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -47,7 +47,7 @@ class ignition::gui::plugins::InteractiveViewControlPrivate
 
   /// \brief Callback for camera view controller request
   /// \param[in] _msg Request message to set the camera view controller
-  /// \param[in] _res Response data
+  /// \param[out] _res Response data
   /// \return True if the request is received
   public: bool OnViewControl(const msgs::StringMsg &_msg,
     msgs::Boolean &_res);
@@ -55,7 +55,7 @@ class ignition::gui::plugins::InteractiveViewControlPrivate
 
   /// \brief Callback for camera reference visual request
   /// \param[in] _msg Request message to enable/disable the reference visual
-  /// \param[in] _res Response data
+  /// \param[out] _res Response data
   /// \return True if the request is received
   public: bool OnReferenceVisual(const msgs::Boolean &_msg,
     msgs::Boolean &_res);

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -205,6 +205,9 @@ void InteractiveViewControlPrivate::OnRender()
       rendering::GeometryPtr sphere = scene->CreateSphere();
       this->refVisual->AddGeometry(sphere);
       this->refVisual->SetLocalScale(math::Vector3d(0.2, 0.2, 0.1));
+      this->refVisual->SetVisibilityFlags(
+        IGN_VISIBILITY_GUI & ~IGN_VISIBILITY_SELECTABLE
+      );
 
       // create material
       math::Color diffuse(1.0f, 1.0f, 0.0f, 1.0f);
@@ -269,6 +272,7 @@ void InteractiveViewControlPrivate::OnRender()
       this->viewControl->Zoom(amount);
       this->UpdateReferenceVisual();
     }
+    // hover
     else
     {
       if (this->refVisual)

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -27,6 +27,8 @@
 #include <ignition/plugin/Register.hh>
 
 #include <ignition/rendering/Camera.hh>
+#include <ignition/rendering/Geometry.hh>
+#include <ignition/rendering/Material.hh>
 #include <ignition/rendering/OrbitViewController.hh>
 #include <ignition/rendering/OrthoViewController.hh>
 #include <ignition/rendering/RenderingIface.hh>
@@ -49,6 +51,18 @@ class ignition::gui::plugins::InteractiveViewControlPrivate
   /// \return True if the request is received
   public: bool OnViewControl(const msgs::StringMsg &_msg,
     msgs::Boolean &_res);
+
+
+  /// \brief Callback for camera reference visual request
+  /// \param[in] _msg Request message to enable/disable the reference visual
+  /// \param[in] _res Response data
+  /// \return True if the request is received
+  public: bool OnReferenceVisual(const msgs::Boolean &_msg,
+    msgs::Boolean &_res);
+
+  /// \brief Update the reference visual. Adjust scale based on distance from
+  /// camera to target point so it remains the same size on screen.
+  public: void UpdateReferenceVisual();
 
   /// \brief Flag to indicate if mouse event is dirty
   public: bool mouseDirty = false;
@@ -83,14 +97,23 @@ class ignition::gui::plugins::InteractiveViewControlPrivate
   /// \brief View controller
   public: std::string viewController{"orbit"};
 
+  /// \brief Enable / disable reference visual
+  public: bool enableRefVisual{true};
+
   /// \brief Camera view control service
   public: std::string cameraViewControlService;
+
+  /// \brief Camera reference visual service
+  public: std::string cameraRefVisualService;
 
   /// \brief Ray query for mouse clicks
   public: rendering::RayQueryPtr rayQuery{nullptr};
 
   //// \brief Pointer to the rendering scene
   public: rendering::ScenePtr scene{nullptr};
+
+  /// \brief Reference visual for visualizing the target point
+  public: rendering::VisualPtr refVisual{nullptr};
 
   /// \brief Transport node for making transform control requests
   public: transport::Node node;
@@ -173,6 +196,31 @@ void InteractiveViewControlPrivate::OnRender()
   }
   this->viewControl->SetCamera(this->camera);
 
+  if (this->enableRefVisual)
+  {
+    if (!this->refVisual)
+    {
+      // create ref visual
+      this->refVisual = scene->CreateVisual();
+      rendering::GeometryPtr sphere = scene->CreateSphere();
+      this->refVisual->AddGeometry(sphere);
+      this->refVisual->SetLocalScale(math::Vector3d(0.2, 0.2, 0.1));
+
+      // create material
+      math::Color diffuse(1.0f, 1.0f, 0.0f, 1.0f);
+      math::Color specular(1.0f, 1.0f, 0.0f, 1.0f);
+      double transparency = 0.3;
+      rendering::MaterialPtr material = scene->CreateMaterial();
+      material->SetDiffuse(diffuse);
+      material->SetSpecular(specular);
+      material->SetTransparency(transparency);
+      material->SetCastShadows(false);
+      this->refVisual->SetMaterial(material);
+      scene->DestroyMaterial(material);
+    }
+    this->refVisual->SetVisible(true);
+  }
+
   if (this->mouseEvent.Type() == common::MouseEvent::SCROLL)
   {
     this->target = rendering::screenToScene(
@@ -183,12 +231,14 @@ void InteractiveViewControlPrivate::OnRender()
         this->target);
     double amount = -this->drag.Y() * distance / 5.0;
     this->viewControl->Zoom(amount);
+    this->UpdateReferenceVisual();
   }
   else if (this->mouseEvent.Type() == common::MouseEvent::PRESS)
   {
     this->target = rendering::screenToScene(
       this->mouseEvent.PressPos(), this->camera, this->rayQuery);
     this->viewControl->SetTarget(this->target);
+    this->UpdateReferenceVisual();
   }
   else
   {
@@ -199,11 +249,13 @@ void InteractiveViewControlPrivate::OnRender()
         this->viewControl->Orbit(this->drag);
       else
         this->viewControl->Pan(this->drag);
+      this->UpdateReferenceVisual();
     }
     // Orbit with middle button
     else if (this->mouseEvent.Buttons() & common::MouseEvent::MIDDLE)
     {
       this->viewControl->Orbit(this->drag);
+      this->UpdateReferenceVisual();
     }
     // Zoom with right button
     else if (this->mouseEvent.Buttons() & common::MouseEvent::RIGHT)
@@ -215,10 +267,33 @@ void InteractiveViewControlPrivate::OnRender()
           static_cast<double>(this->camera->ImageHeight()))
           * distance * tan(vfov/2.0) * 6.0);
       this->viewControl->Zoom(amount);
+      this->UpdateReferenceVisual();
+    }
+    else
+    {
+      if (this->refVisual)
+        this->refVisual->SetVisible(false);
     }
   }
+
   this->drag = 0;
   this->mouseDirty = false;
+}
+
+/////////////////////////////////////////////////
+void InteractiveViewControlPrivate::UpdateReferenceVisual()
+{
+  if (!this->refVisual || !this->enableRefVisual)
+    return;
+  this->refVisual->SetWorldPosition(this->target);
+  // Update the size of the reference visual based on the distance to the
+  // target point.
+  double distance =
+      this->camera->WorldPosition().Distance(this->target);
+
+  double scale = distance * atan(IGN_DTOR(1.0));
+  this->refVisual->SetLocalScale(
+      math::Vector3d(scale, scale, scale * 0.5));
 }
 
 /////////////////////////////////////////////////
@@ -246,6 +321,17 @@ bool InteractiveViewControlPrivate::OnViewControl(const msgs::StringMsg &_msg,
 }
 
 /////////////////////////////////////////////////
+bool InteractiveViewControlPrivate::OnReferenceVisual(const msgs::Boolean &_msg,
+  msgs::Boolean &_res)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+  this->enableRefVisual = _msg.data();
+
+  _res.set_data(true);
+  return true;
+}
+
+/////////////////////////////////////////////////
 InteractiveViewControl::InteractiveViewControl()
   : Plugin(), dataPtr(std::make_unique<InteractiveViewControlPrivate>())
 {
@@ -267,6 +353,12 @@ void InteractiveViewControl::LoadConfig(
       &InteractiveViewControlPrivate::OnViewControl, this->dataPtr.get());
   ignmsg << "Camera view controller topic advertised on ["
          << this->dataPtr->cameraViewControlService << "]" << std::endl;
+
+  this->dataPtr->cameraRefVisualService = "/gui/camera/reference_visual";
+  this->dataPtr->node.Advertise(this->dataPtr->cameraRefVisualService,
+      &InteractiveViewControlPrivate::OnReferenceVisual, this->dataPtr.get());
+  ignmsg << "Camera reference visual topic advertised on ["
+         << this->dataPtr->cameraRefVisualService << "]" << std::endl;
 
   ignition::gui::App()->findChild<
     ignition::gui::MainWindow *>()->installEventFilter(this);
@@ -328,6 +420,13 @@ bool InteractiveViewControl::eventFilter(QObject *_obj, QEvent *_event)
     auto blockOrbit = reinterpret_cast<ignition::gui::events::BlockOrbit *>(
       _event);
     this->dataPtr->blockOrbit = blockOrbit->Block();
+  }
+  else if (_event->type() == gui::events::HoverOnScene::kType)
+  {
+    gui::events::HoverOnScene *_e =
+      static_cast<gui::events::HoverOnScene*>(_event);
+    this->dataPtr->mouseDirty = true;
+    this->dataPtr->mouseEvent = _e->Mouse();
   }
 
   // Standard event processing


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

related issue: https://github.com/gazebosim/gz-rendering/issues/265

related PR: https://github.com/gazebosim/gz-sim/pull/1788

## Summary

Adds a reference visual to help visualize the anchor point for view control operations.

The implementation is done in `gz-gui` instead of `gz-rendering` as it's easier to do since we need to toggle visibility depending on mouse events, and also we don't need to write the same code twice for different view controllers.

By default, the visual is enabled. You can enable / disable this visual with https://github.com/gazebosim/gz-sim/pull/1788.

side note: I tried testing with the orthographic view controller, but the controller seems to be broken

## Test it

Launch gazebo and try panning, orbiting, zooming with the mouse and you should see a small yellow ellipsoid rendered at the mouse press position.

![ref_visual](https://user-images.githubusercontent.com/4000684/200974133-7825f847-12d9-4947-a3e5-b6fcb8a81fc1.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

