### PR TITLE
Fix large / unexpected camera movements

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -77,7 +77,12 @@ class ignition::gui::plugins::IgnRenderer::Implementation
   /// \brief Key event
   public: common::KeyEvent keyEvent;
 
-  /// \brief Max number of mouse events to process
+  /// \brief Max number of mouse events to store in the queue.
+  /// These events are then propagated to other gui plugins. A queue is used
+  /// instead of just keeping the latest mouse event so that we can capture
+  /// important events like mouse presses. However we keep the queue size
+  /// small on purpose so that we do not flood other gui plugins with events
+  /// that may be outdated.
   public: const unsigned int kMaxMouseEventSize = 5u;
 
   /// \brief Mutex to protect mouse events

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -18,6 +18,7 @@
 #include "MinimalScene.hh"
 
 #include <algorithm>
+#include <list>
 #include <map>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gz-sim/issues/1085

## Summary
Fixes large / unexpected camera movement when orbiting / panning due to missing mouse events.

More info:

The `Minimal Scene` is responsible for propagating all mouse events to other GUI plugins. However, mouse events were continuously overriden by the latest ones before they can be propagated / processed. This causes important events like a mouse press to be lost. The `Interactive View Control` relies on mouse press pos to determine the anchor point for camera orbiting and panning, so if it misses a mouse press pos, it justs uses the last anchor point for camera movements. When the anchor point is far away, it causes large camera jumps. 

This gif shows the problem. The first pan motion successfully sets the anchor point (yellow ellipsoid). Subsequent camera orbit and pan motions miss the mouse press events and thus they still use the old anchor point that's on top of the red box.

![missing_mouse_events](https://user-images.githubusercontent.com/4000684/201231865-41b1cd6f-71e1-4332-994f-397562a59ba0.gif)



This PRs fixes the issue by storing mouse events in a list in `Minimal Scene` instead of just the latest event, and makes sure that the `Interactive View Control` always handles mouse press events.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.