### PR TITLE
Set View Camera controller from plugin configuration

### DIFF
--- a/src/plugins/minimal_scene/CMakeLists.txt
+++ b/src/plugins/minimal_scene/CMakeLists.txt
@@ -5,5 +5,5 @@ ign_gui_add_plugin(MinimalScene
     MinimalScene.hh
   PUBLIC_LINK_LIBS
    ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+   ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
 )
-

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -348,8 +348,10 @@ void IgnRenderer::Render(RenderSync *_renderSync)
     {
       if (!_result)
       {
+        // LCOV_EXCL_START
         ignerr << "Error setting view controller. Check if the View Angle GUI "
                   "plugin is loaded." << std::endl;
+        // LCOV_EXCL_STOP
       }
       this->cameraViewController = "";
     };

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -347,7 +347,8 @@ void IgnRenderer::Render(RenderSync *_renderSync)
         [&](const msgs::Boolean &/*_rep*/, const bool _result)
     {
       if (!_result)
-        ignerr << "Error setting view controller" << std::endl;
+        ignerr << "Error setting view controller. Check if view angle GUI "
+                  "plugin is already loaded" << std::endl;
       else
       {
         this->cameraViewController = "";
@@ -355,19 +356,7 @@ void IgnRenderer::Render(RenderSync *_renderSync)
     };
 
     msgs::StringMsg req;
-    if (this->cameraViewController.find("orbit") != std::string::npos)
-    {
-      req.set_data("orbit");
-    }
-    else if (this->cameraViewController.find("ortho") != std::string::npos)
-    {
-      req.set_data("ortho");
-    }
-    else
-    {
-      ignerr << "Unknown view controller selected: "
-             << this->cameraViewController << std::endl;
-    }
+    req.set_data(this->cameraViewController);
     node.Request(viewControlService, req, cb);
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -347,12 +347,11 @@ void IgnRenderer::Render(RenderSync *_renderSync)
         [&](const msgs::Boolean &/*_rep*/, const bool _result)
     {
       if (!_result)
-        ignerr << "Error setting view controller. Check if view angle GUI "
-                  "plugin is already loaded" << std::endl;
-      else
       {
-        this->cameraViewController = "";
+        ignerr << "Error setting view controller. Check if the View Angle GUI "
+                  "plugin is loaded." << std::endl;
       }
+      this->cameraViewController = "";
     };
 
     msgs::StringMsg req;
@@ -1197,17 +1196,7 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     elem = _pluginElem->FirstChildElement("view_controller");
     if (nullptr != elem && nullptr != elem->GetText())
     {
-      std::string viewControllerType = elem->GetText();
-      if (viewControllerType.find("orbit") != std::string::npos ||
-          viewControllerType.find("ortho") != std::string::npos)
-      {
-        renderWindow->SetCameraViewController(viewControllerType);
-      }
-      else
-      {
-        ignerr << "Unknown view controller selected: "
-               << viewControllerType << std::endl;
-      }
+      renderWindow->SetCameraViewController(elem->GetText());
     }
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -63,6 +63,7 @@ namespace plugins
   /// * \<sky\> : If present, sky is enabled.
   /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
   ///                        defaults to 90
+  /// * \<view_controller> : Set the view controller type: ortho or orbit
   class MinimalScene : public Plugin
   {
     Q_OBJECT
@@ -242,6 +243,9 @@ namespace plugins
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 
+    /// \brief view controller type {ortho or orbit}
+    public: std::string cameraViewController{""};
+
     /// \internal
     /// \brief Pointer to private data.
     IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
@@ -346,6 +350,10 @@ namespace plugins
     /// \brief Set the Horizontal FOV of the camera
     /// \param[in] _fov FOV of the camera in degree
     public: void SetCameraHFOV(const ignition::math::Angle &_fov);
+
+    /// \brief Set the camera view controller
+    /// \param[in] _view_controller ortho or orbit
+    public: void SetCameraViewController(const std::string &_view_controller);
 
     /// \brief Slot called when thread is ready to be started
     public Q_SLOTS: void Ready();

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -63,7 +63,8 @@ namespace plugins
   /// * \<sky\> : If present, sky is enabled.
   /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
   ///                        defaults to 90
-  /// * \<view_controller> : Set the view controller type: ortho or orbit
+  /// * \<view_controller> : Set the view controller (InteractiveViewControl
+  ///                        currently supports types: ortho or orbit).
   class MinimalScene : public Plugin
   {
     Q_OBJECT
@@ -243,7 +244,7 @@ namespace plugins
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 
-    /// \brief view controller type {ortho or orbit}
+    /// \brief View controller type
     public: std::string cameraViewController{""};
 
     /// \internal
@@ -352,7 +353,7 @@ namespace plugins
     public: void SetCameraHFOV(const ignition::math::Angle &_fov);
 
     /// \brief Set the camera view controller
-    /// \param[in] _view_controller ortho or orbit
+    /// \param[in] _view_controller The camera view controller type to set
     public: void SetCameraViewController(const std::string &_view_controller);
 
     /// \brief Slot called when thread is ready to be started

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -90,12 +90,14 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "  <far>5000</far>"
       "</camera_clip>"
       "<horizontal_fov>60</horizontal_fov>"
+      "<view_controller>ortho</view_controller>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;
   pluginDoc.Parse(pluginStr);
   EXPECT_TRUE(app.LoadPlugin("MinimalScene",
       pluginDoc.FirstChildElement("plugin")));
+  EXPECT_TRUE(app.LoadPlugin("InteractiveViewControl"));
 
   // Get main window
   auto win = app.findChild<MainWindow *>();
@@ -130,7 +132,7 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     QCoreApplication::processEvents();
-    sleep++;
+    ++sleep;
   }
   EXPECT_TRUE(receivedPreRenderEvent);
   EXPECT_TRUE(receivedRenderEvent);
@@ -157,9 +159,12 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
 
   EXPECT_NEAR(60, camera->HFOV().Degree(), 1e-4);
 
+  EXPECT_EQ(rendering::CameraProjectionType::CPT_ORTHOGRAPHIC,
+            camera->ProjectionType());
+
   // Cleanup
   auto plugins = win->findChildren<Plugin *>();
-  EXPECT_EQ(1, plugins.size());
+  EXPECT_EQ(2, plugins.size());
 
   auto pluginName = plugins[0]->CardItem()->objectName().toStdString();
   EXPECT_TRUE(app.RemovePlugin(pluginName));


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
# 🎉 New feature

## Summary

Set View Camera controller from plugin configuration

```xml
      <!-- 3D scene -->
      <plugin filename="MinimalScene" name="3D View">
        <ignition-gui>
          <title>3D View</title>
          <property type="bool" key="showTitleBar">false</property>
          <property type="string" key="state">docked</property>
        </ignition-gui>

        <engine>ogre2</engine>
        <scene>scene</scene>
        <ambient_light>0.4 0.4 0.4</ambient_light>
        <background_color>0.8 0.8 0.8</background_color>
        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
        <camera_clip>
          <near>0.25</near>
          <far>25000</far>
        </camera_clip>
        <view_controller>ortho</view_controller>
      </plugin>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
