### PR TITLE
3.12.0 pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui3 VERSION 3.11.2)
+project(ignition-gui3 VERSION 3.12.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -15,6 +15,7 @@ find_package(ignition-cmake2 2.14 REQUIRED)
 #============================================================================
 ign_configure_project(
   REPLACE_IGNITION_INCLUDE_PATH gz/gui
+  VERSION_SUFFIX pre1
 )
 
 #============================================================================


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 3.12.0 prerelease.

Comparison to 3.11.2: https://github.com/gazebosim/gz-gui/compare/ignition-gui3_3.11.2...ign-gui3

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sim/pull/1646

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
