### PR TITLE
Bump rendering dep to 8

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -3,7 +3,7 @@ libgz-common5-dev
 libgz-math7-dev
 libgz-msgs9-dev
 libgz-plugin2-dev
-libgz-rendering7-dev
+libgz-rendering8-dev
 libgz-tools2-dev
 libgz-transport12-dev
 libgz-utils2-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,8 @@ set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-rendering
-gz_find_package(gz-rendering7 REQUIRED)
-set(GZ_RENDERING_VER ${gz-rendering7_VERSION_MAJOR})
+gz_find_package(gz-rendering8 REQUIRED)
+set(GZ_RENDERING_VER ${gz-rendering8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-msgs


### PR DESCRIPTION
Bump `main` to depend on rendering8

https://github.com/gazebo-tooling/release-tools/issues/853
