### PR TITLE
Add service to change camera follow pgain.

### DIFF
--- a/examples/standalone/scene_provider/README.md
+++ b/examples/standalone/scene_provider/README.md
@@ -63,3 +63,15 @@ Update follow offset:
 ```
 gz service -s /gui/follow/offset --reqtype gz.msgs.Vector3d --reptype gz.msgs.Boolean --timeout 2000 --req 'x: 5, y: 5, z: 5'
 ```
+
+Set next follow pgain:
+
+```
+gz service -s /gui/follow/pgain --reqtype gz.msgs.Double --reptype gz.msgs.Boolean --timeout 2000 --req 'data: 1.0'
+```
+
+Update follow offset with new pgain:
+
+```
+gz service -s /gui/follow/offset --reqtype gz.msgs.Vector3d --reptype gz.msgs.Boolean --timeout 2000 --req 'x: 1, y: 1, z: 5'
+```

--- a/examples/standalone/scene_provider/README.md
+++ b/examples/standalone/scene_provider/README.md
@@ -9,7 +9,7 @@ plugin to update the scene using Gazebo Transport.
 
 ## Build
 
-```
+```bash
 cd examples/standalone/scene_provider
 mkdir build
 cd build
@@ -21,14 +21,14 @@ make
 
 In one terminal, start the scene provider:
 
-```
+```bash
 cd examples/standalone/scene_provider/build
 ./scene_provider
 ```
 
 On another terminal, start the example config:
 
-```
+```bash
 gz gui -c examples/config/scene3d.config
 ```
 
@@ -42,36 +42,36 @@ Some commands to test camera tracking with this demo:
 
 Move to box:
 
-```
+```bash
 gz service -s /gui/move_to --reqtype gz.msgs.StringMsg --reptype gz.msgs.Boolean --timeout 2000 --req 'data: "box_model"'
 ```
 
 Echo camera pose:
 
-```
+```bash
 gz topic -e -t /gui/camera/pose
 ```
 
 Follow box:
 
-```
+```bash
 gz service -s /gui/follow --reqtype gz.msgs.StringMsg --reptype gz.msgs.Boolean --timeout 2000 --req 'data: "box_model"'
 ```
 
 Update follow offset:
 
-```
+```bash
 gz service -s /gui/follow/offset --reqtype gz.msgs.Vector3d --reptype gz.msgs.Boolean --timeout 2000 --req 'x: 5, y: 5, z: 5'
 ```
 
-Set next follow pgain:
+Set next follow p_gain:
 
-```
-gz service -s /gui/follow/pgain --reqtype gz.msgs.Double --reptype gz.msgs.Boolean --timeout 2000 --req 'data: 1.0'
+```bash
+gz service -s /gui/follow/p_gain --reqtype gz.msgs.Double --reptype gz.msgs.Boolean --timeout 2000 --req 'data: 1.0'
 ```
 
-Update follow offset with new pgain:
+Update follow offset with new p_gain:
 
-```
+```bash
 gz service -s /gui/follow/offset --reqtype gz.msgs.Vector3d --reptype gz.msgs.Boolean --timeout 2000 --req 'x: 1, y: 1, z: 5'
 ```

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -114,6 +114,7 @@ endfunction()
 # Plugins
 add_subdirectory(camera_fps)
 add_subdirectory(camera_tracking)
+add_subdirectory(follow_config)
 add_subdirectory(grid_config)
 add_subdirectory(image_display)
 add_subdirectory(interactive_view_control)

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -77,6 +77,13 @@ class CameraTrackingPrivate
   public: bool OnFollowOffset(const msgs::Vector3d &_msg,
                msgs::Boolean &_res);
 
+  /// \brief Callback for a follow pgain request
+  /// \param[in] _msg Request message to set the camera's follow pgain.
+  /// \param[in] _res Response data
+  /// \return True if the request is received
+  public: bool OnFollowPGain(const msgs::Double &_msg,
+               msgs::Boolean &_res);
+
   /// \brief Callback when a move to animation is complete
   private: void OnMoveToComplete();
 
@@ -142,6 +149,9 @@ class CameraTrackingPrivate
   /// \brief Follow offset service
   public: std::string followOffsetService;
 
+  /// \brief Follow offset pgain service
+  public: std::string followPGainService;
+
   /// \brief Camera pose topic
   public: std::string cameraPoseTopic;
 
@@ -206,12 +216,19 @@ void CameraTrackingPrivate::Initialize()
   gzmsg << "Camera pose topic advertised on ["
          << this->cameraPoseTopic << "]" << std::endl;
 
-   // follow offset
-   this->followOffsetService = "/gui/follow/offset";
-   this->node.Advertise(this->followOffsetService,
-       &CameraTrackingPrivate::OnFollowOffset, this);
-   gzmsg << "Follow offset service on ["
-          << this->followOffsetService << "]" << std::endl;
+  // follow offset
+  this->followOffsetService = "/gui/follow/offset";
+  this->node.Advertise(this->followOffsetService,
+      &CameraTrackingPrivate::OnFollowOffset, this);
+  gzmsg << "Follow offset service on ["
+         << this->followOffsetService << "]" << std::endl;
+
+  // follow pgain
+  this->followPGainService = "/gui/follow/pgain";
+  this->node.Advertise(this->followPGainService,
+      &CameraTrackingPrivate::OnFollowPGain, this);
+  gzmsg << "Follow P gain service on ["
+         << this->followPGainService << "]" << std::endl;
 }
 
 /////////////////////////////////////////////////
@@ -258,6 +275,17 @@ bool CameraTrackingPrivate::OnFollowOffset(const msgs::Vector3d &_msg,
     this->newFollowOffset = true;
     this->followOffset = msgs::Convert(_msg);
   }
+
+  _res.set_data(true);
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool CameraTrackingPrivate::OnFollowPGain(const msgs::Double &_msg,
+  msgs::Boolean &_res)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+  this->followPGain = msgs::Convert(_msg);
 
   _res.set_data(true);
   return true;

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -481,10 +481,37 @@ CameraTracking::CameraTracking()
 CameraTracking::~CameraTracking() = default;
 
 /////////////////////////////////////////////////
-void CameraTracking::LoadConfig(const tinyxml2::XMLElement *)
+void CameraTracking::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 {
   if (this->title.empty())
     this->title = "Camera tracking";
+
+  if (_pluginElem)
+  {
+    if (auto nameElem = _pluginElem->FirstChildElement("follow_target"))
+    {
+      this->dataPtr->followTarget = nameElem->GetText();
+      gzmsg << "CameraTracking: Loaded follow_target from sdf ["
+            << this->dataPtr->followTarget << "]" << std::endl;
+      this->dataPtr->followTargetWait = true;
+    }
+    if (auto offsetElem = _pluginElem->FirstChildElement("follow_offset"))
+    {
+      std::stringstream offsetStr;
+      offsetStr << std::string(offsetElem->GetText());
+      offsetStr >> this->dataPtr->followOffset;
+      gzmsg << "FollowConfig: Loaded follow_offset from sdf ["
+            << this->dataPtr->followOffset << "]" << std::endl;
+      this->dataPtr->newFollowOffset = true;
+    }
+    if (auto pGainElem = _pluginElem->FirstChildElement("follow_pgain"))
+    {
+      this->dataPtr->followPGain = std::stod(std::string(pGainElem->GetText()));
+      gzmsg << "FollowConfig: Loaded follow_pgain from sdf ["
+            << this->dataPtr->followPGain << "]" << std::endl;
+      this->dataPtr->newFollowOffset = true;
+    }
+  }
 
   App()->findChild<MainWindow *>()->installEventFilter(this);
 }

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2023 Rudis Laboratories LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,7 +225,7 @@ void CameraTrackingPrivate::Initialize()
          << this->followOffsetService << "]" << std::endl;
 
   // follow pgain
-  this->followPGainService = "/gui/follow/pgain";
+  this->followPGainService = "/gui/follow/p_gain";
   this->node.Advertise(this->followPGainService,
       &CameraTrackingPrivate::OnFollowPGain, this);
   gzmsg << "Follow P gain service on ["
@@ -285,8 +286,11 @@ bool CameraTrackingPrivate::OnFollowPGain(const msgs::Double &_msg,
   msgs::Boolean &_res)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
-  this->followPGain = msgs::Convert(_msg);
-
+  if (!this->followTarget.empty())
+  {
+    this->newFollowOffset = true;
+    this->followPGain = msgs::Convert(_msg);
+  }
   _res.set_data(true);
   return true;
 }

--- a/src/plugins/camera_tracking/CameraTracking.hh
+++ b/src/plugins/camera_tracking/CameraTracking.hh
@@ -35,6 +35,7 @@ namespace gz::gui::plugins
   /// * `/gui/move_to/pose`: Move the user camera to a given pose.
   /// * `/gui/follow`: Set the user camera to follow a given target,
   ///                   identified by name.
+  /// * `/gui/follow/pgain`: Set the pgain for following.
   /// * `/gui/follow/offset`: Set the offset for following.
   ///
   /// Topics:

--- a/src/plugins/camera_tracking/CameraTracking.hh
+++ b/src/plugins/camera_tracking/CameraTracking.hh
@@ -35,7 +35,7 @@ namespace gz::gui::plugins
   /// * `/gui/move_to/pose`: Move the user camera to a given pose.
   /// * `/gui/follow`: Set the user camera to follow a given target,
   ///                   identified by name.
-  /// * `/gui/follow/pgain`: Set the pgain for following.
+  /// * `/gui/follow/p_gain`: Set the pgain for following.
   /// * `/gui/follow/offset`: Set the offset for following.
   ///
   /// Topics:

--- a/src/plugins/camera_tracking/CameraTracking.qml
+++ b/src/plugins/camera_tracking/CameraTracking.qml
@@ -29,6 +29,7 @@ ColumnLayout {
       '<li>/gui/move_to</li>' +
       '<li>/gui/move_to/pose</li>' +
       '<li>/gui/follow</li>' +
+      '<li>/gui/follow/pgain</li>' +
       '<li>/gui/follow/offset</li></ul><br>Topics provided:<br><ul>' +
       '<li>/gui/camera/pose</li></ul>'
 

--- a/src/plugins/camera_tracking/CameraTracking.qml
+++ b/src/plugins/camera_tracking/CameraTracking.qml
@@ -29,7 +29,7 @@ ColumnLayout {
       '<li>/gui/move_to</li>' +
       '<li>/gui/move_to/pose</li>' +
       '<li>/gui/follow</li>' +
-      '<li>/gui/follow/pgain</li>' +
+      '<li>/gui/follow/p_gain</li>' +
       '<li>/gui/follow/offset</li></ul><br>Topics provided:<br><ul>' +
       '<li>/gui/camera/pose</li></ul>'
 

--- a/src/plugins/follow_config/CMakeLists.txt
+++ b/src/plugins/follow_config/CMakeLists.txt
@@ -1,0 +1,6 @@
+gz_gui_add_plugin(FollowConfig
+  SOURCES
+    FollowConfig.cc
+  QT_HEADERS
+    FollowConfig.hh
+)

--- a/src/plugins/follow_config/FollowConfig.cc
+++ b/src/plugins/follow_config/FollowConfig.cc
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2023 Rudis Laboratories LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <string>
+
+#include <gz/msgs/double.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/vector3d.pb.h>
+
+#include <gz/common/Console.hh>
+#include <gz/msgs/Utility.hh>
+#include <gz/plugin/Register.hh>
+
+#include "gz/gui/Application.hh"
+#include "gz/gui/Conversions.hh"
+#include "gz/gui/GuiEvents.hh"
+#include "gz/gui/MainWindow.hh"
+
+#include <gz/transport/Node.hh>
+
+#include "FollowConfig.hh"
+
+/// \brief Private data class for FollowConfig
+class gz::gui::plugins::FollowConfigPrivate
+{
+  /// \brief Service request topic for follow name
+  public: std::string followTargetNameService;
+
+  /// \brief Service request topic for follow offset
+  public: std::string followOffsetService;
+
+  /// \brief Service request topic for follow p_gain
+  public: std::string followPGainService;
+
+  /// \brief Offset of camera from target being followed
+  public: math::Vector3d followOffset{math::Vector3d(-5.0, 0.0, 3.0)};
+
+  /// \brief Follow P gain
+  public: double followPGain{0.01};
+
+  /// \brief Follow target name from sdf
+  public: std::string followTargetName;
+
+  public: transport::Node node;
+
+  /// \brief Process updated follow name from SDF
+  public: void UpdateFollowTargetName();
+
+  /// \brief Process updated follow offset
+  public: void UpdateFollowOffset();
+
+  /// \brief Process updated P Gain
+  public: void UpdateFollowPGain();
+
+  /// \brief flag for updating target name
+  public: bool newFollowUpdateTargetName = false;
+
+  /// \brief flag for updating P gain
+  public: bool newFollowUpdatePGain = false;
+
+  /// \brief flag for updating offset
+  public: bool newFollowUpdateOffset = false;
+
+};
+
+using namespace gz;
+using namespace gui;
+using namespace plugins;
+
+/////////////////////////////////////////////////
+FollowConfig::FollowConfig()
+  : gz::gui::Plugin(), dataPtr(std::make_unique<FollowConfigPrivate>())
+{
+}
+
+/////////////////////////////////////////////////
+FollowConfig::~FollowConfig() = default;
+
+/////////////////////////////////////////////////
+void FollowConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+{
+  if (this->title.empty())
+    this->title = "Follow Config";
+
+  // Follow target name service
+  this->dataPtr->followTargetNameService = "/gui/follow";
+  gzmsg << "FollowConfig: Follow target name service on ["
+         << this->dataPtr->followTargetNameService << "]" << std::endl;
+
+  // Follow target offset service
+  this->dataPtr->followOffsetService = "/gui/follow/offset";
+  gzmsg << "FollowConfig: Follow offset service on ["
+         << this->dataPtr->followOffsetService << "]" << std::endl;
+
+  // Follow target pgain service
+  this->dataPtr->followPGainService = "/gui/follow/p_gain";
+  gzmsg << "FollowConfig: Follow P gain service on ["
+         << this->dataPtr->followPGainService << "]" << std::endl;
+
+
+  // Read configuration
+  if (_pluginElem)
+  {
+    if (auto nameElem = _pluginElem->FirstChildElement("follow_target"))
+    {
+      this->dataPtr->followTargetName = nameElem->GetText();
+      gzmsg << "FollowConfig: Loaded follow_target from sdf ["
+         << this->dataPtr->followTargetName << "]" << std::endl;
+      this->dataPtr->newFollowUpdateTargetName = true;
+    }
+    if (auto offsetElem = _pluginElem->FirstChildElement("follow_offset"))
+    {
+      std::stringstream offsetStr;
+      offsetStr << std::string(offsetElem->GetText());
+      offsetStr >> this->dataPtr->followOffset;
+      gzmsg << "FollowConfig: Loaded follow_offset from sdf ["
+         << this->dataPtr->followOffset << "]" << std::endl;
+      this->dataPtr->newFollowUpdateOffset = true;
+    }
+    if (auto pGainElem = _pluginElem->FirstChildElement("follow_pgain"))
+    {
+      this->dataPtr->followPGain = std::stod(std::string(pGainElem->GetText()));
+      gzmsg << "FollowConfig: Loaded follow_pgain from sdf ["
+         << this->dataPtr->followPGain << "]" << std::endl;
+      this->dataPtr->newFollowUpdatePGain = true;
+    }
+  }
+
+  gui::App()->findChild<
+      MainWindow *>()->installEventFilter(this);
+}
+
+/////////////////////////////////////////////////
+bool FollowConfig::eventFilter(QObject *_obj, QEvent *_event)
+{
+  if (_event->type() == events::Render::kType)
+  {
+    if (this->dataPtr->newFollowUpdateTargetName)
+    {
+      this->dataPtr->UpdateFollowTargetName();
+    }
+    if (this->dataPtr->newFollowUpdatePGain)
+    {
+      this->dataPtr->UpdateFollowPGain();
+    }
+    if (this->dataPtr->newFollowUpdateOffset)
+    {
+      this->dataPtr->UpdateFollowOffset();
+    }
+  }
+
+  // Standard event processing
+  return QObject::eventFilter(_obj, _event);
+}
+
+/////////////////////////////////////////////////
+void FollowConfig::SetFollowOffset(double _x,
+          double _y, double _z)
+{
+  if (!this->dataPtr->newFollowUpdateOffset)
+  {
+    this->dataPtr->followOffset = math::Vector3d(
+      _x, _y, _z);
+      gzmsg << "FollowConfig: SetFollowOffset("
+        << this->dataPtr->followOffset << ")" << std::endl;
+    this->dataPtr->newFollowUpdateOffset = true;
+  }
+}
+
+/////////////////////////////////////////////////
+void FollowConfig::SetFollowPGain(double _p)
+{
+  if (!this->dataPtr->newFollowUpdatePGain)
+  {
+    this->dataPtr->followPGain = _p;
+    gzmsg << "FollowConfig: SetFollowPGain("
+         << this->dataPtr->followPGain << ")" << std::endl;
+    this->dataPtr->newFollowUpdatePGain = true;
+  }
+}
+
+/////////////////////////////////////////////////
+void FollowConfigPrivate::UpdateFollowTargetName()
+{
+  // Offset
+  std::function<void(const msgs::Boolean &, const bool)> cbName =
+    [&](const msgs::Boolean &/*_rep*/, const bool _resultName)
+  {
+    if (!_resultName)
+    {
+      gzerr << "FollowConfig: Error sending follow target name." << std::endl;
+    } else {
+      gzmsg << "FollowConfig: Request Target Name: "
+            << this->followTargetName << " sent" << std::endl;
+    }
+  };
+
+  msgs::StringMsg reqName;
+  reqName.set_data(this->followTargetName);
+  node.Request(this->followTargetNameService, reqName, cbName);
+  this->newFollowUpdateTargetName = false;
+}
+
+/////////////////////////////////////////////////
+void FollowConfigPrivate::UpdateFollowOffset()
+{
+  // Offset
+  std::function<void(const msgs::Boolean &, const bool)> cbOffset =
+    [&](const msgs::Boolean &/*_rep*/, const bool _resultOffset)
+  {
+    if (!_resultOffset)
+    {
+      gzerr << "FollowConfig: Error sending follow offset." << std::endl;
+    } else {
+      gzmsg << "FollowConfig: Request Offset: "
+            << this->followOffset << " sent" << std::endl;
+    }
+  };
+
+  msgs::Vector3d reqOffset;
+  reqOffset.set_x(this->followOffset.X());
+  reqOffset.set_y(this->followOffset.Y());
+  reqOffset.set_z(this->followOffset.Z());
+  node.Request(this->followOffsetService, reqOffset, cbOffset);
+  this->newFollowUpdateOffset = false;
+}
+
+/////////////////////////////////////////////////
+void FollowConfigPrivate::UpdateFollowPGain()
+{
+  // PGain
+  std::function<void(const msgs::Boolean &, const bool)> cbPGain =
+    [&](const msgs::Boolean &/*_rep*/, const bool _resultPGain)
+  {
+    if (!_resultPGain)
+    {
+      gzerr << "FollowConfig: Error sending follow pgain." << std::endl;
+    } else {
+      gzmsg << "FollowConfig: Request PGain: "
+            << this->followPGain << " sent" << std::endl;
+    }
+  };
+
+  msgs::Double reqPGain;
+  reqPGain.set_data(this->followPGain);
+  node.Request(this->followPGainService, reqPGain, cbPGain);
+  this->newFollowUpdatePGain = false;
+}
+
+// Register this plugin
+GZ_ADD_PLUGIN(FollowConfig,
+              gui::Plugin)

--- a/src/plugins/follow_config/FollowConfig.cc
+++ b/src/plugins/follow_config/FollowConfig.cc
@@ -98,7 +98,7 @@ void FollowConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   // Follow target name service
   this->dataPtr->followTargetNameService = "/gui/follow";
   gzmsg << "FollowConfig: Follow target name service on ["
-         << this->dataPtr->followTargetNameService << "]" << std::endl;
+        << this->dataPtr->followTargetNameService << "]" << std::endl;
 
   // Follow target offset service
   this->dataPtr->followOffsetService = "/gui/follow/offset";
@@ -110,7 +110,6 @@ void FollowConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   gzmsg << "FollowConfig: Follow P gain service on ["
          << this->dataPtr->followPGainService << "]" << std::endl;
 
-
   // Read configuration
   if (_pluginElem)
   {
@@ -118,7 +117,7 @@ void FollowConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     {
       this->dataPtr->followTargetName = nameElem->GetText();
       gzmsg << "FollowConfig: Loaded follow_target from sdf ["
-         << this->dataPtr->followTargetName << "]" << std::endl;
+            << this->dataPtr->followTargetName << "]" << std::endl;
       this->dataPtr->newFollowUpdateTargetName = true;
     }
     if (auto offsetElem = _pluginElem->FirstChildElement("follow_offset"))
@@ -127,14 +126,14 @@ void FollowConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       offsetStr << std::string(offsetElem->GetText());
       offsetStr >> this->dataPtr->followOffset;
       gzmsg << "FollowConfig: Loaded follow_offset from sdf ["
-         << this->dataPtr->followOffset << "]" << std::endl;
+            << this->dataPtr->followOffset << "]" << std::endl;
       this->dataPtr->newFollowUpdateOffset = true;
     }
     if (auto pGainElem = _pluginElem->FirstChildElement("follow_pgain"))
     {
       this->dataPtr->followPGain = std::stod(std::string(pGainElem->GetText()));
       gzmsg << "FollowConfig: Loaded follow_pgain from sdf ["
-         << this->dataPtr->followPGain << "]" << std::endl;
+            << this->dataPtr->followPGain << "]" << std::endl;
       this->dataPtr->newFollowUpdatePGain = true;
     }
   }
@@ -174,8 +173,8 @@ void FollowConfig::SetFollowOffset(double _x,
   {
     this->dataPtr->followOffset = math::Vector3d(
       _x, _y, _z);
-      gzmsg << "FollowConfig: SetFollowOffset("
-        << this->dataPtr->followOffset << ")" << std::endl;
+    gzmsg << "FollowConfig: SetFollowOffset("
+          << this->dataPtr->followOffset << ")" << std::endl;
     this->dataPtr->newFollowUpdateOffset = true;
   }
 }

--- a/src/plugins/follow_config/FollowConfig.hh
+++ b/src/plugins/follow_config/FollowConfig.hh
@@ -40,7 +40,7 @@ namespace plugins
     public: virtual ~FollowConfig();
 
     // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+    public: virtual void LoadConfig(const tinyxml2::XMLElement *)
         override;
 
     /// \brief Set the follow offset, requested from the GUI.

--- a/src/plugins/follow_config/FollowConfig.hh
+++ b/src/plugins/follow_config/FollowConfig.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Rudis Laboratories LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_GUI_PLUGINS_FOLLOWCONFIG_HH_
+#define GZ_GUI_PLUGINS_FOLLOWCONFIG_HH_
+
+#include <memory>
+
+#include "gz/gui/Plugin.hh"
+
+namespace gz
+{
+namespace gui
+{
+namespace plugins
+{
+  class FollowConfigPrivate;
+
+  class FollowConfig : public Plugin
+  {
+    Q_OBJECT
+
+    /// \brief Constructor
+    public: FollowConfig();
+
+    /// \brief Destructor
+    public: virtual ~FollowConfig();
+
+    // Documentation inherited
+    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+        override;
+
+    /// \brief Set the follow offset, requested from the GUI.
+    /// \param[in] _x The follow offset distance in x
+    /// \param[in] _y The follow offset distance in y
+    /// \param[in] _z The follow offset distance in z
+    public slots: void SetFollowOffset(double _x,
+          double _y, double _z);
+
+    /// \brief Set the follow pgain, requested from the GUI.
+    /// \param[in] _p The follow offset distance in x
+    public slots: void SetFollowPGain(double _p);
+
+
+    // Documentation inherited
+    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
+
+    /// \internal
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<FollowConfigPrivate> dataPtr;
+  };
+}
+}
+}
+#endif

--- a/src/plugins/follow_config/FollowConfig.qml
+++ b/src/plugins/follow_config/FollowConfig.qml
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Rudis Laboratories LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Layouts 1.3
+import gz.gui 1.0
+
+ColumnLayout {
+  Layout.minimumWidth: 200
+  Layout.minimumHeight: 200
+  Layout.margins: 2
+  anchors.fill: parent
+  focus: true
+
+  // X camera follow distance
+  property double xFollowOffset: -5.0
+  // Y camera follow distance
+  property double yFollowOffset: 0.0
+  // Z camera follow distance
+  property double zFollowOffset: 3.0
+  // P Gain camera follow distance
+  property double pGainFollow: 0.01
+
+  GridLayout {
+    Layout.fillWidth: true
+    Layout.margins: 2
+    columns: 2
+  
+    // X follow offset distance
+    Label {
+      id: xFollowOffsetLabel
+      text: "Camera follow X (m)"
+      color: "dimgrey"
+    }
+    GzSpinBox {
+      id: xFollowOffsetField
+      Layout.fillWidth: true
+      value: xFollowOffset
+      maximumValue: 10.0
+      minimumValue: -10.0
+      decimals: 2
+      stepSize: 0.5
+      onEditingFinished:{
+        xFollowOffset = value
+        FollowConfig.SetFollowOffset(xFollowOffset, yFollowOffset, zFollowOffset)
+      }
+    }
+    // Y follow offset distance
+    Label {
+      id: yFollowOffsetLabel
+      text: "Camera follow Y (m)"
+      color: "dimgrey"
+    }
+    GzSpinBox {
+      id: yFollowOffsetField
+      Layout.fillWidth: true
+      value: yFollowOffset
+      maximumValue: 10.0
+      minimumValue: -10.0
+      decimals: 2
+      stepSize: 0.5
+      onEditingFinished:{
+        yFollowOffset = value
+        FollowConfig.SetFollowOffset(xFollowOffset, yFollowOffset, zFollowOffset)
+      }
+    }
+    // Z follow offset distance
+    Label {
+      id: zFollowOffsetLabel
+      text: "Camera follow Z (m)"
+      color: "dimgrey"
+    }
+    GzSpinBox {
+      id: zFollowOffsetField
+      Layout.fillWidth: true
+      value: zFollowOffset
+      maximumValue: 10.0
+      minimumValue: -10.0
+      decimals: 2
+      stepSize: 0.5
+      onEditingFinished:{
+        zFollowOffset = value
+        FollowConfig.SetFollowOffset(xFollowOffset, yFollowOffset, zFollowOffset)
+      }
+    }
+    // P Gain follow
+    Label {
+      id: pGainFollowLabel
+      text: "Camera follow P Gain"
+      color: "dimgrey"
+    }
+    GzSpinBox {
+      id: pGainFollowField
+      Layout.fillWidth: true
+      value: pGainFollow
+      maximumValue: 1.0
+      minimumValue: 0.001
+      decimals: 3
+      stepSize: 0.01
+      onEditingFinished:{
+        pGainFollow = value
+        FollowConfig.SetFollowPGain(pGainFollow)
+      }
+    }
+  }
+}

--- a/src/plugins/follow_config/FollowConfig.qrc
+++ b/src/plugins/follow_config/FollowConfig.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="FollowConfig/">
+  <file>FollowConfig.qml</file>
+</qresource>
+</RCC>

--- a/test/integration/camera_tracking.cc
+++ b/test/integration/camera_tracking.cc
@@ -186,6 +186,14 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   EXPECT_TRUE(result);
   EXPECT_TRUE(rep.data());
 
+  msgs::Double reqPGain;
+  reqPGain.set_data(1.0);
+  executed = node.Request("/gui/follow/pgain", reqPGain, timeout, rep,
+      result);
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(rep.data());
+
   // Many update loops to process many events
   maxSleep = 600;
   for (auto it : {150.0, 200.0})

--- a/test/integration/follow_config.cc
+++ b/test/integration/follow_config.cc
@@ -76,6 +76,9 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
 
   pluginStr =
     "<plugin filename=\"CameraTracking\">"
+      "<follow_target>track_me</follow_target>"
+      "<follow_offset>0.0 0.0 0.0</follow_offset>"
+      "<follow_pgain>1.0</follow_pgain>"
     "</plugin>";
 
   pluginDoc.Parse(pluginStr);
@@ -84,9 +87,6 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
 
   pluginStr =
     "<plugin filename=\"FollowConfig\">"
-      "<follow_target>track_me</follow_target>"
-      "<follow_offset>0.0 0.0 0.0</follow_offset>"
-      "<follow_pgain>1.0</follow_pgain>"
     "</plugin>";
 
   pluginDoc.Parse(pluginStr);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #514

## Summary
Now you can set the pgain of the follow camera when following objects. This is needed for extremely high speed objects.

https://user-images.githubusercontent.com/10233412/215242320-eaa9d430-e853-49c6-a0de-81a69dc6c258.mp4




## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
