### PR TITLE
Bump msgs and transport version in Harmonic

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,11 +1,11 @@
 libgz-cmake3-dev
 libgz-common5-dev
 libgz-math7-dev
-libgz-msgs9-dev
+libgz-msgs10-dev
 libgz-plugin2-dev
 libgz-rendering8-dev
 libgz-tools2-dev
-libgz-transport12-dev
+libgz-transport13-dev
 libgz-utils2-dev
 libprotobuf-dev
 libprotoc-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-transport
-gz_find_package(gz-transport12 REQUIRED)
-set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
+gz_find_package(gz-transport13 REQUIRED)
+set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-rendering
@@ -72,8 +72,8 @@ set(GZ_RENDERING_VER ${gz-rendering8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-msgs
-gz_find_package(gz-msgs9 REQUIRED)
-set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+gz_find_package(gz-msgs10 REQUIRED)
+set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
 
 # Find if command is available. This is used to enable tests.
 # Note that CLI files are installed regardless of whether the dependency is

--- a/examples/standalone/marker/CMakeLists.txt
+++ b/examples/standalone/marker/CMakeLists.txt
@@ -3,14 +3,14 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 project(gz-gui-marker)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  find_package(gz-transport12 QUIET REQUIRED OPTIONAL_COMPONENTS log)
-  set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
+  find_package(gz-transport13 QUIET REQUIRED OPTIONAL_COMPONENTS log)
+  set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
 
   find_package(gz-common5 REQUIRED)
   set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
-  find_package(gz-msgs9 REQUIRED)
-  set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+  find_package(gz-msgs10 REQUIRED)
+  set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
 
   add_executable(marker marker.cc)
   target_link_libraries(marker

--- a/examples/standalone/point_cloud/CMakeLists.txt
+++ b/examples/standalone/point_cloud/CMakeLists.txt
@@ -3,14 +3,14 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 project(gz-gui-point-cloud-example)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  find_package(gz-transport12 QUIET REQUIRED OPTIONAL_COMPONENTS log)
-  set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
+  find_package(gz-transport13 QUIET REQUIRED OPTIONAL_COMPONENTS log)
+  set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
 
   find_package(gz-common5 REQUIRED)
   set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
-  find_package(gz-msgs9 REQUIRED)
-  set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+  find_package(gz-msgs10 REQUIRED)
+  set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
 
   add_executable(point_cloud point_cloud.cc)
   target_link_libraries(point_cloud

--- a/examples/standalone/scene_provider/CMakeLists.txt
+++ b/examples/standalone/scene_provider/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 project(gz-gui-scene-provider)
 
-find_package(gz-msgs9 REQUIRED)
-find_package(gz-transport12 REQUIRED)
+find_package(gz-msgs10 REQUIRED)
+find_package(gz-transport13 REQUIRED)
 
 add_executable(scene_provider
   scene_provider.cc
 )
 target_link_libraries(scene_provider
-  gz-msgs9::core
-  gz-transport12::core
+  gz-msgs10::core
+  gz-transport13::core
 )


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

## Summary
Bumping to use the new msgs and transport versions in Harmonic, msgs10 and transport13

Part of https://github.com/gazebo-tooling/release-tools/issues/878

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

