### PR TITLE
Fix INTEGRATION_camera_tracking test

### DIFF
--- a/test/integration/camera_tracking.cc
+++ b/test/integration/camera_tracking.cc
@@ -189,7 +189,7 @@ TEST(MinimalSceneTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   EXPECT_TRUE(rep.data());
 
   // Many update loops to process many events
-  maxSleep = 300;
+  maxSleep = 600;
   for (auto it : {150.0, 200.0})
   {
     // Move target


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-gui/issues/516

## Summary

Fix camera tracking integration test. Test is failing because the camera was not able to reach the target pose in time. 
Increasing the time the test waits for the camera to get to the target pos fixes the issue for me locally. 

Debugging locally shows that the camera does indeed follow the tracked visual and slowly move towards the expected pos but just takes longer.  Possible reasons that the test started to fail only recently could be: Tests are run on less powerful machines or GUI updates are becoming more expensive, i.e. performance regression.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

