### PR TITLE
Switch to use mapboxgl map plugin in NavSat Map gui plugin

### DIFF
--- a/src/plugins/navsat_map/NavSatMap.qml
+++ b/src/plugins/navsat_map/NavSatMap.qml
@@ -91,7 +91,7 @@ Item {
 
   Plugin {
     id: mapPlugin
-    name: "osm"
+    name: "mapboxgl"
   }
 
   Map {


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-gui/issues/482

## Summary

Using the `osm` map plugin in the NavSat gui plugin seems to cause the window to freeze / crash. Switched to use `mapboxgl` instead.

Now it works for me:

![navsat_mapboxgl](https://user-images.githubusercontent.com/4000684/224160572-65a3da74-74bf-4732-9b9c-7a268317ab6b.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
