### PR TITLE
Add Camera FPS plugin

### DIFF
--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -114,6 +114,7 @@ function(ign_gui_add_plugin plugin_name)
 endfunction()
 
 # Plugins
+add_subdirectory(camera_fps)
 add_subdirectory(camera_tracking)
 add_subdirectory(grid_config)
 add_subdirectory(image_display)

--- a/src/plugins/camera_fps/CMakeLists.txt
+++ b/src/plugins/camera_fps/CMakeLists.txt
@@ -1,0 +1,9 @@
+ign_gui_add_plugin(CameraFps
+  SOURCES
+    CameraFps.cc
+  QT_HEADERS
+    CameraFps.hh
+  PUBLIC_LINK_LIBS
+   ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+)
+

--- a/src/plugins/camera_fps/CameraFps.cc
+++ b/src/plugins/camera_fps/CameraFps.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <list>
+#include <string>
+
+#include <gz/common/Console.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
+
+#include "ignition/gui/Application.hh"
+#include "ignition/gui/GuiEvents.hh"
+#include "ignition/gui/MainWindow.hh"
+
+#include "CameraFps.hh"
+
+/// \brief Private data class for CameraFps
+class ignition::gui::plugins::CameraFpsPrivate
+{
+  /// \brief Previous camera update time
+  public: std::optional<std::chrono::steady_clock::time_point>
+      prevCameraUpdateTime;
+
+  /// \brief A moving window of camera update times
+  public: std::list<std::chrono::duration<double>> cameraUpdateTimes;
+
+  /// \brief Sum of all update times in the moving window
+  public: std::chrono::duration<double> cameraUpdateTimeSum;
+
+  /// \brief Size of camera update time window
+  /// \todo(anyone) make this configurable
+  public: unsigned int cameraFPSWindowSize = 20u;
+
+  /// \brief Camera FPS string value
+  public: QString cameraFPSValue;
+};
+
+using namespace ignition;
+using namespace gui;
+using namespace plugins;
+
+/////////////////////////////////////////////////
+void CameraFps::OnRender()
+{
+  auto now = std::chrono::steady_clock::now();
+  if (!this->dataPtr->prevCameraUpdateTime.has_value())
+  {
+    this->dataPtr->prevCameraUpdateTime = now;
+    return;
+  }
+
+  const std::chrono::duration<double> dt =
+    std::chrono::steady_clock::now() - *this->dataPtr->prevCameraUpdateTime;
+  this->dataPtr->prevCameraUpdateTime = now;
+  this->dataPtr->cameraUpdateTimeSum += dt;
+  if (this->dataPtr->cameraUpdateTimes.size() >=
+      this->dataPtr->cameraFPSWindowSize)
+  {
+    auto first = this->dataPtr->cameraUpdateTimes.front();
+    this->dataPtr->cameraUpdateTimes.pop_front();
+    this->dataPtr->cameraUpdateTimeSum -= first;
+    double sum = this->dataPtr->cameraUpdateTimeSum.count();
+    double avg = sum /
+        static_cast<double>(this->dataPtr->cameraFPSWindowSize);
+    this->SetCameraFpsValue(QString::fromStdString(std::to_string(1.0/avg)));
+  }
+  this->dataPtr->cameraUpdateTimes.push_back(dt);
+}
+
+/////////////////////////////////////////////////
+CameraFps::CameraFps()
+  : Plugin(), dataPtr(new CameraFpsPrivate)
+{
+}
+
+/////////////////////////////////////////////////
+CameraFps::~CameraFps()
+{
+}
+
+/////////////////////////////////////////////////
+void CameraFps::LoadConfig(const tinyxml2::XMLElement *)
+{
+  if (this->title.empty())
+    this->title = "Camera FPS";
+
+  App()->findChild<MainWindow *>()->installEventFilter(this);
+}
+
+/////////////////////////////////////////////////
+bool CameraFps::eventFilter(QObject *_obj, QEvent *_event)
+{
+  if (_event->type() == events::Render::kType)
+  {
+    this->OnRender();
+  }
+  // Standard event processing
+  return QObject::eventFilter(_obj, _event);
+}
+
+/////////////////////////////////////////////////
+QString CameraFps::CameraFpsValue() const
+{
+  return this->dataPtr->cameraFPSValue;
+}
+
+/////////////////////////////////////////////////
+void CameraFps::SetCameraFpsValue(const QString &_value)
+{
+  this->dataPtr->cameraFPSValue = _value;
+  this->CameraFpsValueChanged();
+}
+
+// Register this plugin
+IGNITION_ADD_PLUGIN(ignition::gui::plugins::CameraFps,
+                    ignition::gui::Plugin)

--- a/src/plugins/camera_fps/CameraFps.hh
+++ b/src/plugins/camera_fps/CameraFps.hh
@@ -35,7 +35,7 @@ namespace plugins
   {
     Q_OBJECT
 
-    /// \brief Real time factor
+    /// \brief Camera frames per second
     Q_PROPERTY(
       QString cameraFPSValue
       READ CameraFpsValue

--- a/src/plugins/camera_fps/CameraFps.hh
+++ b/src/plugins/camera_fps/CameraFps.hh
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_GUI_PLUGINS_CAMERAFPS_HH_
+#define GZ_GUI_PLUGINS_CAMERAFPS_HH_
+
+#include <memory>
+
+#include "ignition/gui/Plugin.hh"
+
+namespace ignition
+{
+namespace gui
+{
+namespace plugins
+{
+  class CameraFpsPrivate;
+
+  /// \brief This plugin displays the GUI camera's Framerate Per Second (FPS)
+  class CameraFps : public Plugin
+  {
+    Q_OBJECT
+
+    /// \brief Real time factor
+    Q_PROPERTY(
+      QString cameraFPSValue
+      READ CameraFpsValue
+      WRITE SetCameraFpsValue
+      NOTIFY CameraFpsValueChanged
+    )
+
+    /// \brief Constructor
+    public: CameraFps();
+
+    /// \brief Destructor
+    public: virtual ~CameraFps();
+
+    // Documentation inherited
+    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+        override;
+
+    /// \brief Set the camera FPS value string
+    /// \param[in] _value Camera FPS value string
+    public: Q_INVOKABLE void SetCameraFpsValue(const QString &_value);
+
+    /// \brief Get the camera FPS value string
+    /// \return Camera FPS value string
+    public: Q_INVOKABLE QString CameraFpsValue() const;
+
+    /// \brief Notify that camera FPS value has changed
+    signals: void CameraFpsValueChanged();
+
+    /// \brief Perform rendering calls in the rendering thread.
+    private: void OnRender();
+
+    // Documentation inherited
+    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
+
+    /// \internal
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<CameraFpsPrivate> dataPtr;
+  };
+}
+}
+}
+#endif

--- a/src/plugins/camera_fps/CameraFps.qml
+++ b/src/plugins/camera_fps/CameraFps.qml
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+import QtQuick 2.9
+import QtQuick.Controls 2.1
+import QtQuick.Layouts 1.3
+
+Rectangle {
+  id: cameraFps
+  color: "transparent"
+  Layout.minimumWidth: 150
+  Layout.minimumHeight: 80
+
+
+  RowLayout {
+    id: cameraFpsLayout
+    anchors.fill: parent
+    anchors.margins: 10
+
+    Label {
+      ToolTip.text: qsTr("Camera FPS")
+      font.weight: Font.DemiBold
+      text: "FPS"
+    }
+
+    Label {
+      objectName: "cameraFps"
+      text: CameraFps.cameraFPSValue
+      Layout.alignment: Qt.AlignRight
+    }
+  }
+}

--- a/src/plugins/camera_fps/CameraFps.qml
+++ b/src/plugins/camera_fps/CameraFps.qml
@@ -25,7 +25,6 @@ Rectangle {
   Layout.minimumWidth: 150
   Layout.minimumHeight: 80
 
-
   RowLayout {
     id: cameraFpsLayout
     anchors.fill: parent

--- a/src/plugins/camera_fps/CameraFps.qrc
+++ b/src/plugins/camera_fps/CameraFps.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="CameraFps/">
+  <file>CameraFps.qml</file>
+</qresource>
+</RCC>


### PR DESCRIPTION
# 🎉 New feature


## Summary
Adds a simple camera FPS plugin to show the GUI camera's framerate

The background is made transparent so you can configure it to be floating on top of the 3d window, e.g.
![camera_fps](https://user-images.githubusercontent.com/4000684/225743659-8a87d500-cda2-4438-9431-436e197295a9.png)


Note: It's probably more accurate to put the logic for computing the FPS values inside the Minimal Scene plugin but I created a new Camera FPS plugin for modularity. In the Camera FPS plugin, technically it's measuring the rate at which render events are fired by the Minimal Scene plugin which happens after each GUI camera render update. I measured the difference between computing the FPS from inside the Minimal Scene plugin and also here in the Camera FPS plugin and found the difference to be < 1e-2 which is somewhat acceptable.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

