### PR TITLE
Add support for bayer images to get displayed in gazebo gui

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -184,6 +184,10 @@ void ImageDisplay::ProcessImage()
       common::Image::ConvertToRGBImage<uint8_t>(
           this->dataPtr->imageMsg.data().c_str(), width, height, output);
       break;
+    case msgs::PixelFormatType::BAYER_RGGB8:
+      common::Image::ConvertToRGBImage<uint8_t>(
+          this->dataPtr->imageMsg.data().c_str(), width, height, output);
+      break;
     default:
     {
       gzwarn << "Unsupported image type: "

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -188,6 +188,18 @@ void ImageDisplay::ProcessImage()
       common::Image::ConvertToRGBImage<uint8_t>(
           this->dataPtr->imageMsg.data().c_str(), width, height, output);
       break;
+    case msgs::PixelFormatType::BAYER_BGGR8:
+      common::Image::ConvertToRGBImage<uint8_t>(
+          this->dataPtr->imageMsg.data().c_str(), width, height, output);
+      break;
+    case msgs::PixelFormatType::BAYER_GBRG8:
+      common::Image::ConvertToRGBImage<uint8_t>(
+          this->dataPtr->imageMsg.data().c_str(), width, height, output);
+      break;
+    case msgs::PixelFormatType::BAYER_GRBG8:
+      common::Image::ConvertToRGBImage<uint8_t>(
+          this->dataPtr->imageMsg.data().c_str(), width, height, output);
+      break;
     default:
     {
       gzwarn << "Unsupported image type: "

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -185,17 +185,8 @@ void ImageDisplay::ProcessImage()
           this->dataPtr->imageMsg.data().c_str(), width, height, output);
       break;
     case msgs::PixelFormatType::BAYER_RGGB8:
-      common::Image::ConvertToRGBImage<uint8_t>(
-          this->dataPtr->imageMsg.data().c_str(), width, height, output);
-      break;
     case msgs::PixelFormatType::BAYER_BGGR8:
-      common::Image::ConvertToRGBImage<uint8_t>(
-          this->dataPtr->imageMsg.data().c_str(), width, height, output);
-      break;
     case msgs::PixelFormatType::BAYER_GBRG8:
-      common::Image::ConvertToRGBImage<uint8_t>(
-          this->dataPtr->imageMsg.data().c_str(), width, height, output);
-      break;
     case msgs::PixelFormatType::BAYER_GRBG8:
       common::Image::ConvertToRGBImage<uint8_t>(
           this->dataPtr->imageMsg.data().c_str(), width, height, output);


### PR DESCRIPTION
# 🎉 New feature

Closes [`gz-sensors` issue 299](https://github.com/gazebosim/gz-sensors/issues/299) 

## Sub-Tasks
-  [x] Support  simulation for `BAYER_RGGB8` with `OGRE`
-  [x] Extend the functionality to support all bayer types with `OGRE`
-  [x] Extend the functionality to support with `OGRE2`


## Summary and Related PRs
The functionality reads the user input and renders an RGB image, which is later converted into a single channel 8bit Bayer image using `ConvertRGBToBayer()` added to [`Utils.cc`](https://github.com/gazebosim/gz-rendering/blob/gz-rendering7/src/Utils.cc) inside `gz-rendering`.

* `gz-sensors` : Adds a switch case for `RGGB bayer format` inside `CameraSensor.cc` and passes the `R8G8B8` format to render the image.
* `gz-redering` : Adds `ConvertRGBToBayer()` to `Utils.cc`, modifies `OgreRenderTarget.cc` to call the conversion function, and handles image format conversion functions with `if-else` statements.
* `gz-gui` : Adds switch cases to display Bayer images in Gazebo GUI inside. It treats them as single-channel 8-bit images.
* `gz-common` : Modifies `Image::SetFromData` inside `Image.cc` to support saving of Bayer images. In order to save it It treats them as single-channel 8-bit images.

## Test it
In order to test this, one can modify `camera_sensor.sdf` inside `gz-sim` [here](https://github.com/gazebosim/gz-sim/blob/gz-sim7/examples/worlds/camera_sensor.sdf#L291). Would have just to replace the part with the following snippet.
```xml
<image>
   <width>320</width>
   <height>240</height>
   <format>BAYER_RGGB8</format>
</image>
<clip>
   <near>0.1</near>
   <far>100</far>
</clip>
<save enabled="true">
    <path>path to the folder</path>
</save>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
