### PR TITLE
Apply low-pass filter to RTF display

### DIFF
--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -58,7 +58,12 @@ namespace plugins
     /// \brief Holds iterations
     public: QString iterations;
 
+    /// \brief Time delayed version if simTime used for computing a low-pass
+    /// filtered RTF
     public: std::optional<double> simTimeDelayed;
+
+    /// \brief Time delayed version if realTime used for computing a low-pass
+    /// filtered RTF
     public: std::optional<double> realTimeDelayed;
   };
 }

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -57,6 +57,9 @@ namespace plugins
 
     /// \brief Holds iterations
     public: QString iterations;
+
+    public: std::optional<double> simTimeDelayed;
+    public: std::optional<double> realTimeDelayed;
   };
 }
 }
@@ -207,30 +210,65 @@ void WorldStats::ProcessMsg()
 {
   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
 
-  std::chrono::steady_clock::time_point timePoint;
+  std::chrono::steady_clock::time_point simTimePoint;
+  std::chrono::steady_clock::time_point realTimePoint;
 
   if (this->dataPtr->msg.has_sim_time())
   {
-    timePoint = math::secNsecToTimePoint(
+    simTimePoint = math::secNsecToTimePoint(
         this->dataPtr->msg.sim_time().sec(),
         this->dataPtr->msg.sim_time().nsec());
     this->SetSimTime(QString::fromStdString(
-      math::timePointToString(timePoint)));
+      math::timePointToString(simTimePoint)));
   }
 
   if (this->dataPtr->msg.has_real_time())
   {
-    timePoint = math::secNsecToTimePoint(
+    realTimePoint = math::secNsecToTimePoint(
         this->dataPtr->msg.real_time().sec(),
         this->dataPtr->msg.real_time().nsec());
     this->SetRealTime(QString::fromStdString(
-      math::timePointToString(timePoint)));
+      math::timePointToString(realTimePoint)));
   }
 
   {
-    // RTF as a percentage.
-    double rtf = this->dataPtr->msg.real_time_factor() * 100;
-    this->SetRealTimeFactor(QString::number(rtf, 'f', 2) + " %");
+    const double simTimeCount =
+        static_cast<double>(simTimePoint.time_since_epoch().count());
+    const double realTimeCount =
+        static_cast<double>(realTimePoint.time_since_epoch().count());
+
+    if (realTimeCount > 0)
+    {
+      constexpr double kAlpha = 0.9;
+      this->dataPtr->simTimeDelayed =
+        kAlpha * this->dataPtr->simTimeDelayed.value_or(simTimeCount) +
+        (1.0 - kAlpha) * simTimeCount;
+
+      this->dataPtr->realTimeDelayed =
+        kAlpha * this->dataPtr->realTimeDelayed.value_or(realTimeCount) +
+        (1.0 - kAlpha) * realTimeCount;
+
+      // Compute the average sim and real times.
+      const double realTimeFiltered =
+          realTimeCount - (*this->dataPtr->realTimeDelayed);
+      const double simTimeFiltered =
+          simTimeCount - (*this->dataPtr->simTimeDelayed);
+
+      // RTF, only compute this if the realTime count is greater than zero. The
+      // realtTime count could be zero if simulation was started paused.
+      if (realTimeFiltered > 0)
+      {
+        const double rtf =
+            math::precision(simTimeFiltered / realTimeFiltered, 4) * 100;
+        this->SetRealTimeFactor(QString::number(rtf, 'f', 2) + " %");
+      }
+    }
+    else
+    {
+      // RTF as a percentage.
+      double rtf = this->dataPtr->msg.real_time_factor() * 100;
+      this->SetRealTimeFactor(QString::number(rtf, 'f', 2) + " %");
+    }
   }
 
   {


### PR DESCRIPTION
# 🎉 New feature

Follow-up from https://github.com/gazebosim/gz-sim/pull/1942

## Summary
This adds a more aggressive low-pass filter than what was in gz-sim such that the RTF display is more stable and reflects the RTF of a longer window of time.

## Test it
Run `gz sim camera_sensor.sdf`. The RTF will display is much more stable than before. After a while, remove the image display and watch the RTF increase.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
