### PR TITLE
Disable deprecation messages about onFoo connections

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -99,6 +99,12 @@ Application::Application(int &_argc, char **_argv, const WindowType _type)
   this->setOrganizationDomain("gazebosim.org");
   this->setApplicationName("Gazebo GUI");
 
+  // Disable deprecation messages about onFoo connections since the new way of
+  // definining connections is only available as of Qt 5.12, which is not
+  // available in Ubuntu Focal
+  // TODO(azeey) Remove once Qt 5.12 is available in all supported platforms.
+  QLoggingCategory::setFilterRules("qt.qml.connections=false");
+
 #if __APPLE__
   // Use the Metal graphics API on macOS.
   gzdbg << "Qt using Metal graphics interface" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Alternative to https://github.com/gazebosim/gz-gui/pull/493. See https://github.com/gazebosim/gz-gui/pull/493/files#r982750363

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
