### PR TITLE
Fix tests by delaying get render engine calls 

### DIFF
--- a/test/integration/marker_manager.cc
+++ b/test/integration/marker_manager.cc
@@ -32,6 +32,7 @@
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "test_config.hh"  // NOLINT(build/include)
+#include "../helpers/TestHelper.hh"
 #include "gz/gui/Application.hh"
 #include "gz/gui/GuiEvents.hh"
 #include "gz/gui/MainWindow.hh"
@@ -142,18 +143,29 @@ TEST_F(MarkerManagerTestFixture,
   // Show, but don't exec, so we don't block
   window->QuickWindow()->show();
 
-  // Check scene
-  auto engine = rendering::engine("ogre2");
-  ASSERT_NE(nullptr, engine);
+  bool receivedRenderEvent{false};
+  auto testHelper = std::make_unique<TestHelper>();
+  testHelper->forwardEvent = [&](QEvent *_event)
+  {
+    if (_event->type() == events::Render::kType)
+    {
+      receivedRenderEvent = true;
+    }
+  };
 
   int sleep = 0;
   int maxSleep = 30;
-  while (0 == engine->SceneCount() && sleep < maxSleep)
+  while (!receivedRenderEvent && sleep < maxSleep)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     QCoreApplication::processEvents();
     sleep++;
   }
+  EXPECT_TRUE(receivedRenderEvent);
+
+  // Check scene
+  auto engine = rendering::engine("ogre2");
+  ASSERT_NE(nullptr, engine);
 
   EXPECT_EQ(1u, engine->SceneCount());
   scene = engine->SceneByName("scene");

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -122,10 +122,6 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
     }
   };
 
-  // Check scene
-  auto engine = rendering::engine("ogre2");
-  ASSERT_NE(nullptr, engine);
-
   int sleep = 0;
   int maxSleep = 30;
   while (!receivedRenderEvent && sleep < maxSleep)
@@ -136,6 +132,10 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   }
   EXPECT_TRUE(receivedPreRenderEvent);
   EXPECT_TRUE(receivedRenderEvent);
+
+  // Check scene
+  auto engine = rendering::engine("ogre2");
+  ASSERT_NE(nullptr, engine);
 
   EXPECT_EQ(1u, engine->SceneCount());
   auto scene = engine->SceneByName("banana");
@@ -172,4 +172,5 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
 
   win->QuickWindow()->close();
   engine->DestroyScene(scene);
+  EXPECT_TRUE(rendering::unloadEngine(engine->Name()));
 }

--- a/test/integration/transport_scene_manager.cc
+++ b/test/integration/transport_scene_manager.cc
@@ -154,10 +154,6 @@ TEST(TransportSceneManagerTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   // Show, but don't exec, so we don't block
   win->QuickWindow()->show();
 
-  // Get scene
-  auto engine = rendering::engine("ogre2");
-  ASSERT_NE(nullptr, engine);
-
   int sleep = 0;
   int maxSleep = 30;
   while (!sceneRequested && sleep < maxSleep)
@@ -168,6 +164,10 @@ TEST(TransportSceneManagerTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   }
   EXPECT_TRUE(sceneRequested);
   EXPECT_LT(sleep, maxSleep);
+
+  // Get scene
+  auto engine = rendering::engine("ogre2");
+  ASSERT_NE(nullptr, engine);
 
   auto scene = engine->SceneByName("banana");
   ASSERT_NE(nullptr, scene);
@@ -261,5 +261,6 @@ TEST(TransportSceneManagerTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
 
   win->QuickWindow()->close();
   engine->DestroyScene(scene);
+  EXPECT_TRUE(rendering::unloadEngine(engine->Name()));
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Targets #429

## Summary

Changes:
* moved `rendering::engine` calls to after the window had a chance to load the engine in tests. Otherwise the engine will be loaded in the main test thread and subsequent render calls will fail.
* reinstated calls to unload engine


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

