### PR TITLE
Fix data race issues in CameraTracking plugin

### DIFF
--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -251,14 +251,12 @@ bool CameraTrackingPrivate::OnFollow(const msgs::StringMsg &_msg,
 /////////////////////////////////////////////////
 void CameraTrackingPrivate::OnMoveToComplete()
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
   this->moveToTarget.clear();
 }
 
 /////////////////////////////////////////////////
 void CameraTrackingPrivate::OnMoveToPoseComplete()
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
   this->moveToPoseValue.reset();
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
There are three threads at work here: the main thread, the render thread, and the transport thread. The change is meant to synchronize all of these threads.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.