### PR TITLE
6.8.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui6 VERSION 6.7.0)
+project(ignition-gui6 VERSION 6.8.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,44 @@
 ## Gazebo GUI 6
 
+### Gazebo GUI 6.7.0 (2023-05-12)
+
+1. Add degree as an optional unit for rotation in GzPose.
+    * [Pull request #475](https://github.com/gazebosim/gz-gui/pull/475)
+
+1. Fix image display test.
+    * [Pull request #468](https://github.com/gazebosim/gz-gui/pull/468)
+
+1. Update cmd/CMakeLists to conform with all other gz libraries.
+    * [Pull request #478](https://github.com/gazebosim/gz-gui/pull/478)
+
+1. Add key publisher test.
+    * [Pull request #477](https://github.com/gazebosim/gz-gui/pull/477)
+
+1. Add pointer check in Application::RemovePlugin.
+    * [Pull request #501](https://github.com/gazebosim/gz-gui/pull/501)
+
+1. ign -> gz Migrate Ignition Headers : gz-gui.
+    * [Pull request #466](https://github.com/gazebosim/gz-gui/pull/466)
+
+1. Fix INTEGRATION_camera_tracking test.
+    * [Pull request #519](https://github.com/gazebosim/gz-gui/pull/519)
+
+1. Update maintainer email.
+    * [Pull request #521](https://github.com/gazebosim/gz-gui/pull/521)
+
+1. Add Camera FPS plugin.
+    * [Pull request #523](https://github.com/gazebosim/gz-gui/pull/523)
+
+1. Rename COPYING to LICENSE.
+    * [Pull request #525](https://github.com/gazebosim/gz-gui/pull/525)
+
+1. CI workflow: use checkout v3.
+    * [Pull request #526](https://github.com/gazebosim/gz-gui/pull/526)
+    * [Pull request #536](https://github.com/gazebosim/gz-gui/pull/536)
+
+1. Fix data race issues in CameraTracking plugin.
+    * [Pull request #537](https://github.com/gazebosim/gz-gui/pull/537)
+
 ### Gazebo GUI 6.7.0 (2022-12-02)
 
 1. Set View Camera controller from plugin configuration


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.8.0 release.

Comparison to 6.8.0:  https://github.com/gazebosim/gz-gui/compare/ignition-gui6_6.7.0...ign-gui6

Needed by https://github.com/gazebosim/gz-sim/pull/1989

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
