### PR TITLE
Fix TopicInfo deprecation warnings

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -265,7 +265,8 @@ void ImageDisplay::OnRefresh()
   for (auto topic : allTopics)
   {
     std::vector<transport::MessagePublisher> publishers;
-    this->dataPtr->node.TopicInfo(topic, publishers);
+    std::vector<transport::MessagePublisher> subscribers;
+    this->dataPtr->node.TopicInfo(topic, publishers, subscribers);
     for (auto pub : publishers)
     {
       if (pub.MsgTypeName() == "gz.msgs.Image")

--- a/src/plugins/navsat_map/NavSatMap.cc
+++ b/src/plugins/navsat_map/NavSatMap.cc
@@ -156,7 +156,8 @@ void NavSatMap::OnRefresh()
   for (auto topic : allTopics)
   {
     std::vector<transport::MessagePublisher> publishers;
-    this->dataPtr->node.TopicInfo(topic, publishers);
+    std::vector<transport::MessagePublisher> subscribers;
+    this->dataPtr->node.TopicInfo(topic, publishers, subscribers);
     for (auto pub : publishers)
     {
       if (pub.MsgTypeName() == "gz.msgs.NavSat")

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -236,7 +236,8 @@ void PointCloud::OnRefresh()
   for (auto topic : allTopics)
   {
     std::vector<gz::transport::MessagePublisher> publishers;
-    this->dataPtr->node.TopicInfo(topic, publishers);
+    std::vector<gz::transport::MessagePublisher> subscribers;
+    this->dataPtr->node.TopicInfo(topic, publishers, subscribers);
     for (auto pub : publishers)
     {
       if (pub.MsgTypeName() == "gz.msgs.PointCloudPacked")

--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -199,9 +199,10 @@ void TopicViewerPrivate::CreateModel()
 
   for (unsigned int i = 0; i < topics.size(); ++i)
   {
-    std::vector<transport::MessagePublisher> infoMsgs;
-    this->node.TopicInfo(topics[i], infoMsgs);
-    std::string msgType = infoMsgs[0].MsgTypeName();
+    std::vector<transport::MessagePublisher> publishers;
+    std::vector<transport::MessagePublisher> subscribers;
+    this->node.TopicInfo(topics[i], publishers, subscribers);
+    std::string msgType = publishers[0].MsgTypeName();
     this->AddTopic(topics[i], msgType);
   }
 }
@@ -384,9 +385,10 @@ void TopicViewer::UpdateModel()
   for (unsigned int i = 0; i < topics.size(); ++i)
   {
     // get the msg type
-    std::vector<transport::MessagePublisher> infoMsgs;
-    this->dataPtr->node.TopicInfo(topics[i], infoMsgs);
-    std::string msgType = infoMsgs[0].MsgTypeName();
+    std::vector<transport::MessagePublisher> publishers;
+    std::vector<transport::MessagePublisher> subscribers;
+    this->dataPtr->node.TopicInfo(topics[i], publishers, subscribers);
+    std::string msgType = publishers[0].MsgTypeName();
 
     // skip the matched topics
     if (this->dataPtr->currentTopics.count(topics[i]) &&


### PR DESCRIPTION


# 🦟 Bug fix

A new `TopicInfo` function with an extra arg was added in https://github.com/gazebosim/gz-transport/pull/384 and the existing one is now deprecated. This PR switches to use the new overloaded `TopicInfo` function.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

