### PR TITLE
Fix issue in TopicViewer

### DIFF
--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -388,11 +388,19 @@ void TopicViewer::UpdateModel()
     std::vector<transport::MessagePublisher> publishers;
     std::vector<transport::MessagePublisher> subscribers;
     this->dataPtr->node.TopicInfo(topics[i], publishers, subscribers);
+
+    if (publishers.empty())
+      continue;
+
+    // ToDo: Go over all the publishers and also consider subscribers.
+    // Review the way we're using "topicsToRemove" as the logic doesn't look
+    // very clear to me.
+
     std::string msgType = publishers[0].MsgTypeName();
 
     // skip the matched topics
     if (this->dataPtr->currentTopics.count(topics[i]) &&
-            this->dataPtr->currentTopics[topics[i]] == msgType)
+        this->dataPtr->currentTopics[topics[i]] == msgType)
     {
       topicsToRemove.erase(topics[i]);
       continue;
@@ -413,7 +421,7 @@ void TopicViewer::UpdateModel()
       auto child = root->child(i);
 
       if (child->data(NAME_ROLE).toString().toStdString() == topic.first &&
-              child->data(TYPE_ROLE).toString().toStdString() == topic.second)
+          child->data(TYPE_ROLE).toString().toStdString() == topic.second)
       {
         // remove from model
         root->removeRow(i);


### PR DESCRIPTION
# 🦟 Bug fix

See [#430 ](https://github.com/gazebosim/gz-transport/issues/430)

## Summary

This patch fixes a crash running the `TopicViewer` plugin. The code was assuming that all topics reported after calling `TopicList()` have publishers. This is no longer the case as we can also report subscribers.

See [#430 ](https://github.com/gazebosim/gz-transport/issues/430)to reproduce the issue/fix with the Gazebo `Topic Viewer` plugin.
 
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
