### PR TITLE
Changes ignition for gz in tutorial commands

### DIFF
--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -108,7 +108,7 @@ Build and install as follows:
   ```
   brew install --only-dependencies gz-gui<#>
   ```
-  Be sure to replace `<#>` with a number value, such as 5 or 6, depending on
+  Be sure to replace `<#>` with a number value, such as 7 or 8, depending on
   which version you need.
 
 3. Configure and build

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -15,6 +15,8 @@ The source install instructions should be used if you need the very latest
 software improvements, if you need to modify the code, or if you plan to make a
 contribution.
 
+**Note:** If the version is 6 or downwards replace `gz-gui<#>` for `ign-gui<#>` in the command line. For more information take a look [here](https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).
+
 ## Binary Install
 
 ### Ubuntu
@@ -102,7 +104,6 @@ Build and install as follows:
   ```
   Be sure to replace `<#>` with a number value, such as 7 or 8, depending on
   which version you need.
-  **Note:** If the version is 6 or downwards replace `gz-gui<#>` for `ign-gui<#>` in the command line. For more information take a look [here](https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).
 
 2. Install dependencies
   ```

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -98,14 +98,14 @@ Build and install as follows:
 
 1. Clone the repository
   ```
-  git clone https://github.com/gazebosim/gz-gui -b ign-gui<#>
+  git clone https://github.com/gazebosim/gz-gui -b gz-gui<#>
   ```
   Be sure to replace `<#>` with a number value, such as 5 or 6, depending on
   which version you need.
 
 2. Install dependencies
   ```
-  brew install --only-dependencies ignition-gui<#>
+  brew install --only-dependencies gz-gui<#>
   ```
   Be sure to replace `<#>` with a number value, such as 5 or 6, depending on
   which version you need.

--- a/tutorials/01_install.md
+++ b/tutorials/01_install.md
@@ -100,8 +100,9 @@ Build and install as follows:
   ```
   git clone https://github.com/gazebosim/gz-gui -b gz-gui<#>
   ```
-  Be sure to replace `<#>` with a number value, such as 5 or 6, depending on
+  Be sure to replace `<#>` with a number value, such as 7 or 8, depending on
   which version you need.
+  **Note:** If the version is 6 or downwards replace `gz-gui<#>` for `ign-gui<#>` in the command line. For more information take a look [here](https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).
 
 2. Install dependencies
   ```


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/564

## Summary
Changes the use of `ignition` for `gz` in tutorial commands.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.