### PR TITLE
Add plugins namespace

### DIFF
--- a/include/gz/gui/Plugin.hh
+++ b/include/gz/gui/Plugin.hh
@@ -35,6 +35,9 @@ namespace gz
 {
   namespace gui
   {
+    /// \brief Namespace for all plugins
+    namespace plugins {}
+
     class PluginPrivate;
 
     /// \brief Base class for Gazebo GUI plugins.


### PR DESCRIPTION
# 🦟 Bug fix

Add namespace so `gz::gui::plugins` can be used as a `\ref` link in gz-sim Doxygen tutorials.

## Summary

Per https://github.com/gazebosim/gz-sim/pull/2107#discussion_r1326428623

Braces same line or breakline - I followed the format here
https://github.com/gazebosim/gz-sim/blob/9d79b629c9e0fed1c8635e30f06b2c61462f32d8/include/gz/sim/System.hh#L40

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.