### PR TITLE
Changes SpinBox for a TextField

### DIFF
--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -23,20 +23,24 @@ Item {
   property double maximumValue : 100
   property double stepSize : 0
   property double decimals : 0
-  property real value : 0
-  signal onEditingFinished()
+  property double value : 0
+  signal editingFinished
+  
+  onEditingFinished: {
+    value = parseFloat(numberField.text)
+  }
   
   TextField {
     id: numberField
     placeholderText: "0.0"
-    validator: DoubleValidator{bottom: minimumValue;
-                               top: maximumValue;
-                               decimals: decimals;
+    validator: DoubleValidator{bottom: parent.minimumValue;
+                               top: parent.maximumValue;
+                               decimals: parent.decimals;
                                notation: DoubleValidator.StandardNotation;
                               }
     onEditingFinished: {
-          parent.value = parseFloat(text)
-    } 
+      parent.editingFinished()
+    }
     style: TextFieldStyle{
       background: Rectangle {
         implicitWidth: 70

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -16,7 +16,6 @@
 */
 import QtQuick 2.9
 import QtQuick.Controls 2.15
-import QtQuick.Controls.Styles 2.15
 
 Item {
   id: gzSpinBoxItem
@@ -33,7 +32,8 @@ Item {
   
   TextField {
     id: numberField
-    placeholderText: "0.0"
+    placeholderText: gzSpinBoxItem.value
+    horizontalAlignment: TextInput.AlignHCenter
     validator: DoubleValidator{bottom: gzSpinBoxItem.minimumValue;
                                top: gzSpinBoxItem.maximumValue;
                                decimals: gzSpinBoxItem.decimals;

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -15,8 +15,8 @@
  *
 */
 import QtQuick 2.9
-import QtQuick.Controls 1.4
-import QtQuick.Controls.Styles 1.4
+import QtQuick.Controls 2.15
+import QtQuick.Controls.Styles 2.15
 
 Item {
   id: gzSpinBoxItem
@@ -40,14 +40,13 @@ Item {
                                notation: DoubleValidator.StandardNotation;
                               }
     onEditingFinished: {
-      gzSpinBoxItem.editingFinished()
+      parent.editingFinished()
     }
-    style: TextFieldStyle{
-      background: Rectangle {
-        implicitWidth: 70
-        implicitHeight: 40
-        border.color: "gray"
-      }
+    
+    background: Rectangle {
+      implicitWidth: 70
+      implicitHeight: 40
+      border.color: "gray"
     }
   }
 }

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.15
 
-Item {
-  id: gzSpinBoxItem
+Control {
+  id: spinBoxItem
   property real minimumValue : 0
   property real maximumValue : 100
   property real stepSize : 0
@@ -26,23 +26,21 @@ Item {
   property real value : 0
   signal editingFinished
   
-  onEditingFinished: {
-    value = parseFloat(numberField.text)
-  }
-  
   TextField {
     id: numberField
-    placeholderText: gzSpinBoxItem.value
+    placeholderText: spinBoxItem.value
     horizontalAlignment: TextInput.AlignHCenter
-    validator: DoubleValidator{bottom: gzSpinBoxItem.minimumValue;
-                               top: gzSpinBoxItem.maximumValue;
-                               decimals: gzSpinBoxItem.decimals;
+    activeFocusOnPress: spinBoxItem.activeFocusOnPress
+    enabled: false // The TextField is disabled for the moment due to a not desired behavior.
+    validator: DoubleValidator{bottom: spinBoxItem.minimumValue;
+                               top: spinBoxItem.maximumValue;
+                               decimals: spinBoxItem.decimals;
                                notation: DoubleValidator.StandardNotation;
                               }
     onEditingFinished: {
-      parent.editingFinished()
+      spinBoxItem.value = parseFloat(text)
+      spinBoxItem.editingFinished()
     }
-    
     background: Rectangle {
       implicitWidth: 70
       implicitHeight: 40

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -19,11 +19,12 @@ import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 
 Item {
-  property double minimumValue : 0
-  property double maximumValue : 100
-  property double stepSize : 0
-  property double decimals : 0
-  property double value : 0
+  id: gzSpinBoxItem
+  property real minimumValue : 0
+  property real maximumValue : 100
+  property real stepSize : 0
+  property int decimals : 0
+  property real value : 0
   signal editingFinished
   
   onEditingFinished: {
@@ -33,13 +34,13 @@ Item {
   TextField {
     id: numberField
     placeholderText: "0.0"
-    validator: DoubleValidator{bottom: parent.minimumValue;
-                               top: parent.maximumValue;
-                               decimals: parent.decimals;
+    validator: DoubleValidator{bottom: gzSpinBoxItem.minimumValue;
+                               top: gzSpinBoxItem.maximumValue;
+                               decimals: gzSpinBoxItem.decimals;
                                notation: DoubleValidator.StandardNotation;
                               }
     onEditingFinished: {
-      parent.editingFinished()
+      gzSpinBoxItem.editingFinished()
     }
     style: TextFieldStyle{
       background: Rectangle {

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -18,12 +18,31 @@ import QtQuick 2.9
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 
-SpinBox {
-  style: SpinBoxStyle{
-    background: Rectangle {
-      implicitWidth: 70
-      implicitHeight: 40
-      border.color: "gray"
+Item {
+  property double minimumValue : 0
+  property double maximumValue : 100
+  property double stepSize : 0
+  property double decimals : 0
+  property real value : 0
+  signal onEditingFinished()
+  
+  TextField {
+    id: numberField
+    placeholderText: "0.0"
+    validator: DoubleValidator{bottom: minimumValue;
+                               top: maximumValue;
+                               decimals: decimals;
+                               notation: DoubleValidator.StandardNotation;
+                              }
+    onEditingFinished: {
+          parent.value = parseFloat(text)
+    } 
+    style: TextFieldStyle{
+      background: Rectangle {
+        implicitWidth: 70
+        implicitHeight: 40
+        border.color: "gray"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #542 

## Summary
Changes the implementation of GzSpinBox from a SpinBox to a TextField for MacOS.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.