### PR TITLE
Fix crash when starting Topic Viewer

### DIFF
--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -202,8 +202,11 @@ void TopicViewerPrivate::CreateModel()
     std::vector<transport::MessagePublisher> publishers;
     std::vector<transport::MessagePublisher> subscribers;
     this->node.TopicInfo(topics[i], publishers, subscribers);
-    std::string msgType = publishers[0].MsgTypeName();
-    this->AddTopic(topics[i], msgType);
+    if (!publishers.empty())
+    {
+      std::string msgType = publishers[0].MsgTypeName();
+      this->AddTopic(topics[i], msgType);
+    }
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Starting the Topic Viewer in gz-sim causes a crash for me. The crash only seems to happen in one of my machines, so it might not be easy to reproduce. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

