### PR TITLE
Use fully-qualified message names to avoid deprecation warning

### DIFF
--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -266,7 +266,7 @@ void TopicViewerPrivate::AddField(QStandardItem *_parentItem,
     auto messageType = msgField->message_type();
 
     if (messageType)
-      this->AddField(msgItem, msgField->name(), messageType->name());
+      this->AddField(msgItem, msgField->name(), messageType->full_name());
 
     else
     {


### PR DESCRIPTION
gz-msgs now expects the factory to get fully qualified message names, and only provides the short name functionality with deprecation warnings.

This avoids the deprecation warnings, and should make message population more robust with 3rd-party messages.