### PR TITLE
Tidy namespaces

### DIFF
--- a/include/gz/gui/Application.hh
+++ b/include/gz/gui/Application.hh
@@ -37,191 +37,188 @@ namespace tinyxml2
   class XMLElement;
 }
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    class ApplicationPrivate;
-    class Dialog;
-    class MainWindow;
-    class Plugin;
+class ApplicationPrivate;
+class Dialog;
+class MainWindow;
+class Plugin;
 
-    /// \brief Type of window which the application will display
-    enum class WindowType : int
-    {
-      /// \brief A main window, which may contain top-level menus and multiple
-      /// plugins
-      kMainWindow = 0,
+/// \brief Type of window which the application will display
+enum class WindowType : int
+{
+  /// \brief A main window, which may contain top-level menus and multiple
+  /// plugins
+  kMainWindow = 0,
 
-      /// \brief One independent dialog per plugin. Also useful to open a
-      /// startup dialog before the main window.
-      kDialog = 1
-    };
+  /// \brief One independent dialog per plugin. Also useful to open a
+  /// startup dialog before the main window.
+  kDialog = 1
+};
 
-    /// \brief A Gazebo GUI application loads a QML engine and
-    /// provides an API to load plugins and configuration files. The application
-    /// supports either running a single main window or several plugins as
-    /// standalone dialogs.
-    class GZ_GUI_VISIBLE Application : public QApplication
-    {
-      Q_OBJECT
+/// \brief A Gazebo GUI application loads a QML engine and
+/// provides an API to load plugins and configuration files. The application
+/// supports either running a single main window or several plugins as
+/// standalone dialogs.
+class GZ_GUI_VISIBLE Application : public QApplication
+{
+  Q_OBJECT
 
-      /// \brief Constructor.
-      /// \param[in] _argc Argument count.
-      /// \param[in] _argv Argument values.
-      /// \param[in] _type Window type, by default it's a main window.
-      /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
-      /// option
-      public: Application(int &_argc, char **_argv,
-          const WindowType _type = WindowType::kMainWindow,
-          const char *_renderEngineGuiApiBackend = nullptr);
+  /// \brief Constructor.
+  /// \param[in] _argc Argument count.
+  /// \param[in] _argv Argument values.
+  /// \param[in] _type Window type, by default it's a main window.
+  /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
+  /// option
+  public: Application(int &_argc, char **_argv,
+      const WindowType _type = WindowType::kMainWindow,
+      const char *_renderEngineGuiApiBackend = nullptr);
 
-      /// \brief Destructor
-      public: virtual ~Application();
+  /// \brief Destructor
+  public: virtual ~Application();
 
-      /// \brief Get the QML engine
-      /// \return Pointer to QML engine
-      public: QQmlApplicationEngine *Engine() const;
+  /// \brief Get the QML engine
+  /// \return Pointer to QML engine
+  public: QQmlApplicationEngine *Engine() const;
 
-      /// \brief Load a plugin from a file name. The plugin file must be in the
-      /// path.
-      /// If a window has been initialized, the plugin is added to the window.
-      /// Otherwise, the plugin is stored and can be later added to a window or
-      /// dialog.
-      /// \param[in] _filename Plugin filename.
-      /// \param[in] _pluginElem Element containing plugin configuration
-      /// \return True if successful
-      /// \sa LoadConfig
-      /// \sa AddPluginsToWindow
-      public: bool LoadPlugin(const std::string &_filename,
-          const tinyxml2::XMLElement *_pluginElem = nullptr);
+  /// \brief Load a plugin from a file name. The plugin file must be in the
+  /// path.
+  /// If a window has been initialized, the plugin is added to the window.
+  /// Otherwise, the plugin is stored and can be later added to a window or
+  /// dialog.
+  /// \param[in] _filename Plugin filename.
+  /// \param[in] _pluginElem Element containing plugin configuration
+  /// \return True if successful
+  /// \sa LoadConfig
+  /// \sa AddPluginsToWindow
+  public: bool LoadPlugin(const std::string &_filename,
+      const tinyxml2::XMLElement *_pluginElem = nullptr);
 
-      /// \brief Load a configuration file, which includes window configurations
-      /// and plugins. This function doesn't instantiate the plugins, it just
-      /// keeps them in memory and they can be applied later by either
-      /// instantiating a window or several dialogs.
-      /// \param[in] _path Full path to configuration file.
-      /// \return True if successful
-      /// \sa InitializeMainWindow
-      /// \sa InitializeDialogs
-      public: bool LoadConfig(const std::string &_path);
+  /// \brief Load a configuration file, which includes window configurations
+  /// and plugins. This function doesn't instantiate the plugins, it just
+  /// keeps them in memory and they can be applied later by either
+  /// instantiating a window or several dialogs.
+  /// \param[in] _path Full path to configuration file.
+  /// \return True if successful
+  /// \sa InitializeMainWindow
+  /// \sa InitializeDialogs
+  public: bool LoadConfig(const std::string &_path);
 
-      /// \brief Load the configuration from the default config file.
-      /// \return True if successful
-      /// \sa SetDefaultConfigPath
-      /// \sa DefaultConfigPath
-      /// \sa LoadConfig
-      public: bool LoadDefaultConfig();
+  /// \brief Load the configuration from the default config file.
+  /// \return True if successful
+  /// \sa SetDefaultConfigPath
+  /// \sa DefaultConfigPath
+  /// \sa LoadConfig
+  public: bool LoadDefaultConfig();
 
-      /// \brief Specifies the location of the default configuration file.
-      /// This is the file that stores the user settings when pressing
-      /// "Save configuration".
-      /// \param[in] _path The default configuration full path including
-      /// filename.
-      /// \sa LoadDefaultConfig
-      /// \sa defaultConfigPath
-      public: void SetDefaultConfigPath(const std::string &_path);
+  /// \brief Specifies the location of the default configuration file.
+  /// This is the file that stores the user settings when pressing
+  /// "Save configuration".
+  /// \param[in] _path The default configuration full path including
+  /// filename.
+  /// \sa LoadDefaultConfig
+  /// \sa defaultConfigPath
+  public: void SetDefaultConfigPath(const std::string &_path);
 
-      /// \brief Get the location of the default configuration file.
-      /// \return The default configuration path.
-      /// \sa LoadDefaultConfig
-      /// \sa SetDefaultConfigPath
-      public: std::string DefaultConfigPath();
+  /// \brief Get the location of the default configuration file.
+  /// \return The default configuration path.
+  /// \sa LoadDefaultConfig
+  /// \sa SetDefaultConfigPath
+  public: std::string DefaultConfigPath();
 
-      /// \brief Set the environment variable which defines the paths to
-      /// look for plugins.
-      /// \param[in] _env Name of environment variable.
-      public: void SetPluginPathEnv(const std::string &_env);
+  /// \brief Set the environment variable which defines the paths to
+  /// look for plugins.
+  /// \param[in] _env Name of environment variable.
+  public: void SetPluginPathEnv(const std::string &_env);
 
-      /// \brief Add an path to look for plugins.
-      /// \param[in] _path Full path.
-      public: void AddPluginPath(const std::string &_path);
+  /// \brief Add an path to look for plugins.
+  /// \param[in] _path Full path.
+  public: void AddPluginPath(const std::string &_path);
 
-      /// \brief Get the list of available plugins, organized by path. The
-      /// paths are given in the following order:
-      ///
-      /// 1. Paths given by the environment variable
-      /// 2. Paths added by calling addPluginPath
-      /// 3. Path ~/.gz/gui/plugins
-      /// 4. The path where Gazebo GUI plugins are installed
-      ///
-      /// \return A vector of pairs, where each pair contains:
-      /// * A path
-      /// * A vector of plugins in that path
-      public: std::vector<std::pair<std::string, std::vector<std::string>>>
-          PluginList();
+  /// \brief Get the list of available plugins, organized by path. The
+  /// paths are given in the following order:
+  ///
+  /// 1. Paths given by the environment variable
+  /// 2. Paths added by calling addPluginPath
+  /// 3. Path ~/.gz/gui/plugins
+  /// 4. The path where Gazebo GUI plugins are installed
+  ///
+  /// \return A vector of pairs, where each pair contains:
+  /// * A path
+  /// * A vector of plugins in that path
+  public: std::vector<std::pair<std::string, std::vector<std::string>>>
+      PluginList();
 
-      /// \brief Remove plugin by name. The plugin is removed from the
-      /// application and its shared library unloaded if this was its last
-      /// instance.
-      /// \param[in] _pluginName Plugn instance's unique name. This is the
-      /// plugin card's object name.
-      /// \return True if successful
-      public: bool RemovePlugin(const std::string &_pluginName);
+  /// \brief Remove plugin by name. The plugin is removed from the
+  /// application and its shared library unloaded if this was its last
+  /// instance.
+  /// \param[in] _pluginName Plugn instance's unique name. This is the
+  /// plugin card's object name.
+  /// \return True if successful
+  public: bool RemovePlugin(const std::string &_pluginName);
 
-      /// \brief Get a plugin by its unique name.
-      /// \param[in] _pluginName Plugn instance's unique name. This is the
-      /// plugin card's object name.
-      /// \return Pointer to plugin object, null if not found.
-      public: std::shared_ptr<Plugin> PluginByName(
-          const std::string &_pluginName) const;
+  /// \brief Get a plugin by its unique name.
+  /// \param[in] _pluginName Plugn instance's unique name. This is the
+  /// plugin card's object name.
+  /// \return Pointer to plugin object, null if not found.
+  public: std::shared_ptr<Plugin> PluginByName(
+      const std::string &_pluginName) const;
 
-      /// \brief Notify that a plugin has been added.
-      /// \param[in] _objectName Plugin's object name.
-      signals: void PluginAdded(const QString &_objectName);
+  /// \brief Notify that a plugin has been added.
+  /// \param[in] _objectName Plugin's object name.
+  signals: void PluginAdded(const QString &_objectName);
 
-      /// \brief Callback when user requests to close a plugin
-      public slots: void OnPluginClose();
+  /// \brief Callback when user requests to close a plugin
+  public slots: void OnPluginClose();
 
-      /// \brief Create a main window. Just calls InitializeMainWindow.
-      /// \return True if successful
-      /// \sa InitializeMainWindow
-      public: bool CreateMainWindow();
+  /// \brief Create a main window. Just calls InitializeMainWindow.
+  /// \return True if successful
+  /// \sa InitializeMainWindow
+  public: bool CreateMainWindow();
 
-      /// \brief Create a main window, populate with previously loaded plugins
-      /// and apply previously loaded configuration.
-      /// An empty window will be created if no plugins have been loaded.
-      /// \return True if successful
-      /// \sa LoadConfig
-      /// \sa LoadPlugin
-      private: bool InitializeMainWindow();
+  /// \brief Create a main window, populate with previously loaded plugins
+  /// and apply previously loaded configuration.
+  /// An empty window will be created if no plugins have been loaded.
+  /// \return True if successful
+  /// \sa LoadConfig
+  /// \sa LoadPlugin
+  private: bool InitializeMainWindow();
 
-      /// \brief Create individual dialogs for all previously loaded plugins.
-      /// This has no effect if no plugins have been loaded.
-      /// \return True if successful
-      /// \sa LoadConfig
-      /// \sa LoadPlugin
-      private: bool InitializeDialogs();
+  /// \brief Create individual dialogs for all previously loaded plugins.
+  /// This has no effect if no plugins have been loaded.
+  /// \return True if successful
+  /// \sa LoadConfig
+  /// \sa LoadPlugin
+  private: bool InitializeDialogs();
 
-      /// \brief Remove plugin by pointer.
-      /// \param[in] _plugin Shared pointer to plugin
-      private: void RemovePlugin(std::shared_ptr<Plugin> _plugin);
+  /// \brief Remove plugin by pointer.
+  /// \param[in] _plugin Shared pointer to plugin
+  private: void RemovePlugin(std::shared_ptr<Plugin> _plugin);
 
-      /// \brief Add previously loaded plugins to the main window.
-      /// \return True if successful. Will fail if the window hasn't been
-      /// created yet.
-      /// \sa LoadPlugin
-      private: bool AddPluginsToWindow();
+  /// \brief Add previously loaded plugins to the main window.
+  /// \return True if successful. Will fail if the window hasn't been
+  /// created yet.
+  /// \sa LoadPlugin
+  private: bool AddPluginsToWindow();
 
-      /// \brief Apply previously loaded config to the main window.
-      /// \return True if successful, will fail if there's no main window
-      /// initialized.
-      private: bool ApplyConfig();
+  /// \brief Apply previously loaded config to the main window.
+  /// \return True if successful, will fail if there's no main window
+  /// initialized.
+  private: bool ApplyConfig();
 
-      /// \internal
-      /// \brief Private data pointer
-      private: std::unique_ptr<ApplicationPrivate> dataPtr;
-    };
+  /// \internal
+  /// \brief Private data pointer
+  private: std::unique_ptr<ApplicationPrivate> dataPtr;
+};
 
-    /// \brief Get current running application, this is a cast of qGuiApp.
-    /// \return Pointer to running application, or nullptr if none is running.
-    GZ_GUI_VISIBLE
-    Application *App();
-  }
-}
+/// \brief Get current running application, this is a cast of qGuiApp.
+/// \return Pointer to running application, or nullptr if none is running.
+GZ_GUI_VISIBLE
+Application *App();
+}  // namespace gz::gui
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#endif
+#endif  // GZ_GUI_APPLICATION_HH_

--- a/include/gz/gui/Conversions.hh
+++ b/include/gz/gui/Conversions.hh
@@ -27,74 +27,71 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Export.hh"
 
-namespace gz
+namespace gz::common
 {
-  namespace common
-  {
-    class MouseEvent;
-  }
+class MouseEvent;
+}  // namespace gz::common
 
-  namespace gui
-  {
-    /// \brief Return the equivalent Qt color
-    /// \param[in] _color Gazebo color to convert
-    /// \return Qt color value
-    GZ_GUI_VISIBLE
-    QColor convert(const math::Color &_color);
+namespace gz::gui
+{
+/// \brief Return the equivalent Qt color
+/// \param[in] _color Gazebo color to convert
+/// \return Qt color value
+GZ_GUI_VISIBLE
+QColor convert(const math::Color &_color);
 
-    /// \brief Return the equivalent Gazebo color
-    /// \param[in] _color Qt color to convert
-    /// \return Gazebo color value
-    GZ_GUI_VISIBLE
-    math::Color convert(const QColor &_color);
+/// \brief Return the equivalent Gazebo color
+/// \param[in] _color Qt color to convert
+/// \return Gazebo color value
+GZ_GUI_VISIBLE
+math::Color convert(const QColor &_color);
 
-    /// \brief Return the equivalent QPointF.
-    /// \param[in] _pt Gazebo vector to convert.
-    /// \return QPointF.
-    GZ_GUI_VISIBLE
-    QPointF convert(const math::Vector2d &_pt);
+/// \brief Return the equivalent QPointF.
+/// \param[in] _pt Gazebo vector to convert.
+/// \return QPointF.
+GZ_GUI_VISIBLE
+QPointF convert(const math::Vector2d &_pt);
 
-    /// \brief Return the equivalent Gazebo vector.
-    /// \param[in] _pt QPointF to convert
-    /// \return Gazebo Vector2d.
-    GZ_GUI_VISIBLE
-    math::Vector2d convert(const QPointF &_pt);
+/// \brief Return the equivalent Gazebo vector.
+/// \param[in] _pt QPointF to convert
+/// \return Gazebo Vector2d.
+GZ_GUI_VISIBLE
+math::Vector2d convert(const QPointF &_pt);
 
-    /// \brief Return the equivalent Qt vector 3d.
-    /// \param[in] _vec Gazebo vector 3d to convert.
-    /// \return Qt vector 3d value.
-    GZ_GUI_VISIBLE
-    QVector3D convert(const math::Vector3d &_vec);
+/// \brief Return the equivalent Qt vector 3d.
+/// \param[in] _vec Gazebo vector 3d to convert.
+/// \return Qt vector 3d value.
+GZ_GUI_VISIBLE
+QVector3D convert(const math::Vector3d &_vec);
 
-    /// \brief Return the equivalent Gazebo vector 3d.
-    /// \param[in] _vec Qt vector 3d to convert.
-    /// \return Gazebo vector 3d value
-    GZ_GUI_VISIBLE
-    math::Vector3d convert(const QVector3D &_vec);
+/// \brief Return the equivalent Gazebo vector 3d.
+/// \param[in] _vec Qt vector 3d to convert.
+/// \return Gazebo vector 3d value
+GZ_GUI_VISIBLE
+math::Vector3d convert(const QVector3D &_vec);
 
-    /// \brief Return the equivalent Gazebo mouse event.
-    ///
-    /// Note that there isn't a 1-1 mapping between these types, so fields such
-    /// as common::MouseEvent::PressPos need to be set afterwards.
-    /// \param[in] _e Qt mouse event
-    /// \return Gazebo mouse event
-    GZ_GUI_VISIBLE
-    common::MouseEvent convert(const QMouseEvent &_e);
+/// \brief Return the equivalent Gazebo mouse event.
+///
+/// Note that there isn't a 1-1 mapping between these types, so fields such
+/// as common::MouseEvent::PressPos need to be set afterwards.
+/// \param[in] _e Qt mouse event
+/// \return Gazebo mouse event
+GZ_GUI_VISIBLE
+common::MouseEvent convert(const QMouseEvent &_e);
 
-    /// \brief Return the equivalent Gazebo mouse event.
-    ///
-    /// Note that there isn't a 1-1 mapping between these types.
-    /// \param[in] _e Qt wheel event
-    /// \return Gazebo mouse event
-    GZ_GUI_VISIBLE
-    common::MouseEvent convert(const QWheelEvent &_e);
+/// \brief Return the equivalent Gazebo mouse event.
+///
+/// Note that there isn't a 1-1 mapping between these types.
+/// \param[in] _e Qt wheel event
+/// \return Gazebo mouse event
+GZ_GUI_VISIBLE
+common::MouseEvent convert(const QWheelEvent &_e);
 
-    /// \brief Return the equivalent Gazebo key event.
-    ///
-    /// \param[in] _e Qt key event
-    /// \return Gazebo key event
-    GZ_GUI_VISIBLE
-    common::KeyEvent convert(const QKeyEvent &_e);
-  }
-}
-#endif
+/// \brief Return the equivalent Gazebo key event.
+///
+/// \param[in] _e Qt key event
+/// \return Gazebo key event
+GZ_GUI_VISIBLE
+common::KeyEvent convert(const QKeyEvent &_e);
+}  // namespace gz::gui
+#endif  // GZ_GUI_CONVERSIONS_HH_

--- a/include/gz/gui/Dialog.hh
+++ b/include/gz/gui/Dialog.hh
@@ -31,74 +31,72 @@
 #pragma warning(disable: 4251)
 #endif
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    class DialogPrivate;
+/// Forward declarations
+class DialogPrivate;
 
-    /// \brief Gui plugin
-    class GZ_GUI_VISIBLE Dialog : public QObject
-    {
-      Q_OBJECT
+/// \brief Gui plugin
+class GZ_GUI_VISIBLE Dialog : public QObject
+{
+  Q_OBJECT
 
-      /// \brief Constructor
-      public: Dialog();
+  /// \brief Constructor
+  public: Dialog();
 
-      /// \brief Destructor
-      public: virtual ~Dialog();
+  /// \brief Destructor
+  public: virtual ~Dialog();
 
-      /// \brief Get the QtQuick window created by this object
-      /// \return Pointer to the QtQuick window
-      public: QQuickWindow *QuickWindow() const;
+  /// \brief Get the QtQuick window created by this object
+  /// \return Pointer to the QtQuick window
+  public: QQuickWindow *QuickWindow() const;
 
-      /// \brief Get the root quick item of this window
-      /// \return Pointer to the item
-      public: QQuickItem *RootItem() const;
+  /// \brief Get the root quick item of this window
+  /// \return Pointer to the item
+  public: QQuickItem *RootItem() const;
 
-      /// \brief Store dialog default config
-      /// \param[in] _config XML config as string
-      /// \deprecated Introduce deprecation warnings on v7.
-      public: void SetDefaultConfig(const std::string &_config);
+  /// \brief Store dialog default config
+  /// \param[in] _config XML config as string
+  /// \deprecated Introduce deprecation warnings on v7.
+  public: void SetDefaultConfig(const std::string &_config);
 
-      /// \brief Update an attribute on an XML file. The attribute belongs to
-      /// a `<dialog>` element that has a `name` attrbute matching this dialog's
-      /// name, i.e.
-      ///
-      /// `<dialog name="dialog_name" attribute="value"/>`
-      ///
-      /// If a dialog element with this dialog's name doesn't exist yet, one
-      /// will be created.
-      ///
-      /// \param[in] _path File path. File must already exist, this function
-      /// will not create a new file.
-      /// \param[in] _attribute XMLElement attribute name
-      /// \param[in] _value XMLElement attribute value
-      /// \return True if written to config file
-      public: bool UpdateConfigAttribute(
-        const std::string &_path, const std::string &_attribute,
-        const bool _value) const;
+  /// \brief Update an attribute on an XML file. The attribute belongs to
+  /// a `<dialog>` element that has a `name` attrbute matching this dialog's
+  /// name, i.e.
+  ///
+  /// `<dialog name="dialog_name" attribute="value"/>`
+  ///
+  /// If a dialog element with this dialog's name doesn't exist yet, one
+  /// will be created.
+  ///
+  /// \param[in] _path File path. File must already exist, this function
+  /// will not create a new file.
+  /// \param[in] _attribute XMLElement attribute name
+  /// \param[in] _value XMLElement attribute value
+  /// \return True if written to config file
+  public: bool UpdateConfigAttribute(
+    const std::string &_path, const std::string &_attribute,
+    const bool _value) const;
 
-      /// \brief Gets an attribute value from an XML file. The attribute belongs
-      /// to a `<dialog>` element that has a `name` attribute matching this
-      /// dialog's name.
-      /// It will return an empty string if the file or the attribute
-      /// don't exist.
-      /// \param[in] _path File path
-      /// \param[in] _attribute attribute name
-      /// \return Attribute value as string
-      public: std::string ReadConfigAttribute(const std::string &_path,
-        const std::string &_attribute) const;
+  /// \brief Gets an attribute value from an XML file. The attribute belongs
+  /// to a `<dialog>` element that has a `name` attribute matching this
+  /// dialog's name.
+  /// It will return an empty string if the file or the attribute
+  /// don't exist.
+  /// \param[in] _path File path
+  /// \param[in] _attribute attribute name
+  /// \return Attribute value as string
+  public: std::string ReadConfigAttribute(const std::string &_path,
+    const std::string &_attribute) const;
 
-      /// \internal
-      /// \brief Private data pointer
-      private: std::unique_ptr<DialogPrivate> dataPtr;
-    };
-  }
-}
+  /// \internal
+  /// \brief Private data pointer
+  private: std::unique_ptr<DialogPrivate> dataPtr;
+};
+}  // namespace gz::gui
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#endif
+#endif  // GZ_GUI_DIALOG_HH_

--- a/include/gz/gui/DragDropModel.hh
+++ b/include/gz/gui/DragDropModel.hh
@@ -20,19 +20,16 @@
 #include "gz/gui/Export.hh"
 #include "gz/gui/qt.h"
 
-namespace gz
+namespace gz::gui
 {
-namespace gui
+/// \brief Customized item model so that we can pass along an URI query as
+/// MIME information during a drag-drop.
+class GZ_GUI_VISIBLE DragDropModel : public QStandardItemModel
 {
-  /// \brief Customized item model so that we can pass along an URI query as
-  /// MIME information during a drag-drop.
-  class GZ_GUI_VISIBLE DragDropModel : public QStandardItemModel
-  {
-    /// \brief Overloaded from Qt. Custom MIME data function.
-    /// \param[in] _indexes List of selected items.
-    /// \return Mime data for the selected items.
-    public: QMimeData *mimeData(const QModelIndexList &_indexes) const;
-  };
-}
-}
-#endif
+  /// \brief Overloaded from Qt. Custom MIME data function.
+  /// \param[in] _indexes List of selected items.
+  /// \return Mime data for the selected items.
+  public: QMimeData *mimeData(const QModelIndexList &_indexes) const;
+};
+}  // namespace gz::gui
+#endif  // GZ_GUI_DRAGDROPMODEL_HH_

--- a/include/gz/gui/Enums.hh
+++ b/include/gz/gui/Enums.hh
@@ -20,67 +20,64 @@
 
 #include "gz/gui/qt.h"
 
-namespace gz
+namespace gz::gui
 {
-namespace gui
+/// \brief Data roles
+enum DataRole
 {
-  /// \brief Data roles
-  enum DataRole
-  {
-    /// \brief Text which is displayed for the user.
-    DISPLAY_NAME = Qt::UserRole + 100,
+  /// \brief Text which is displayed for the user.
+  DISPLAY_NAME = Qt::UserRole + 100,
 
-    /// \brief URI including detailed query. This is the information carried
-    /// during a drag-drop operation.
-    URI_QUERY,
+  /// \brief URI including detailed query. This is the information carried
+  /// during a drag-drop operation.
+  URI_QUERY,
 
-    /// \brief Data type name, such as "Double" or "Bool", or "model", "link".
-    /// Used to specialize display according to type.
-    TYPE,
+  /// \brief Data type name, such as "Double" or "Bool", or "model", "link".
+  /// Used to specialize display according to type.
+  TYPE,
 
-    /// \brief Flag indicating whether an item should be expanded or not.
-    TO_EXPAND
-  };
+  /// \brief Flag indicating whether an item should be expanded or not.
+  TO_EXPAND
+};
 
-  /// \brief String types
-  enum class StringType
-  {
-    /// \brief Undefined type
-    NONE,
+/// \brief String types
+enum class StringType
+{
+  /// \brief Undefined type
+  NONE,
 
-    /// \brief Use line for short strings which usually fit in a single
-    /// line.
-    LINE,
+  /// \brief Use line for short strings which usually fit in a single
+  /// line.
+  LINE,
 
-    /// \brief Use text for longer strings which span multiple lines.
-    PLAIN_TEXT
-  };
+  /// \brief Use text for longer strings which span multiple lines.
+  PLAIN_TEXT
+};
 
-  /// \brief Number types
-  enum class NumberType
-  {
-    /// \brief Undefined type
-    NONE,
+/// \brief Number types
+enum class NumberType
+{
+  /// \brief Undefined type
+  NONE,
 
-    /// \brief Double
-    DOUBLE,
+  /// \brief Double
+  DOUBLE,
 
-    /// \brief Integer
-    INT,
+  /// \brief Integer
+  INT,
 
-    /// \brief Unsigned integer
-    UINT
-  };
+  /// \brief Unsigned integer
+  UINT
+};
 
-  /// \brief File types
-  enum FileType
-  {
-    /// \brief Comma separated value (CSV)
-    CSVFile,
+/// \brief File types
+enum FileType
+{
+  /// \brief Comma separated value (CSV)
+  CSVFile,
 
-    /// \brief Portable document format (PDF)
-    PDFFile
-  };
-}
-}
-#endif
+  /// \brief Portable document format (PDF)
+  PDFFile
+};
+}  // namespace gz::gui
+#endif  // GZ_GUI_ENUMS_HH_

--- a/include/gz/gui/GuiEvents.hh
+++ b/include/gz/gui/GuiEvents.hh
@@ -32,462 +32,455 @@
 
 #include "gz/gui/Export.hh"
 
-namespace gz
+namespace gz::gui::events
 {
-  namespace gui
+
+/// User defined events should start from QEvent::MaxUser and
+/// count down to avoid collision with gz-sim events
+
+/// \brief Event called in the render thread of a 3D scene after the user
+/// camera has rendered.
+/// It's safe to make rendering calls in this event's callback.
+class Render : public QEvent
+{
+  public: Render()
+      : QEvent(kType)
   {
-    /// \brief Namespace for all events.
-    namespace events
-    {
-      /// User defined events should start from QEvent::MaxUser and
-      /// count down to avoid collision with gz-sim events
-
-      /// \brief Event called in the render thread of a 3D scene after the user
-      /// camera has rendered.
-      /// It's safe to make rendering calls in this event's callback.
-      class Render : public QEvent
-      {
-        public: Render()
-            : QEvent(kType)
-        {
-        }
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser);
-      };
-
-      /// \brief The class for sending and receiving custom snap value events.
-      /// This event is used in the Transform Control plugin tool when the
-      /// user manually alters their snapping values.
-      class GZ_GUI_VISIBLE SnapIntervals : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _xyz XYZ snapping values.
-        /// \param[in] _rpy RPY snapping values.
-        /// \param[in] _scale Scale snapping values.
-        public: SnapIntervals(
-                    const math::Vector3d &_xyz,
-                    const math::Vector3d &_rpy,
-                    const math::Vector3d &_scale);
-
-        /// \brief Get the XYZ snapping values.
-        /// \return The XYZ snapping values.
-        public: math::Vector3d Position() const;
-
-        /// \brief Get the RPY snapping values.
-        /// \return The RPY snapping values.
-        public: math::Vector3d Rotation() const;
-
-        /// \brief Get the scale snapping values.
-        /// \return The scale snapping values.
-        public: math::Vector3d Scale() const;
-
-        /// \brief The QEvent representing a snap event occurrence.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 1);
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event called to spawn a resource, given its description as a
-      /// string.
-      class GZ_GUI_VISIBLE SpawnFromDescription : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _description The resource's description as a string, such
-        /// as an SDF file.
-        public: explicit SpawnFromDescription(const std::string &_description);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 2);
-
-        /// \brief Get the string description of the resource.
-        /// \return The resource string
-        public: const std::string &Description() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event called to spawn a resource, which takes the path
-      /// to its file.
-      class GZ_GUI_VISIBLE SpawnFromPath : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _filePath The path to a file.
-        public: explicit SpawnFromPath(const std::string &_filePath);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 3);
-
-        /// \brief Get the path of the file.
-        /// \return The file path.
-        public: const std::string &FilePath() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the 3D coordinates of a
-      /// user's mouse hover within the scene.
-      class GZ_GUI_VISIBLE HoverToScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _point The point at which the mouse is hovering within
-        /// the scene
-        public: explicit HoverToScene(const math::Vector3d &_point);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 4);
-
-        /// \brief Get the point within the scene over which the user is
-        /// hovering.
-        /// \return The 3D point
-        public: math::Vector3d Point() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the 3D coordinates of a
-      /// user's releasing the left button within the scene.
-      /// \sa LeftClickOnScene
-      class GZ_GUI_VISIBLE LeftClickToScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _point The point which the user has left clicked within
-        /// the scene
-        public: explicit LeftClickToScene(const math::Vector3d &_point);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 5);
-
-        /// \brief Get the point within the scene that the user clicked.
-        /// \return The 3D point.
-        public: math::Vector3d Point() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the 3D coordinates of a
-      /// user's releasing the right button within the scene.
-      /// \sa RightClickOnScene
-      class GZ_GUI_VISIBLE RightClickToScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _point The point which the user has right clicked
-        /// within the scene
-        public: explicit RightClickToScene(const math::Vector3d &_point);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 6);
-
-        /// \brief Get the point within the scene that the user clicked.
-        /// \return The 3D point.
-        public: math::Vector3d Point() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to enable or disable the dropdown menu.
-      /// This is primarily used by plugins which also use the right click
-      /// mouse event to cancel any actions currently in progress.
-      class GZ_GUI_VISIBLE DropdownMenuEnabled : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _menuEnabled The boolean indicating whether the dropdown
-        /// menu should be enabled or disabled.
-        public: explicit DropdownMenuEnabled(bool _menuEnabled);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 7);
-
-        /// \brief Gets whether the menu is enabled or not for this event.
-        /// \return True if enabling the menu, false if disabling the menu
-        public: bool MenuEnabled() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the key release within
-      /// the scene.
-      class GZ_GUI_VISIBLE KeyReleaseOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _key The key released event within the scene
-        public: explicit KeyReleaseOnScene(const common::KeyEvent &_key);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 8);
-
-        /// \brief Get the released key within the scene that the user released.
-        /// \return The key code.
-        public: common::KeyEvent Key() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the key press within
-      /// the scene.
-      class GZ_GUI_VISIBLE KeyPressOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _key The pressed key within the scene
-        public: explicit KeyPressOnScene(const common::KeyEvent &_key);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 9);
-
-        /// \brief Get the key within the scene that the user pressed
-        /// \return The key code.
-        public: common::KeyEvent Key() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast information about left
-      /// mouse releases on the scene.
-      /// For the 3D coordinates of that point on the scene, see
-      /// `LeftClickToScene`.
-      /// \sa LeftClickToScene
-      class GZ_GUI_VISIBLE LeftClickOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The left mouse event on the scene
-        public: explicit LeftClickOnScene(
-          const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 10);
-
-        /// \brief Return the left mouse event
-        public: const common::MouseEvent &Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast information about right
-      /// mouse releases on the scene.
-      /// For the 3D coordinates of that point on the scene, see
-      /// `RightClickToScene`.
-      /// \sa RightClickToScene
-      class GZ_GUI_VISIBLE RightClickOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The right mouse event on the scene
-        public: RightClickOnScene(
-          const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 11);
-
-        /// \brief Return the right mouse event
-        public: const common::MouseEvent &Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event that block the Interactive View control when some of the
-      /// other plugins require it. For example: When the transform control is
-      /// active we should block the movements of the camera.
-      class GZ_GUI_VISIBLE BlockOrbit : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _block True to block otherwise False
-        public: explicit BlockOrbit(const bool &_block);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 12);
-
-        /// \brief Get the if the event should block the Interactive view
-        /// controller
-        /// \return True to block otherwise False.
-        public: bool Block() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast the 2D coordinates of a
-      /// user's mouse hover within the scene.
-      class GZ_GUI_VISIBLE HoverOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The hover mouse event on the scene
-        public: explicit HoverOnScene(const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 13);
-
-        /// \brief Get the point within the scene over which the user is
-        /// hovering.
-        /// \return The 2D point
-        public: common::MouseEvent Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event called to clone a resource, given its name as a string.
-      class GZ_GUI_VISIBLE SpawnCloneFromName : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _name The name of the resource to clone
-        public: explicit SpawnCloneFromName(const std::string &_name);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 14);
-
-        /// \brief Get the name of the resource to be cloned
-        /// \return The name of the resource to be cloned
-        public: const std::string &Name() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event called to clone a resource, given its name as a string.
-      class GZ_GUI_VISIBLE DropOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _dropText Dropped string.
-        /// \param[in] _dropMouse x and y  coordinate of mouse position.
-        public: explicit DropOnScene(
-          const std::string &_dropText,
-          const math::Vector2i &_dropMouse);
-
-        /// \brief Get the text of the dropped thing on the scene
-        /// \return The name of the dropped thing on the scene
-        public: const std::string &DropText() const;
-
-        /// \brief Get X and Y position
-        /// \return Get X and Y position
-        public: const math::Vector2i &Mouse() const;
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 15);
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast information about mouse
-      /// scrolls on the scene.
-      class GZ_GUI_VISIBLE ScrollOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The scroll mouse event on the scene
-        public: explicit ScrollOnScene(const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 16);
-
-        /// \brief Return the scroll mouse event
-        public: const common::MouseEvent &Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast information about mouse
-      /// drags on the scene.
-      class GZ_GUI_VISIBLE DragOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The drag mouse event on the scene
-        public: explicit DragOnScene(const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 17);
-
-        /// \brief Get the point within the scene over which the user is
-        /// dragging.
-        /// \return The 2D point
-        public: common::MouseEvent Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to broadcast information about mouse
-      /// presses on the scene, with right, left or middle buttons.
-      class GZ_GUI_VISIBLE MousePressOnScene : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _mouse The mouse event on the scene
-        public: MousePressOnScene(
-          const common::MouseEvent &_mouse);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 18);
-
-        /// \brief Return the button press mouse event
-        public: const common::MouseEvent &Mouse() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event which is called to share WorldControl information.
-      class GZ_GUI_VISIBLE WorldControl : public QEvent
-      {
-        /// \brief Constructor
-        /// \param[in] _worldControl The WorldControl information
-        public: explicit WorldControl(const msgs::WorldControl &_worldControl);
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 19);
-
-        /// \brief Get the WorldControl information
-        /// \return The WorldControl information
-        public: const msgs::WorldControl &WorldControlInfo() const;
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-
-      /// \brief Event called in the render thread of a 3D scene, before the
-      /// user camera is rendered.
-      /// It's safe to make rendering calls in this event's callback.
-      class GZ_GUI_VISIBLE PreRender : public QEvent
-      {
-        /// \brief Constructor
-        public: PreRender();
-
-        /// \brief Unique type for this event.
-        static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 20);
-
-        /// \internal
-        /// \brief Private data pointer
-        GZ_UTILS_IMPL_PTR(dataPtr)
-      };
-    }
   }
-}
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser);
+};
 
+/// \brief The class for sending and receiving custom snap value events.
+/// This event is used in the Transform Control plugin tool when the
+/// user manually alters their snapping values.
+class GZ_GUI_VISIBLE SnapIntervals : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _xyz XYZ snapping values.
+  /// \param[in] _rpy RPY snapping values.
+  /// \param[in] _scale Scale snapping values.
+  public: SnapIntervals(
+              const math::Vector3d &_xyz,
+              const math::Vector3d &_rpy,
+              const math::Vector3d &_scale);
+
+  /// \brief Get the XYZ snapping values.
+  /// \return The XYZ snapping values.
+  public: math::Vector3d Position() const;
+
+  /// \brief Get the RPY snapping values.
+  /// \return The RPY snapping values.
+  public: math::Vector3d Rotation() const;
+
+  /// \brief Get the scale snapping values.
+  /// \return The scale snapping values.
+  public: math::Vector3d Scale() const;
+
+  /// \brief The QEvent representing a snap event occurrence.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 1);
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event called to spawn a resource, given its description as a
+/// string.
+class GZ_GUI_VISIBLE SpawnFromDescription : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _description The resource's description as a string, such
+  /// as an SDF file.
+  public: explicit SpawnFromDescription(const std::string &_description);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 2);
+
+  /// \brief Get the string description of the resource.
+  /// \return The resource string
+  public: const std::string &Description() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event called to spawn a resource, which takes the path
+/// to its file.
+class GZ_GUI_VISIBLE SpawnFromPath : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _filePath The path to a file.
+  public: explicit SpawnFromPath(const std::string &_filePath);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 3);
+
+  /// \brief Get the path of the file.
+  /// \return The file path.
+  public: const std::string &FilePath() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the 3D coordinates of a
+/// user's mouse hover within the scene.
+class GZ_GUI_VISIBLE HoverToScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _point The point at which the mouse is hovering within
+  /// the scene
+  public: explicit HoverToScene(const math::Vector3d &_point);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 4);
+
+  /// \brief Get the point within the scene over which the user is
+  /// hovering.
+  /// \return The 3D point
+  public: math::Vector3d Point() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the 3D coordinates of a
+/// user's releasing the left button within the scene.
+/// \sa LeftClickOnScene
+class GZ_GUI_VISIBLE LeftClickToScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _point The point which the user has left clicked within
+  /// the scene
+  public: explicit LeftClickToScene(const math::Vector3d &_point);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 5);
+
+  /// \brief Get the point within the scene that the user clicked.
+  /// \return The 3D point.
+  public: math::Vector3d Point() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the 3D coordinates of a
+/// user's releasing the right button within the scene.
+/// \sa RightClickOnScene
+class GZ_GUI_VISIBLE RightClickToScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _point The point which the user has right clicked
+  /// within the scene
+  public: explicit RightClickToScene(const math::Vector3d &_point);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 6);
+
+  /// \brief Get the point within the scene that the user clicked.
+  /// \return The 3D point.
+  public: math::Vector3d Point() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to enable or disable the dropdown menu.
+/// This is primarily used by plugins which also use the right click
+/// mouse event to cancel any actions currently in progress.
+class GZ_GUI_VISIBLE DropdownMenuEnabled : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _menuEnabled The boolean indicating whether the dropdown
+  /// menu should be enabled or disabled.
+  public: explicit DropdownMenuEnabled(bool _menuEnabled);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 7);
+
+  /// \brief Gets whether the menu is enabled or not for this event.
+  /// \return True if enabling the menu, false if disabling the menu
+  public: bool MenuEnabled() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the key release within
+/// the scene.
+class GZ_GUI_VISIBLE KeyReleaseOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _key The key released event within the scene
+  public: explicit KeyReleaseOnScene(const common::KeyEvent &_key);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 8);
+
+  /// \brief Get the released key within the scene that the user released.
+  /// \return The key code.
+  public: common::KeyEvent Key() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the key press within
+/// the scene.
+class GZ_GUI_VISIBLE KeyPressOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _key The pressed key within the scene
+  public: explicit KeyPressOnScene(const common::KeyEvent &_key);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 9);
+
+  /// \brief Get the key within the scene that the user pressed
+  /// \return The key code.
+  public: common::KeyEvent Key() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast information about left
+/// mouse releases on the scene.
+/// For the 3D coordinates of that point on the scene, see
+/// `LeftClickToScene`.
+/// \sa LeftClickToScene
+class GZ_GUI_VISIBLE LeftClickOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The left mouse event on the scene
+  public: explicit LeftClickOnScene(
+    const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 10);
+
+  /// \brief Return the left mouse event
+  public: const common::MouseEvent &Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast information about right
+/// mouse releases on the scene.
+/// For the 3D coordinates of that point on the scene, see
+/// `RightClickToScene`.
+/// \sa RightClickToScene
+class GZ_GUI_VISIBLE RightClickOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The right mouse event on the scene
+  public: RightClickOnScene(
+    const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 11);
+
+  /// \brief Return the right mouse event
+  public: const common::MouseEvent &Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event that block the Interactive View control when some of the
+/// other plugins require it. For example: When the transform control is
+/// active we should block the movements of the camera.
+class GZ_GUI_VISIBLE BlockOrbit : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _block True to block otherwise False
+  public: explicit BlockOrbit(const bool &_block);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 12);
+
+  /// \brief Get the if the event should block the Interactive view
+  /// controller
+  /// \return True to block otherwise False.
+  public: bool Block() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast the 2D coordinates of a
+/// user's mouse hover within the scene.
+class GZ_GUI_VISIBLE HoverOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The hover mouse event on the scene
+  public: explicit HoverOnScene(const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 13);
+
+  /// \brief Get the point within the scene over which the user is
+  /// hovering.
+  /// \return The 2D point
+  public: common::MouseEvent Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event called to clone a resource, given its name as a string.
+class GZ_GUI_VISIBLE SpawnCloneFromName : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _name The name of the resource to clone
+  public: explicit SpawnCloneFromName(const std::string &_name);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 14);
+
+  /// \brief Get the name of the resource to be cloned
+  /// \return The name of the resource to be cloned
+  public: const std::string &Name() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event called to clone a resource, given its name as a string.
+class GZ_GUI_VISIBLE DropOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _dropText Dropped string.
+  /// \param[in] _dropMouse x and y  coordinate of mouse position.
+  public: explicit DropOnScene(
+    const std::string &_dropText,
+    const math::Vector2i &_dropMouse);
+
+  /// \brief Get the text of the dropped thing on the scene
+  /// \return The name of the dropped thing on the scene
+  public: const std::string &DropText() const;
+
+  /// \brief Get X and Y position
+  /// \return Get X and Y position
+  public: const math::Vector2i &Mouse() const;
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 15);
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast information about mouse
+/// scrolls on the scene.
+class GZ_GUI_VISIBLE ScrollOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The scroll mouse event on the scene
+  public: explicit ScrollOnScene(const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 16);
+
+  /// \brief Return the scroll mouse event
+  public: const common::MouseEvent &Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast information about mouse
+/// drags on the scene.
+class GZ_GUI_VISIBLE DragOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The drag mouse event on the scene
+  public: explicit DragOnScene(const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 17);
+
+  /// \brief Get the point within the scene over which the user is
+  /// dragging.
+  /// \return The 2D point
+  public: common::MouseEvent Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to broadcast information about mouse
+/// presses on the scene, with right, left or middle buttons.
+class GZ_GUI_VISIBLE MousePressOnScene : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _mouse The mouse event on the scene
+  public: MousePressOnScene(
+    const common::MouseEvent &_mouse);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 18);
+
+  /// \brief Return the button press mouse event
+  public: const common::MouseEvent &Mouse() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event which is called to share WorldControl information.
+class GZ_GUI_VISIBLE WorldControl : public QEvent
+{
+  /// \brief Constructor
+  /// \param[in] _worldControl The WorldControl information
+  public: explicit WorldControl(const msgs::WorldControl &_worldControl);
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 19);
+
+  /// \brief Get the WorldControl information
+  /// \return The WorldControl information
+  public: const msgs::WorldControl &WorldControlInfo() const;
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+
+/// \brief Event called in the render thread of a 3D scene, before the
+/// user camera is rendered.
+/// It's safe to make rendering calls in this event's callback.
+class GZ_GUI_VISIBLE PreRender : public QEvent
+{
+  /// \brief Constructor
+  public: PreRender();
+
+  /// \brief Unique type for this event.
+  static const QEvent::Type kType = QEvent::Type(QEvent::MaxUser - 20);
+
+  /// \internal
+  /// \brief Private data pointer
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
+}  // namespace gz::gui::events
 #endif  // GZ_GUI_GUIEVENTS_HH_

--- a/include/gz/gui/Helpers.hh
+++ b/include/gz/gui/Helpers.hh
@@ -22,114 +22,111 @@
 #include "gz/gui/Enums.hh"
 #include "gz/gui/Export.hh"
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
+/// \brief Create a human readable key, capitalizing the first letter
+/// and removing characters like "_".
+/// \param[in] _key Non-human-readable key.
+/// \return Human-readable key.
+GZ_GUI_VISIBLE
+std::string humanReadable(const std::string &_key);
+
+/// \brief Returns the unit for a given key. For example, the key "mass"
+/// returns "kg".
+/// \param[in] _key The key.
+/// \param[in] _type In case the key may have more than one type, the type
+/// must be given too. For example, a prismatic joint will have different
+/// units from a revolute joint.
+/// \return The unit.
+GZ_GUI_VISIBLE
+std::string unitFromKey(const std::string &_key,
+                        const std::string &_type = "");
+
+/// \brief Returns the range for a given key. For example, the key
+/// "transparency" returns min == 0, max == 1.
+/// \param[in] _key The key.
+/// \param[out] _min The minimum value.
+/// \param[out] _max The maximum value.
+GZ_GUI_VISIBLE
+void rangeFromKey(const std::string &_key, double &_min, double &_max);
+
+/// \brief Returns the string type for a given key. For example, the key
+/// "innerxml" has a PLAIN_TEXT type while "name" is a LINE.
+/// \param[in] _key The key.
+/// \return The string type.
+GZ_GUI_VISIBLE
+StringType stringTypeFromKey(const std::string &_key);
+
+/// \brief Generates a path for a file which doesn't collide with existing
+/// files, by appending numbers to it (i.e. (0), (1), ...)
+/// \param[in] _pathAndName Full absolute path and file name up to the
+/// file extension.
+/// \param[in] _extension File extension, such as "pdf".
+/// \return Full path, with name and extension, which doesn't collide with
+/// existing files
+GZ_GUI_VISIBLE
+std::string uniqueFilePath(const std::string &_pathAndName,
+                           const std::string &_extension);
+
+/// \brief The main window's "worldNames" property may be filled with a list
+/// of the names of all worlds currently loaded. This information can be
+/// used by plugins to choose which world to work with.
+/// This helper function provides a handy access to the world names list.
+/// \return List of world names, as stored in the `MainWindow`'s
+/// "worldNames" property.
+GZ_GUI_VISIBLE
+QStringList worldNames();
+
+/// \brief The main window's "renderEngine" property may be filled with
+/// a string of the render engine gui name. This information can be
+/// used by plugins to set the GUI render engine
+/// This helper function provides a handy access to the render engine GUI
+/// name
+/// \return Name of render engine used on the GUI, as stored in the
+/// `MainWindow`'s "renderEngine" property.
+GZ_GUI_VISIBLE
+std::string renderEngineName();
+
+/// \brief Just like renderEngineName(), but valid entries are:
+///  - opengl (default)
+///  - metal (Apple only)
+///  - vulkan
+/// \return Name of API backend used on the GUI, as stored in the
+/// `MainWindow`'s "renderEngineBackendApiName" property.
+GZ_GUI_VISIBLE
+std::string renderEngineBackendApiName();
+
+/// \brief Import path for gz-gui QML modules added to the Qt resource
+/// system. This helper function returns the QRC resource path where custom
+/// Gazebo QML modules can be imported from. To import a Gazebo QML
+/// module, add this path to the QML engine's import path list before
+/// attempting to load a QML file that imports Gazebo QML modules.
+/// \return Resousrce path prefix as a string
+GZ_GUI_VISIBLE
+const QString qmlQrcImportPath();
+
+/// \brief Returns the first element on a QList which matches the given
+/// property.
+/// \param[in] _list The list to search through.
+/// \param[in] _key The property key value.
+/// \param[in] _value The property value.
+/// \return The first matching element.
+template<class T>
+T findFirstByProperty(const QList<T> _list, const char *_key,
+    QVariant _value)
+{
+  if (nullptr == _key)
+    return nullptr;
+
+  for (const auto &w : _list)
   {
-    /// \brief Create a human readable key, capitalizing the first letter
-    /// and removing characters like "_".
-    /// \param[in] _key Non-human-readable key.
-    /// \return Human-readable key.
-    GZ_GUI_VISIBLE
-    std::string humanReadable(const std::string &_key);
+    if (nullptr == w)
+      continue;
 
-    /// \brief Returns the unit for a given key. For example, the key "mass"
-    /// returns "kg".
-    /// \param[in] _key The key.
-    /// \param[in] _type In case the key may have more than one type, the type
-    /// must be given too. For example, a prismatic joint will have different
-    /// units from a revolute joint.
-    /// \return The unit.
-    GZ_GUI_VISIBLE
-    std::string unitFromKey(const std::string &_key,
-                            const std::string &_type = "");
-
-    /// \brief Returns the range for a given key. For example, the key
-    /// "transparency" returns min == 0, max == 1.
-    /// \param[in] _key The key.
-    /// \param[out] _min The minimum value.
-    /// \param[out] _max The maximum value.
-    GZ_GUI_VISIBLE
-    void rangeFromKey(const std::string &_key, double &_min, double &_max);
-
-    /// \brief Returns the string type for a given key. For example, the key
-    /// "innerxml" has a PLAIN_TEXT type while "name" is a LINE.
-    /// \param[in] _key The key.
-    /// \return The string type.
-    GZ_GUI_VISIBLE
-    StringType stringTypeFromKey(const std::string &_key);
-
-    /// \brief Generates a path for a file which doesn't collide with existing
-    /// files, by appending numbers to it (i.e. (0), (1), ...)
-    /// \param[in] _pathAndName Full absolute path and file name up to the
-    /// file extension.
-    /// \param[in] _extension File extension, such as "pdf".
-    /// \return Full path, with name and extension, which doesn't collide with
-    /// existing files
-    GZ_GUI_VISIBLE
-    std::string uniqueFilePath(const std::string &_pathAndName,
-                               const std::string &_extension);
-
-    /// \brief The main window's "worldNames" property may be filled with a list
-    /// of the names of all worlds currently loaded. This information can be
-    /// used by plugins to choose which world to work with.
-    /// This helper function provides a handy access to the world names list.
-    /// \return List of world names, as stored in the `MainWindow`'s
-    /// "worldNames" property.
-    GZ_GUI_VISIBLE
-    QStringList worldNames();
-
-    /// \brief The main window's "renderEngine" property may be filled with
-    /// a string of the render engine gui name. This information can be
-    /// used by plugins to set the GUI render engine
-    /// This helper function provides a handy access to the render engine GUI
-    /// name
-    /// \return Name of render engine used on the GUI, as stored in the
-    /// `MainWindow`'s "renderEngine" property.
-    GZ_GUI_VISIBLE
-    std::string renderEngineName();
-
-    /// \brief Just like renderEngineName(), but valid entries are:
-    ///  - opengl (default)
-    ///  - metal (Apple only)
-    ///  - vulkan
-    /// \return Name of API backend used on the GUI, as stored in the
-    /// `MainWindow`'s "renderEngineBackendApiName" property.
-    GZ_GUI_VISIBLE
-    std::string renderEngineBackendApiName();
-
-    /// \brief Import path for gz-gui QML modules added to the Qt resource
-    /// system. This helper function returns the QRC resource path where custom
-    /// Gazebo QML modules can be imported from. To import a Gazebo QML
-    /// module, add this path to the QML engine's import path list before
-    /// attempting to load a QML file that imports Gazebo QML modules.
-    /// \return Resousrce path prefix as a string
-    GZ_GUI_VISIBLE
-    const QString qmlQrcImportPath();
-
-    /// \brief Returns the first element on a QList which matches the given
-    /// property.
-    /// \param[in] _list The list to search through.
-    /// \param[in] _key The property key value.
-    /// \param[in] _value The property value.
-    /// \return The first matching element.
-    template<class T>
-    T findFirstByProperty(const QList<T> _list, const char *_key,
-        QVariant _value)
-    {
-      if (nullptr == _key)
-        return nullptr;
-
-      for (const auto &w : _list)
-      {
-        if (nullptr == w)
-          continue;
-
-        if (w->property(_key) == _value)
-          return w;
-      }
-      return nullptr;
-    }
+    if (w->property(_key) == _value)
+      return w;
   }
+  return nullptr;
 }
-#endif
+}  // namespace gz::gui
+#endif  // GZ_GUI_HELPERS_HH_

--- a/include/gz/gui/MainWindow.hh
+++ b/include/gz/gui/MainWindow.hh
@@ -35,652 +35,649 @@
 #pragma warning(disable: 4251)
 #endif
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    Q_NAMESPACE
-    class MainWindowPrivate;
-    struct WindowConfig;
-
-    /// \brief The action executed when GUI is closed without prompt.
-    enum class ExitAction
-    {
-      /// \brief Close GUI and leave server running
-      CLOSE_GUI,
-      /// \brief Close GUI and shutdown server
-      SHUTDOWN_SERVER,
-    };
-    /// \cond DO_NOT_DOCUMENT
-    Q_ENUM_NS(ExitAction)
-    /// \endcond
-
-    /// \brief The main window class creates a QQuickWindow and acts as an
-    /// interface which provides properties and functions which can be called
-    /// from Main.qml
-    class GZ_GUI_VISIBLE MainWindow : public QObject
-    {
-      Q_OBJECT
-
-      /// \brief Number of plugins currently instantiated inside the window.
-      Q_PROPERTY(
-        int pluginCount
-        READ PluginCount
-        WRITE SetPluginCount
-        NOTIFY PluginCountChanged
-      )
-
-      /// \brief Material theme (Light / Dark)
-      Q_PROPERTY(
-        QString materialTheme
-        READ MaterialTheme
-        WRITE SetMaterialTheme
-        NOTIFY MaterialThemeChanged
-      )
-
-      /// \brief Material primary color (Pre-defined color name or hex value)
-      Q_PROPERTY(
-        QString materialPrimary
-        READ MaterialPrimary
-        WRITE SetMaterialPrimary
-        NOTIFY MaterialPrimaryChanged
-      )
-
-      /// \brief Material accent color (Pre-defined color name or hex value)
-      Q_PROPERTY(
-        QString materialAccent
-        READ MaterialAccent
-        WRITE SetMaterialAccent
-        NOTIFY MaterialAccentChanged
-      )
-
-      /// \brief Top toolbar color for light theme (Pre-defined color name or
-      /// hex value). Defaults to material primary.
-      Q_PROPERTY(
-        QString toolBarColorLight
-        READ ToolBarColorLight
-        WRITE SetToolBarColorLight
-        NOTIFY ToolBarColorLightChanged
-      )
-
-      /// \brief Top toolbar text color for light theme (Pre-defined color name
-      /// or hex value). Defaults to material background.
-      Q_PROPERTY(
-        QString toolBarTextColorLight
-        READ ToolBarTextColorLight
-        WRITE SetToolBarTextColorLight
-        NOTIFY ToolBarTextColorLightChanged
-      )
-
-      /// \brief Top toolbar color for dark theme (Pre-defined color name or
-      /// hex value). Defaults to material primary.
-      Q_PROPERTY(
-        QString toolBarColorDark
-        READ ToolBarColorDark
-        WRITE SetToolBarColorDark
-        NOTIFY ToolBarColorDarkChanged
-      )
-
-      /// \brief Top toolbar text color for dark theme (Pre-defined color name
-      /// or hex value). Defaults to material background.
-      Q_PROPERTY(
-        QString toolBarTextColorDark
-        READ ToolBarTextColorDark
-        WRITE SetToolBarTextColorDark
-        NOTIFY ToolBarTextColorDarkChanged
-      )
-
-      /// \brief Plugin toolbar color for light theme (Pre-defined color name or
-      /// hex value). Defaults to material accent.
-      Q_PROPERTY(
-        QString pluginToolBarColorLight
-        READ PluginToolBarColorLight
-        WRITE SetPluginToolBarColorLight
-        NOTIFY PluginToolBarColorLightChanged
-      )
-
-      /// \brief Plugin toolbar text color for light theme (Pre-defined color
-      /// name or hex value). Defaults to material foreground.
-      Q_PROPERTY(
-        QString pluginToolBarTextColorLight
-        READ PluginToolBarTextColorLight
-        WRITE SetPluginToolBarTextColorLight
-        NOTIFY PluginToolBarTextColorLightChanged
-      )
-
-      /// \brief Plugin toolbar color for dark theme (Pre-defined color name or
-      /// hex value). Defaults to material accent.
-      Q_PROPERTY(
-        QString pluginToolBarColorDark
-        READ PluginToolBarColorDark
-        WRITE SetPluginToolBarColorDark
-        NOTIFY PluginToolBarColorDarkChanged
-      )
-
-      /// \brief Plugin toolbar text color for dark theme (Pre-defined color
-      /// name or hex value). Defaults to material foreground.
-      Q_PROPERTY(
-        QString pluginToolBarTextColorDark
-        READ PluginToolBarTextColorDark
-        WRITE SetPluginToolBarTextColorDark
-        NOTIFY PluginToolBarTextColorDarkChanged
-      )
-
-      /// \brief Flag to show side drawer
-      Q_PROPERTY(
-        bool showDrawer
-        READ ShowDrawer
-        WRITE SetShowDrawer
-        NOTIFY ShowDrawerChanged
-      )
-
-      /// \brief Flag to show side drawer's default options
-      Q_PROPERTY(
-        bool showDefaultDrawerOpts
-        READ ShowDefaultDrawerOpts
-        WRITE SetShowDefaultDrawerOpts
-        NOTIFY ShowDefaultDrawerOptsChanged
-      )
-
-      /// \brief Flag to show plugins menu
-      Q_PROPERTY(
-        bool showPluginMenu
-        READ ShowPluginMenu
-        WRITE SetShowPluginMenu
-        NOTIFY ShowPluginMenuChanged
-      )
-
-      /// \brief Flag to enable confirmation dialog on exit
-      Q_PROPERTY(
-        ExitAction defaultExitAction
-        READ DefaultExitAction
-        WRITE SetDefaultExitAction
-        NOTIFY DefaultExitActionChanged
-      )
-
-      /// \brief Flag to enable confirmation dialog on exit
-      Q_PROPERTY(
-        bool showDialogOnExit
-        READ ShowDialogOnExit
-        WRITE SetShowDialogOnExit
-        NOTIFY ShowDialogOnExitChanged
-      )
-
-      /// \brief Text of the prompt in confirmation dialog on exit
-      Q_PROPERTY(
-        QString dialogOnExitText
-        READ DialogOnExitText
-        WRITE SetDialogOnExitText
-        NOTIFY DialogOnExitTextChanged
-      )
-
-      /// \brief Flag to show "shutdown" button in confirmation dialog on exit
-      Q_PROPERTY(
-        bool exitDialogShowShutdown
-        READ ExitDialogShowShutdown
-        WRITE SetExitDialogShowShutdown
-        NOTIFY ExitDialogShowShutdownChanged
-      )
-
-      /// \brief Flag to show "close GUI" button in confirmation dialog on exit
-      Q_PROPERTY(
-        bool exitDialogShowCloseGui
-        READ ExitDialogShowCloseGui
-        WRITE SetExitDialogShowCloseGui
-        NOTIFY ExitDialogShowCloseGuiChanged
-      )
-
-      /// \brief Text of the "shutdown" button in confirmation dialog on exit
-      Q_PROPERTY(
-        QString exitDialogShutdownText
-        READ ExitDialogShutdownText
-        WRITE SetExitDialogShutdownText
-        NOTIFY ExitDialogShutdownTextChanged
-      )
-
-      /// \brief Text of the "Close GUI" button in confirmation dialog on exit
-      Q_PROPERTY(
-        QString exitDialogCloseGuiText
-        READ ExitDialogCloseGuiText
-        WRITE SetExitDialogCloseGuiText
-        NOTIFY ExitDialogCloseGuiTextChanged
-      )
-
-      /// \brief Constructor
-      public: MainWindow();
-
-      /// \brief Destructor
-      public: virtual ~MainWindow();
-
-      /// \brief Get the QtQuick window created by this object
-      /// \return Pointer to the QtQuick window
-      public: QQuickWindow *QuickWindow() const;
-
-      /// \brief Save current window and plugin configuration to a file on disk.
-      /// Will open an error dialog in case it's not possible to write to the
-      /// path.
-      /// \param[in] _path The full destination path including filename.
-      public: void SaveConfig(const std::string &_path);
-
-      /// \brief Apply a WindowConfig to this window and keep a copy of it.
-      /// \param[in] _config The configuration to apply.
-      /// \return True if successful.
-      public: bool ApplyConfig(const WindowConfig &_config);
-
-      /// \brief Get the current window configuration.
-      /// \return Updated window config
-      public: WindowConfig CurrentWindowConfig() const;
-
-      /// \brief Set the Render engine GUI name passed by the command line
-      /// \param[in] _renderEngine name of the render engine to use
-      public: void SetRenderEngine(const std::string &_renderEngine);
-
-      /// \brief Add a plugin to the window.
-      /// \param [in] _plugin Plugin filename
-      public slots: void OnAddPlugin(QString _plugin);
-
-      /// \brief Return a list of all plugin names found
-      /// \return List with plugin names
-      public: Q_INVOKABLE QStringList PluginListModel() const;
-
-      /// \brief Returns the number of plugins current instantiated in the
-      /// window.
-      /// \return Number of plugins
-      public: Q_INVOKABLE int PluginCount() const;
-
-      /// \brief Sets the number of plugins current instantiated in the
-      /// window.
-      /// \param[in] _pluginCount Number of plugins
-      public: Q_INVOKABLE void SetPluginCount(const int _pluginCount);
-
-      /// \brief Returns the material theme.
-      /// \return Theme (Light / Dark)
-      public: Q_INVOKABLE QString MaterialTheme() const;
-
-      /// \brief Sets the material theme
-      /// \param[in] _materialTheme Theme (Light / Dark)
-      public: Q_INVOKABLE void SetMaterialTheme(
-          const QString &_materialTheme);
-
-      /// \brief Returns the material primary color.
-      /// \return Primary color
-      public: Q_INVOKABLE QString MaterialPrimary() const;
-
-      /// \brief Sets the material primary color
-      /// \param[in] _materialPrimary Primary color
-      public: Q_INVOKABLE void SetMaterialPrimary(
-          const QString &_materialPrimary);
-
-      /// \brief Returns the material accent color.
-      /// \return Accent color
-      public: Q_INVOKABLE QString MaterialAccent() const;
-
-      /// \brief Sets the material accent color
-      /// \param[in] _materialAccent Accent color
-      public: Q_INVOKABLE void SetMaterialAccent(
-          const QString &_materialAccent);
-
-      /// \brief Returns the top toolbar color for light theme.
-      /// \return Toolbar color
-      public: Q_INVOKABLE QString ToolBarColorLight() const;
-
-      /// \brief Sets the top toolbar color for light theme.
-      /// \param[in] _toolBarColorLight Toolbar color
-      public: Q_INVOKABLE void SetToolBarColorLight(
-          const QString &_toolBarColorLight);
-
-      /// \brief Returns the top toolbar text color for light theme.
-      /// \return Toolbar text color
-      public: Q_INVOKABLE QString ToolBarTextColorLight() const;
-
-      /// \brief Sets the top toolbar text color for light theme.
-      /// \param[in] _toolBarTextColorLight Toolbar text color
-      public: Q_INVOKABLE void SetToolBarTextColorLight(
-          const QString &_toolBarTextColorLight);
-
-      /// \brief Returns the top toolbar color for dark theme.
-      /// \return Toolbar color
-      public: Q_INVOKABLE QString ToolBarColorDark() const;
-
-      /// \brief Sets the top toolbar color for dark theme.
-      /// \param[in] _toolBarColorDark Toolbar color
-      public: Q_INVOKABLE void SetToolBarColorDark(
-          const QString &_toolBarColorDark);
-
-      /// \brief Returns the top toolbar text color for dark theme.
-      /// \return Toolbar text color
-      public: Q_INVOKABLE QString ToolBarTextColorDark() const;
-
-      /// \brief Sets the top toolbar text color for dark theme.
-      /// \param[in] _toolBarTextColorDark Toolbar text color
-      public: Q_INVOKABLE void SetToolBarTextColorDark(
-          const QString &_toolBarTextColorDark);
-
-      /// \brief Returns the plugin toolbar color for light theme.
-      /// \return Toolbar color
-      public: Q_INVOKABLE QString PluginToolBarColorLight() const;
-
-      /// \brief Sets the plugin toolbar color for light theme.
-      /// \param[in] _pluginPluginToolBarColorLight Toolbar color
-      public: Q_INVOKABLE void SetPluginToolBarColorLight(
-          const QString &_pluginPluginToolBarColorLight);
-
-      /// \brief Returns the plugin toolbar text color for light theme.
-      /// \return Toolbar text color
-      public: Q_INVOKABLE QString PluginToolBarTextColorLight() const;
-
-      /// \brief Sets the plugin toolbar text color for light theme.
-      /// \param[in] _pluginPluginToolBarTextColorLight Toolbar text color
-      public: Q_INVOKABLE void SetPluginToolBarTextColorLight(
-          const QString &_pluginPluginToolBarTextColorLight);
-
-      /// \brief Returns the plugin toolbar color for dark theme.
-      /// \return Toolbar color
-      public: Q_INVOKABLE QString PluginToolBarColorDark() const;
-
-      /// \brief Sets the plugin toolbar color for dark theme.
-      /// \param[in] _pluginPluginToolBarColorDark Toolbar color
-      public: Q_INVOKABLE void SetPluginToolBarColorDark(
-          const QString &_pluginPluginToolBarColorDark);
-
-      /// \brief Returns the plugin toolbar text color for dark theme.
-      /// \return Toolbar text color
-      public: Q_INVOKABLE QString PluginToolBarTextColorDark() const;
-
-      /// \brief Sets the plugin toolbar text color for dark theme.
-      /// \param[in] _pluginPluginToolBarTextColorDark Toolbar text color
-      public: Q_INVOKABLE void SetPluginToolBarTextColorDark(
-          const QString &_pluginPluginToolBarTextColorDark);
-
-      /// \brief Get the flag to show the side drawer.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ShowDrawer() const;
-
-      /// \brief Set the flag to show the side drawer.
-      /// \param[in] _showDrawer True to show.
-      public: Q_INVOKABLE void SetShowDrawer(const bool _showDrawer);
-
-      /// \brief Get the flag to show the side drawer's default options.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ShowDefaultDrawerOpts() const;
-
-      /// \brief Set the flag to show the side drawer's default options.
-      /// \param[in] _showDefaultDrawerOpts True to show.
-      public: Q_INVOKABLE void SetShowDefaultDrawerOpts(
-          const bool _showDefaultDrawerOpts);
-
-      /// \brief Get the flag to show the plugin menu.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ShowPluginMenu() const;
-
-      /// \brief Set the flag to show the plugin menu.
-      /// \param[in] _showPluginMenu True to show.
-      public: Q_INVOKABLE void SetShowPluginMenu(const bool _showPluginMenu);
-
-      /// \brief Get the action performed when GUI closes without prompt.
-      /// \return The action.
-      public: Q_INVOKABLE ExitAction DefaultExitAction() const;
-
-      /// \brief Set the action performed when GUI closes without prompt.
-      /// \param[in] _defaultExitAction The action.
-      public: Q_INVOKABLE void SetDefaultExitAction(
-        enum ExitAction _defaultExitAction);
-
-      /// \brief Get the flag to show the plugin menu.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ShowDialogOnExit() const;
-
-      /// \brief Set the flag to show the confirmation dialog when exiting.
-      /// \param[in] _showDialogOnExit True to show.
-      public: Q_INVOKABLE void SetShowDialogOnExit(bool _showDialogOnExit);
-
-      /// \brief Get the text of prompt in exit dialog.
-      /// \return Prompt text.
-      public: Q_INVOKABLE QString DialogOnExitText() const;
-
-      /// \brief Set the text of the prompt in exit dialog.
-      /// \param[in] _dialogOnExitText Prompt text.
-      public: Q_INVOKABLE void SetDialogOnExitText(
-        const QString &_dialogOnExitText);
-
-      /// \brief Get the flag to show "shutdown" button in exit dialog.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ExitDialogShowShutdown() const;
-
-      /// \brief Set the flag to show "shutdown" button in exit dialog.
-      /// \param[in] _exitDialogShowShutdown True to show.
-      public: Q_INVOKABLE void SetExitDialogShowShutdown(
-        bool _exitDialogShowShutdown);
-
-      /// \brief Get the flag to show "Close GUI" button in exit dialog.
-      /// \return True to show.
-      public: Q_INVOKABLE bool ExitDialogShowCloseGui() const;
-
-      /// \brief Set the flag to show "Close GUI" button in exit dialog.
-      /// \param[in] _exitDialogShowCloseGui True to show.
-      public: Q_INVOKABLE void SetExitDialogShowCloseGui(
-        bool _exitDialogShowCloseGui);
-
-      /// \brief Get the text of the "shutdown" button in exit dialog.
-      /// \return Button text.
-      public: Q_INVOKABLE QString ExitDialogShutdownText() const;
-
-      /// \brief Set the text of the "shutdown" button in exit dialog.
-      /// \param[in] _exitDialogShutdownText Button text.
-      public: Q_INVOKABLE void SetExitDialogShutdownText(
-        const QString &_exitDialogShutdownText);
-
-      /// \brief Get the text of the "Close GUI" button in exit dialog.
-      /// \return Button text.
-      public: Q_INVOKABLE QString ExitDialogCloseGuiText() const;
-
-      /// \brief Set the text of the "Close GUI" button in exit dialog.
-      /// \param[in] _exitDialogCloseGuiText Button text.
-      public: Q_INVOKABLE void SetExitDialogCloseGuiText(
-        const QString &_exitDialogCloseGuiText);
-
-      /// \brief Get the topic of the server control service.
-      /// \return The service topic.
-      public: Q_INVOKABLE std::string ServerControlService() const;
-
-      /// \brief Set the topic of the server control service.
-      /// \param[in] _service The service topic.
-      public: Q_INVOKABLE void SetServerControlService(
-        const std::string &_service);
-
-      /// \brief Callback when load configuration is selected
-      public slots: void OnLoadConfig(const QString &_path);
-
-      /// \brief Callback when "save configuration" is selected
-      public slots: void OnSaveConfig();
-
-      /// \brief Callback when "save configuration as" is selected
-      public slots: void OnSaveConfigAs(const QString &_path);
-
-      /// \brief Callback when "shutdown simulation" is called
-      public slots: void OnStopServer();
-
-      /// \brief Notifies when the number of plugins has changed.
-      signals: void PluginCountChanged();
-
-      /// \brief Notifies when the theme has changed.
-      signals: void MaterialThemeChanged();
-
-      /// \brief Notifies when the primary color has changed.
-      signals: void MaterialPrimaryChanged();
-
-      /// \brief Notifies when the accent color has changed.
-      signals: void MaterialAccentChanged();
-
-      /// \brief Notifies when the toolbar color light has changed.
-      signals: void ToolBarColorLightChanged();
-
-      /// \brief Notifies when the toolbar text color light has changed.
-      signals: void ToolBarTextColorLightChanged();
-
-      /// \brief Notifies when the toolbar color dark has changed.
-      signals: void ToolBarColorDarkChanged();
-
-      /// \brief Notifies when the toolbar text color dark has changed.
-      signals: void ToolBarTextColorDarkChanged();
-
-      /// \brief Notifies when the toolbar color light has changed.
-      signals: void PluginToolBarColorLightChanged();
-
-      /// \brief Notifies when the toolbar text color light has changed.
-      signals: void PluginToolBarTextColorLightChanged();
-
-      /// \brief Notifies when the toolbar color dark has changed.
-      signals: void PluginToolBarColorDarkChanged();
-
-      /// \brief Notifies when the toolbar text color dark has changed.
-      signals: void PluginToolBarTextColorDarkChanged();
-
-      /// \brief Notifies when the show drawer flag has changed.
-      signals: void ShowDrawerChanged();
-
-      /// \brief Notifies when the show drawer default options flag has changed.
-      signals: void ShowDefaultDrawerOptsChanged();
-
-      /// \brief Notifies when the show menu flag has changed.
-      signals: void ShowPluginMenuChanged();
-
-      /// \brief Notifies when the defaultExitAction has changed.
-      signals: void DefaultExitActionChanged();
-
-      /// \brief Notifies when the showDialogOnExit flag has changed.
-      signals: void ShowDialogOnExitChanged();
-
-      /// \brief Notifies when dialogOnExitText has changed.
-      signals: void DialogOnExitTextChanged();
-
-      /// \brief Notifies when the exitDialogShowShutdown flag has changed.
-      signals: void ExitDialogShowShutdownChanged();
-
-      /// \brief Notifies when the exitDialogShowCloseGui flag has changed.
-      signals: void ExitDialogShowCloseGuiChanged();
-
-      /// \brief Notifies when exitDialogShutdownText has changed.
-      signals: void ExitDialogShutdownTextChanged();
-
-      /// \brief Notifies when exitDialogCloseGuiText has changed.
-      signals: void ExitDialogCloseGuiTextChanged();
-
-      /// \brief Notifies when the window config has changed.
-      signals: void configChanged();
-
-      /// \brief Displays a message to the user
-      /// The message will appear in a snackbar, this message requires to
-      /// click on the botton "Dismiss" to close the dialog.
-      signals: void notify(const QString &_message);
-
-      /// \brief Displays a message to the user
-      /// The message will appear in a snackbar, this message disappear when
-      /// the duration is over, or if the user clicks outside or escape before
-      /// that.
-      /// \param[in] _message Message to show
-      /// \param[in] _duration Time in milliseconds that the message will
-      /// appear
-      signals: void notifyWithDuration(const QString &_message, int _duration);
-
-      /// \internal
-      /// \brief Private data pointer
-      private: std::unique_ptr<MainWindowPrivate> dataPtr;
-    };
-
-    /// \brief Holds configurations related to a MainWindow.
-    struct GZ_GUI_VISIBLE WindowConfig
-    {
-      /// \brief Update this config from an XML string. Only fields present on
-      /// the XML will be overriden / appended / created.
-      /// \param[in] _xml A config XML file in string format
-      /// \return True if successful. It may fail for example if the string
-      /// can't be parsed into XML.
-      bool MergeFromXML(const std::string &_xml);
-
-      /// \brief Return this configuration in XML format as a string.
-      /// \return String containing a complete config file.
-      std::string XMLString() const;
-
-      /// \brief Get whether a property should be ignored
-      /// \return True if it's being ignored
-      bool IsIgnoring(const std::string &_prop) const;
-
-      /// \brief Window X position in px
-      int posX{-1};
-
-      /// \brief Window Y position in px
-      int posY{-1};
-
-      /// \brief Window width in px
-      int width{-1};
-
-      /// \brief Window height in px
-      int height{-1};
-
-      /// \brief Window state (dock configuration)
-      QByteArray state;
-
-      /// \brief Material theme (light / dark)
-      std::string materialTheme{""};
-
-      /// \brief Material primary color
-      std::string materialPrimary{""};
-
-      /// \brief Material accent color
-      std::string materialAccent{""};
-
-      /// \brief Top toolbar color light
-      std::string toolBarColorLight{""};
-
-      /// \brief Top toolbar text color light
-      std::string toolBarTextColorLight{""};
-
-      /// \brief Top toolbar color dark
-      std::string toolBarColorDark{""};
-
-      /// \brief Top toolbar text color dark
-      std::string toolBarTextColorDark{""};
-
-      /// \brief Plugin toolbar color light
-      std::string pluginToolBarColorLight{""};
-
-      /// \brief Plugin toolbar text color light
-      std::string pluginToolBarTextColorLight{""};
-
-      /// \brief Plugin toolbar color dark
-      std::string pluginToolBarColorDark{""};
-
-      /// \brief Plugin toolbar text color dark
-      std::string pluginToolBarTextColorDark{""};
-
-      /// \brief Show the side drawer
-      bool showDrawer{true};
-
-      /// \brief Show the default options of the drawer
-      bool showDefaultDrawerOpts{true};
-
-      /// \brief Show the plugins menu
-      bool showPluginMenu{true};
-
-      /// \brief True if plugins found in plugin paths should be listed under
-      /// the Plugins menu. True by default.
-      bool pluginsFromPaths{true};
-
-      /// \brief List of plugins which should be shown on the list
-      std::vector<std::string> showPlugins;
-
-      /// \brief List of window properties which should be ignored on load
-      std::set<std::string> ignoredProps;
-
-      /// \brief Concatenation of all plugin configurations.
-      std::string plugins{""};
-    };
-  }
-}
+Q_NAMESPACE
+class MainWindowPrivate;
+struct WindowConfig;
+
+/// \brief The action executed when GUI is closed without prompt.
+enum class ExitAction
+{
+  /// \brief Close GUI and leave server running
+  CLOSE_GUI,
+  /// \brief Close GUI and shutdown server
+  SHUTDOWN_SERVER,
+};
+/// \cond DO_NOT_DOCUMENT
+Q_ENUM_NS(ExitAction)
+/// \endcond
+
+/// \brief The main window class creates a QQuickWindow and acts as an
+/// interface which provides properties and functions which can be called
+/// from Main.qml
+class GZ_GUI_VISIBLE MainWindow : public QObject
+{
+  Q_OBJECT
+
+  /// \brief Number of plugins currently instantiated inside the window.
+  Q_PROPERTY(
+    int pluginCount
+    READ PluginCount
+    WRITE SetPluginCount
+    NOTIFY PluginCountChanged
+  )
+
+  /// \brief Material theme (Light / Dark)
+  Q_PROPERTY(
+    QString materialTheme
+    READ MaterialTheme
+    WRITE SetMaterialTheme
+    NOTIFY MaterialThemeChanged
+  )
+
+  /// \brief Material primary color (Pre-defined color name or hex value)
+  Q_PROPERTY(
+    QString materialPrimary
+    READ MaterialPrimary
+    WRITE SetMaterialPrimary
+    NOTIFY MaterialPrimaryChanged
+  )
+
+  /// \brief Material accent color (Pre-defined color name or hex value)
+  Q_PROPERTY(
+    QString materialAccent
+    READ MaterialAccent
+    WRITE SetMaterialAccent
+    NOTIFY MaterialAccentChanged
+  )
+
+  /// \brief Top toolbar color for light theme (Pre-defined color name or
+  /// hex value). Defaults to material primary.
+  Q_PROPERTY(
+    QString toolBarColorLight
+    READ ToolBarColorLight
+    WRITE SetToolBarColorLight
+    NOTIFY ToolBarColorLightChanged
+  )
+
+  /// \brief Top toolbar text color for light theme (Pre-defined color name
+  /// or hex value). Defaults to material background.
+  Q_PROPERTY(
+    QString toolBarTextColorLight
+    READ ToolBarTextColorLight
+    WRITE SetToolBarTextColorLight
+    NOTIFY ToolBarTextColorLightChanged
+  )
+
+  /// \brief Top toolbar color for dark theme (Pre-defined color name or
+  /// hex value). Defaults to material primary.
+  Q_PROPERTY(
+    QString toolBarColorDark
+    READ ToolBarColorDark
+    WRITE SetToolBarColorDark
+    NOTIFY ToolBarColorDarkChanged
+  )
+
+  /// \brief Top toolbar text color for dark theme (Pre-defined color name
+  /// or hex value). Defaults to material background.
+  Q_PROPERTY(
+    QString toolBarTextColorDark
+    READ ToolBarTextColorDark
+    WRITE SetToolBarTextColorDark
+    NOTIFY ToolBarTextColorDarkChanged
+  )
+
+  /// \brief Plugin toolbar color for light theme (Pre-defined color name or
+  /// hex value). Defaults to material accent.
+  Q_PROPERTY(
+    QString pluginToolBarColorLight
+    READ PluginToolBarColorLight
+    WRITE SetPluginToolBarColorLight
+    NOTIFY PluginToolBarColorLightChanged
+  )
+
+  /// \brief Plugin toolbar text color for light theme (Pre-defined color
+  /// name or hex value). Defaults to material foreground.
+  Q_PROPERTY(
+    QString pluginToolBarTextColorLight
+    READ PluginToolBarTextColorLight
+    WRITE SetPluginToolBarTextColorLight
+    NOTIFY PluginToolBarTextColorLightChanged
+  )
+
+  /// \brief Plugin toolbar color for dark theme (Pre-defined color name or
+  /// hex value). Defaults to material accent.
+  Q_PROPERTY(
+    QString pluginToolBarColorDark
+    READ PluginToolBarColorDark
+    WRITE SetPluginToolBarColorDark
+    NOTIFY PluginToolBarColorDarkChanged
+  )
+
+  /// \brief Plugin toolbar text color for dark theme (Pre-defined color
+  /// name or hex value). Defaults to material foreground.
+  Q_PROPERTY(
+    QString pluginToolBarTextColorDark
+    READ PluginToolBarTextColorDark
+    WRITE SetPluginToolBarTextColorDark
+    NOTIFY PluginToolBarTextColorDarkChanged
+  )
+
+  /// \brief Flag to show side drawer
+  Q_PROPERTY(
+    bool showDrawer
+    READ ShowDrawer
+    WRITE SetShowDrawer
+    NOTIFY ShowDrawerChanged
+  )
+
+  /// \brief Flag to show side drawer's default options
+  Q_PROPERTY(
+    bool showDefaultDrawerOpts
+    READ ShowDefaultDrawerOpts
+    WRITE SetShowDefaultDrawerOpts
+    NOTIFY ShowDefaultDrawerOptsChanged
+  )
+
+  /// \brief Flag to show plugins menu
+  Q_PROPERTY(
+    bool showPluginMenu
+    READ ShowPluginMenu
+    WRITE SetShowPluginMenu
+    NOTIFY ShowPluginMenuChanged
+  )
+
+  /// \brief Flag to enable confirmation dialog on exit
+  Q_PROPERTY(
+    ExitAction defaultExitAction
+    READ DefaultExitAction
+    WRITE SetDefaultExitAction
+    NOTIFY DefaultExitActionChanged
+  )
+
+  /// \brief Flag to enable confirmation dialog on exit
+  Q_PROPERTY(
+    bool showDialogOnExit
+    READ ShowDialogOnExit
+    WRITE SetShowDialogOnExit
+    NOTIFY ShowDialogOnExitChanged
+  )
+
+  /// \brief Text of the prompt in confirmation dialog on exit
+  Q_PROPERTY(
+    QString dialogOnExitText
+    READ DialogOnExitText
+    WRITE SetDialogOnExitText
+    NOTIFY DialogOnExitTextChanged
+  )
+
+  /// \brief Flag to show "shutdown" button in confirmation dialog on exit
+  Q_PROPERTY(
+    bool exitDialogShowShutdown
+    READ ExitDialogShowShutdown
+    WRITE SetExitDialogShowShutdown
+    NOTIFY ExitDialogShowShutdownChanged
+  )
+
+  /// \brief Flag to show "close GUI" button in confirmation dialog on exit
+  Q_PROPERTY(
+    bool exitDialogShowCloseGui
+    READ ExitDialogShowCloseGui
+    WRITE SetExitDialogShowCloseGui
+    NOTIFY ExitDialogShowCloseGuiChanged
+  )
+
+  /// \brief Text of the "shutdown" button in confirmation dialog on exit
+  Q_PROPERTY(
+    QString exitDialogShutdownText
+    READ ExitDialogShutdownText
+    WRITE SetExitDialogShutdownText
+    NOTIFY ExitDialogShutdownTextChanged
+  )
+
+  /// \brief Text of the "Close GUI" button in confirmation dialog on exit
+  Q_PROPERTY(
+    QString exitDialogCloseGuiText
+    READ ExitDialogCloseGuiText
+    WRITE SetExitDialogCloseGuiText
+    NOTIFY ExitDialogCloseGuiTextChanged
+  )
+
+  /// \brief Constructor
+  public: MainWindow();
+
+  /// \brief Destructor
+  public: virtual ~MainWindow();
+
+  /// \brief Get the QtQuick window created by this object
+  /// \return Pointer to the QtQuick window
+  public: QQuickWindow *QuickWindow() const;
+
+  /// \brief Save current window and plugin configuration to a file on disk.
+  /// Will open an error dialog in case it's not possible to write to the
+  /// path.
+  /// \param[in] _path The full destination path including filename.
+  public: void SaveConfig(const std::string &_path);
+
+  /// \brief Apply a WindowConfig to this window and keep a copy of it.
+  /// \param[in] _config The configuration to apply.
+  /// \return True if successful.
+  public: bool ApplyConfig(const WindowConfig &_config);
+
+  /// \brief Get the current window configuration.
+  /// \return Updated window config
+  public: WindowConfig CurrentWindowConfig() const;
+
+  /// \brief Set the Render engine GUI name passed by the command line
+  /// \param[in] _renderEngine name of the render engine to use
+  public: void SetRenderEngine(const std::string &_renderEngine);
+
+  /// \brief Add a plugin to the window.
+  /// \param [in] _plugin Plugin filename
+  public slots: void OnAddPlugin(QString _plugin);
+
+  /// \brief Return a list of all plugin names found
+  /// \return List with plugin names
+  public: Q_INVOKABLE QStringList PluginListModel() const;
+
+  /// \brief Returns the number of plugins current instantiated in the
+  /// window.
+  /// \return Number of plugins
+  public: Q_INVOKABLE int PluginCount() const;
+
+  /// \brief Sets the number of plugins current instantiated in the
+  /// window.
+  /// \param[in] _pluginCount Number of plugins
+  public: Q_INVOKABLE void SetPluginCount(const int _pluginCount);
+
+  /// \brief Returns the material theme.
+  /// \return Theme (Light / Dark)
+  public: Q_INVOKABLE QString MaterialTheme() const;
+
+  /// \brief Sets the material theme
+  /// \param[in] _materialTheme Theme (Light / Dark)
+  public: Q_INVOKABLE void SetMaterialTheme(
+      const QString &_materialTheme);
+
+  /// \brief Returns the material primary color.
+  /// \return Primary color
+  public: Q_INVOKABLE QString MaterialPrimary() const;
+
+  /// \brief Sets the material primary color
+  /// \param[in] _materialPrimary Primary color
+  public: Q_INVOKABLE void SetMaterialPrimary(
+      const QString &_materialPrimary);
+
+  /// \brief Returns the material accent color.
+  /// \return Accent color
+  public: Q_INVOKABLE QString MaterialAccent() const;
+
+  /// \brief Sets the material accent color
+  /// \param[in] _materialAccent Accent color
+  public: Q_INVOKABLE void SetMaterialAccent(
+      const QString &_materialAccent);
+
+  /// \brief Returns the top toolbar color for light theme.
+  /// \return Toolbar color
+  public: Q_INVOKABLE QString ToolBarColorLight() const;
+
+  /// \brief Sets the top toolbar color for light theme.
+  /// \param[in] _toolBarColorLight Toolbar color
+  public: Q_INVOKABLE void SetToolBarColorLight(
+      const QString &_toolBarColorLight);
+
+  /// \brief Returns the top toolbar text color for light theme.
+  /// \return Toolbar text color
+  public: Q_INVOKABLE QString ToolBarTextColorLight() const;
+
+  /// \brief Sets the top toolbar text color for light theme.
+  /// \param[in] _toolBarTextColorLight Toolbar text color
+  public: Q_INVOKABLE void SetToolBarTextColorLight(
+      const QString &_toolBarTextColorLight);
+
+  /// \brief Returns the top toolbar color for dark theme.
+  /// \return Toolbar color
+  public: Q_INVOKABLE QString ToolBarColorDark() const;
+
+  /// \brief Sets the top toolbar color for dark theme.
+  /// \param[in] _toolBarColorDark Toolbar color
+  public: Q_INVOKABLE void SetToolBarColorDark(
+      const QString &_toolBarColorDark);
+
+  /// \brief Returns the top toolbar text color for dark theme.
+  /// \return Toolbar text color
+  public: Q_INVOKABLE QString ToolBarTextColorDark() const;
+
+  /// \brief Sets the top toolbar text color for dark theme.
+  /// \param[in] _toolBarTextColorDark Toolbar text color
+  public: Q_INVOKABLE void SetToolBarTextColorDark(
+      const QString &_toolBarTextColorDark);
+
+  /// \brief Returns the plugin toolbar color for light theme.
+  /// \return Toolbar color
+  public: Q_INVOKABLE QString PluginToolBarColorLight() const;
+
+  /// \brief Sets the plugin toolbar color for light theme.
+  /// \param[in] _pluginPluginToolBarColorLight Toolbar color
+  public: Q_INVOKABLE void SetPluginToolBarColorLight(
+      const QString &_pluginPluginToolBarColorLight);
+
+  /// \brief Returns the plugin toolbar text color for light theme.
+  /// \return Toolbar text color
+  public: Q_INVOKABLE QString PluginToolBarTextColorLight() const;
+
+  /// \brief Sets the plugin toolbar text color for light theme.
+  /// \param[in] _pluginPluginToolBarTextColorLight Toolbar text color
+  public: Q_INVOKABLE void SetPluginToolBarTextColorLight(
+      const QString &_pluginPluginToolBarTextColorLight);
+
+  /// \brief Returns the plugin toolbar color for dark theme.
+  /// \return Toolbar color
+  public: Q_INVOKABLE QString PluginToolBarColorDark() const;
+
+  /// \brief Sets the plugin toolbar color for dark theme.
+  /// \param[in] _pluginPluginToolBarColorDark Toolbar color
+  public: Q_INVOKABLE void SetPluginToolBarColorDark(
+      const QString &_pluginPluginToolBarColorDark);
+
+  /// \brief Returns the plugin toolbar text color for dark theme.
+  /// \return Toolbar text color
+  public: Q_INVOKABLE QString PluginToolBarTextColorDark() const;
+
+  /// \brief Sets the plugin toolbar text color for dark theme.
+  /// \param[in] _pluginPluginToolBarTextColorDark Toolbar text color
+  public: Q_INVOKABLE void SetPluginToolBarTextColorDark(
+      const QString &_pluginPluginToolBarTextColorDark);
+
+  /// \brief Get the flag to show the side drawer.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ShowDrawer() const;
+
+  /// \brief Set the flag to show the side drawer.
+  /// \param[in] _showDrawer True to show.
+  public: Q_INVOKABLE void SetShowDrawer(const bool _showDrawer);
+
+  /// \brief Get the flag to show the side drawer's default options.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ShowDefaultDrawerOpts() const;
+
+  /// \brief Set the flag to show the side drawer's default options.
+  /// \param[in] _showDefaultDrawerOpts True to show.
+  public: Q_INVOKABLE void SetShowDefaultDrawerOpts(
+      const bool _showDefaultDrawerOpts);
+
+  /// \brief Get the flag to show the plugin menu.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ShowPluginMenu() const;
+
+  /// \brief Set the flag to show the plugin menu.
+  /// \param[in] _showPluginMenu True to show.
+  public: Q_INVOKABLE void SetShowPluginMenu(const bool _showPluginMenu);
+
+  /// \brief Get the action performed when GUI closes without prompt.
+  /// \return The action.
+  public: Q_INVOKABLE ExitAction DefaultExitAction() const;
+
+  /// \brief Set the action performed when GUI closes without prompt.
+  /// \param[in] _defaultExitAction The action.
+  public: Q_INVOKABLE void SetDefaultExitAction(
+    enum ExitAction _defaultExitAction);
+
+  /// \brief Get the flag to show the plugin menu.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ShowDialogOnExit() const;
+
+  /// \brief Set the flag to show the confirmation dialog when exiting.
+  /// \param[in] _showDialogOnExit True to show.
+  public: Q_INVOKABLE void SetShowDialogOnExit(bool _showDialogOnExit);
+
+  /// \brief Get the text of prompt in exit dialog.
+  /// \return Prompt text.
+  public: Q_INVOKABLE QString DialogOnExitText() const;
+
+  /// \brief Set the text of the prompt in exit dialog.
+  /// \param[in] _dialogOnExitText Prompt text.
+  public: Q_INVOKABLE void SetDialogOnExitText(
+    const QString &_dialogOnExitText);
+
+  /// \brief Get the flag to show "shutdown" button in exit dialog.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ExitDialogShowShutdown() const;
+
+  /// \brief Set the flag to show "shutdown" button in exit dialog.
+  /// \param[in] _exitDialogShowShutdown True to show.
+  public: Q_INVOKABLE void SetExitDialogShowShutdown(
+    bool _exitDialogShowShutdown);
+
+  /// \brief Get the flag to show "Close GUI" button in exit dialog.
+  /// \return True to show.
+  public: Q_INVOKABLE bool ExitDialogShowCloseGui() const;
+
+  /// \brief Set the flag to show "Close GUI" button in exit dialog.
+  /// \param[in] _exitDialogShowCloseGui True to show.
+  public: Q_INVOKABLE void SetExitDialogShowCloseGui(
+    bool _exitDialogShowCloseGui);
+
+  /// \brief Get the text of the "shutdown" button in exit dialog.
+  /// \return Button text.
+  public: Q_INVOKABLE QString ExitDialogShutdownText() const;
+
+  /// \brief Set the text of the "shutdown" button in exit dialog.
+  /// \param[in] _exitDialogShutdownText Button text.
+  public: Q_INVOKABLE void SetExitDialogShutdownText(
+    const QString &_exitDialogShutdownText);
+
+  /// \brief Get the text of the "Close GUI" button in exit dialog.
+  /// \return Button text.
+  public: Q_INVOKABLE QString ExitDialogCloseGuiText() const;
+
+  /// \brief Set the text of the "Close GUI" button in exit dialog.
+  /// \param[in] _exitDialogCloseGuiText Button text.
+  public: Q_INVOKABLE void SetExitDialogCloseGuiText(
+    const QString &_exitDialogCloseGuiText);
+
+  /// \brief Get the topic of the server control service.
+  /// \return The service topic.
+  public: Q_INVOKABLE std::string ServerControlService() const;
+
+  /// \brief Set the topic of the server control service.
+  /// \param[in] _service The service topic.
+  public: Q_INVOKABLE void SetServerControlService(
+    const std::string &_service);
+
+  /// \brief Callback when load configuration is selected
+  public slots: void OnLoadConfig(const QString &_path);
+
+  /// \brief Callback when "save configuration" is selected
+  public slots: void OnSaveConfig();
+
+  /// \brief Callback when "save configuration as" is selected
+  public slots: void OnSaveConfigAs(const QString &_path);
+
+  /// \brief Callback when "shutdown simulation" is called
+  public slots: void OnStopServer();
+
+  /// \brief Notifies when the number of plugins has changed.
+  signals: void PluginCountChanged();
+
+  /// \brief Notifies when the theme has changed.
+  signals: void MaterialThemeChanged();
+
+  /// \brief Notifies when the primary color has changed.
+  signals: void MaterialPrimaryChanged();
+
+  /// \brief Notifies when the accent color has changed.
+  signals: void MaterialAccentChanged();
+
+  /// \brief Notifies when the toolbar color light has changed.
+  signals: void ToolBarColorLightChanged();
+
+  /// \brief Notifies when the toolbar text color light has changed.
+  signals: void ToolBarTextColorLightChanged();
+
+  /// \brief Notifies when the toolbar color dark has changed.
+  signals: void ToolBarColorDarkChanged();
+
+  /// \brief Notifies when the toolbar text color dark has changed.
+  signals: void ToolBarTextColorDarkChanged();
+
+  /// \brief Notifies when the toolbar color light has changed.
+  signals: void PluginToolBarColorLightChanged();
+
+  /// \brief Notifies when the toolbar text color light has changed.
+  signals: void PluginToolBarTextColorLightChanged();
+
+  /// \brief Notifies when the toolbar color dark has changed.
+  signals: void PluginToolBarColorDarkChanged();
+
+  /// \brief Notifies when the toolbar text color dark has changed.
+  signals: void PluginToolBarTextColorDarkChanged();
+
+  /// \brief Notifies when the show drawer flag has changed.
+  signals: void ShowDrawerChanged();
+
+  /// \brief Notifies when the show drawer default options flag has changed.
+  signals: void ShowDefaultDrawerOptsChanged();
+
+  /// \brief Notifies when the show menu flag has changed.
+  signals: void ShowPluginMenuChanged();
+
+  /// \brief Notifies when the defaultExitAction has changed.
+  signals: void DefaultExitActionChanged();
+
+  /// \brief Notifies when the showDialogOnExit flag has changed.
+  signals: void ShowDialogOnExitChanged();
+
+  /// \brief Notifies when dialogOnExitText has changed.
+  signals: void DialogOnExitTextChanged();
+
+  /// \brief Notifies when the exitDialogShowShutdown flag has changed.
+  signals: void ExitDialogShowShutdownChanged();
+
+  /// \brief Notifies when the exitDialogShowCloseGui flag has changed.
+  signals: void ExitDialogShowCloseGuiChanged();
+
+  /// \brief Notifies when exitDialogShutdownText has changed.
+  signals: void ExitDialogShutdownTextChanged();
+
+  /// \brief Notifies when exitDialogCloseGuiText has changed.
+  signals: void ExitDialogCloseGuiTextChanged();
+
+  /// \brief Notifies when the window config has changed.
+  signals: void configChanged();
+
+  /// \brief Displays a message to the user
+  /// The message will appear in a snackbar, this message requires to
+  /// click on the botton "Dismiss" to close the dialog.
+  signals: void notify(const QString &_message);
+
+  /// \brief Displays a message to the user
+  /// The message will appear in a snackbar, this message disappear when
+  /// the duration is over, or if the user clicks outside or escape before
+  /// that.
+  /// \param[in] _message Message to show
+  /// \param[in] _duration Time in milliseconds that the message will
+  /// appear
+  signals: void notifyWithDuration(const QString &_message, int _duration);
+
+  /// \internal
+  /// \brief Private data pointer
+  private: std::unique_ptr<MainWindowPrivate> dataPtr;
+};
+
+/// \brief Holds configurations related to a MainWindow.
+struct GZ_GUI_VISIBLE WindowConfig
+{
+  /// \brief Update this config from an XML string. Only fields present on
+  /// the XML will be overriden / appended / created.
+  /// \param[in] _xml A config XML file in string format
+  /// \return True if successful. It may fail for example if the string
+  /// can't be parsed into XML.
+  bool MergeFromXML(const std::string &_xml);
+
+  /// \brief Return this configuration in XML format as a string.
+  /// \return String containing a complete config file.
+  std::string XMLString() const;
+
+  /// \brief Get whether a property should be ignored
+  /// \return True if it's being ignored
+  bool IsIgnoring(const std::string &_prop) const;
+
+  /// \brief Window X position in px
+  int posX{-1};
+
+  /// \brief Window Y position in px
+  int posY{-1};
+
+  /// \brief Window width in px
+  int width{-1};
+
+  /// \brief Window height in px
+  int height{-1};
+
+  /// \brief Window state (dock configuration)
+  QByteArray state;
+
+  /// \brief Material theme (light / dark)
+  std::string materialTheme{""};
+
+  /// \brief Material primary color
+  std::string materialPrimary{""};
+
+  /// \brief Material accent color
+  std::string materialAccent{""};
+
+  /// \brief Top toolbar color light
+  std::string toolBarColorLight{""};
+
+  /// \brief Top toolbar text color light
+  std::string toolBarTextColorLight{""};
+
+  /// \brief Top toolbar color dark
+  std::string toolBarColorDark{""};
+
+  /// \brief Top toolbar text color dark
+  std::string toolBarTextColorDark{""};
+
+  /// \brief Plugin toolbar color light
+  std::string pluginToolBarColorLight{""};
+
+  /// \brief Plugin toolbar text color light
+  std::string pluginToolBarTextColorLight{""};
+
+  /// \brief Plugin toolbar color dark
+  std::string pluginToolBarColorDark{""};
+
+  /// \brief Plugin toolbar text color dark
+  std::string pluginToolBarTextColorDark{""};
+
+  /// \brief Show the side drawer
+  bool showDrawer{true};
+
+  /// \brief Show the default options of the drawer
+  bool showDefaultDrawerOpts{true};
+
+  /// \brief Show the plugins menu
+  bool showPluginMenu{true};
+
+  /// \brief True if plugins found in plugin paths should be listed under
+  /// the Plugins menu. True by default.
+  bool pluginsFromPaths{true};
+
+  /// \brief List of plugins which should be shown on the list
+  std::vector<std::string> showPlugins;
+
+  /// \brief List of window properties which should be ignored on load
+  std::set<std::string> ignoredProps;
+
+  /// \brief Concatenation of all plugin configurations.
+  std::string plugins{""};
+};
+}  // namespace gz::gui
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#endif
+#endif  // GZ_GUI_MAINWINDOW_HH_

--- a/include/gz/gui/PlottingInterface.hh
+++ b/include/gz/gui/PlottingInterface.hh
@@ -38,9 +38,7 @@
 
 #include "gz/gui/Export.hh"
 
-namespace gz
-{
-namespace gui
+namespace gz::gui
 {
 class PlotDataPrivate;
 
@@ -333,7 +331,5 @@ class GZ_GUI_VISIBLE PlottingInterface : public QObject
   private: std::unique_ptr<PlottingIfacePrivate> dataPtr;
 };
 
-}
-}
-
-#endif
+}  // namespace gz::gui
+#endif  // GZ_GUI_PLOTTINGINTERFACE_HH_

--- a/include/gz/gui/Plugin.hh
+++ b/include/gz/gui/Plugin.hh
@@ -31,126 +31,122 @@
 #pragma warning(disable: 4251)
 #endif
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    /// \brief Namespace for all plugins
-    namespace plugins {}
+/// \brief Namespace for all plugins
+namespace plugins {}
 
-    class PluginPrivate;
+class PluginPrivate;
 
-    /// \brief Base class for Gazebo GUI plugins.
-    ///
-    /// When inheriting from this plugin, the following are assumed:
-    ///
-    /// * The derived class' name is the same as the generated shared library
-    ///   (i.e. if the Publisher class extends Plugin, the library file is
-    ///   libPublisher.so)
-    ///
-    /// * There is a QML file with the same name as the plugin's shared library
-    ///   name.
-    ///   (i.e. there must be a Publisher.qml)
-    ///
-    /// * The QML file is prefixed by the library's name in the QRC file
-    ///   (i.e. the file's resource is found at ':/Publisher/Publisher.qml')
-    class GZ_GUI_VISIBLE Plugin : public QObject
-    {
-      Q_OBJECT
+/// \brief Base class for Gazebo GUI plugins.
+///
+/// When inheriting from this plugin, the following are assumed:
+///
+/// * The derived class' name is the same as the generated shared library
+///   (i.e. if the Publisher class extends Plugin, the library file is
+///   libPublisher.so)
+///
+/// * There is a QML file with the same name as the plugin's shared library
+///   name.
+///   (i.e. there must be a Publisher.qml)
+///
+/// * The QML file is prefixed by the library's name in the QRC file
+///   (i.e. the file's resource is found at ':/Publisher/Publisher.qml')
+class GZ_GUI_VISIBLE Plugin : public QObject
+{
+  Q_OBJECT
 
-      /// \brief Constructor
-      public: Plugin();
+  /// \brief Constructor
+  public: Plugin();
 
-      /// \brief Destructor
-      public: virtual ~Plugin();
+  /// \brief Destructor
+  public: virtual ~Plugin();
 
-      /// \brief Load the plugin with a configuration file.
-      /// This loads the default parameters and then calls LoadConfig(), which
-      /// should be overridden to load custom parameters.
-      ///
-      /// Called when a plugin is first created.
-      /// This function should not be blocking.
-      ///
-      /// \sa Load
-      /// \param[in] _pluginElem Element containing configuration
-      public: void Load(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Load the plugin with a configuration file.
+  /// This loads the default parameters and then calls LoadConfig(), which
+  /// should be overridden to load custom parameters.
+  ///
+  /// Called when a plugin is first created.
+  /// This function should not be blocking.
+  ///
+  /// \sa Load
+  /// \param[in] _pluginElem Element containing configuration
+  public: void Load(const tinyxml2::XMLElement *_pluginElem);
 
-      /// \brief Get the configuration XML as a string
-      /// \return Config element
-      public: virtual std::string ConfigStr();
+  /// \brief Get the configuration XML as a string
+  /// \return Config element
+  public: virtual std::string ConfigStr();
 
-      /// \brief Get the card item which contains this plugin. The item is
-      /// generated the first time this function is run.
-      /// \return Pointer to card item.
-      public: QQuickItem *CardItem() const;
+  /// \brief Get the card item which contains this plugin. The item is
+  /// generated the first time this function is run.
+  /// \return Pointer to card item.
+  public: QQuickItem *CardItem() const;
 
-      /// \brief Get the plugin item.
-      /// \return Pointer to plugin item.
-      public: QQuickItem *PluginItem() const;
+  /// \brief Get the plugin item.
+  /// \return Pointer to plugin item.
+  public: QQuickItem *PluginItem() const;
 
-      /// \brief Get the QML context where the plugin was created.
-      /// \return Pointer context.
-      public: QQmlContext *Context() const;
+  /// \brief Get the QML context where the plugin was created.
+  /// \return Pointer context.
+  public: QQmlContext *Context() const;
 
-      /// \brief Apply changes which should come after the plugin already
-      /// has a parent.
-      public: void PostParentChanges();
+  /// \brief Apply changes which should come after the plugin already
+  /// has a parent.
+  public: void PostParentChanges();
 
-      /// \brief Load the plugin with a configuration file. Override this
-      /// on custom plugins to handle custom configurations.
-      ///
-      /// Called when a plugin is first created.
-      /// This function should not be blocking.
-      ///
-      /// \sa Load
-      /// \param[in] _pluginElem Element containing configuration
-      protected: virtual void LoadConfig(
-          const tinyxml2::XMLElement *_pluginElem)
-          {
-            (void)_pluginElem;
-          }
+  /// \brief Load the plugin with a configuration file. Override this
+  /// on custom plugins to handle custom configurations.
+  ///
+  /// Called when a plugin is first created.
+  /// This function should not be blocking.
+  ///
+  /// \sa Load
+  /// \param[in] _pluginElem Element containing configuration
+  protected: virtual void LoadConfig(
+      const tinyxml2::XMLElement *_pluginElem)
+      {
+        (void)_pluginElem;
+      }
 
-      /// \brief Get title
-      /// \return Plugin title.
-      public: virtual std::string Title() const {return this->title;}
+  /// \brief Get title
+  /// \return Plugin title.
+  public: virtual std::string Title() const {return this->title;}
 
-      /// \brief Get the value of the the `delete_later` element from the
-      /// configuration file, which defaults to false.
-      /// \return The value of `delete_later`.
-      public: bool DeleteLaterRequested() const;
+  /// \brief Get the value of the the `delete_later` element from the
+  /// configuration file, which defaults to false.
+  /// \return The value of `delete_later`.
+  public: bool DeleteLaterRequested() const;
 
-      /// \brief Wait until the plugin has a parent, then close and delete the
-      /// parent.
-      protected: void DeleteLater();
+  /// \brief Wait until the plugin has a parent, then close and delete the
+  /// parent.
+  protected: void DeleteLater();
 
-      /// \brief Title to be displayed on top of plugin.
-      protected: std::string title = "";
+  /// \brief Title to be displayed on top of plugin.
+  protected: std::string title = "";
 
-      /// \brief XML configuration
-      protected: std::string configStr;
+  /// \brief XML configuration
+  protected: std::string configStr;
 
-      /// \brief Load configuration which is common to all plugins and handled
-      /// by Gazebo GUI.
-      /// \details Called when a plugin is first created.
-      /// \sa LoadConfig
-      /// \param[in] _gzGuiElem <gz-gui> element within the <plugin>.
-      /// Will be nullptr if not present in the SDF.
-      private: virtual void LoadCommonConfig(
-          const tinyxml2::XMLElement *_gzGuiElem);
+  /// \brief Load configuration which is common to all plugins and handled
+  /// by Gazebo GUI.
+  /// \details Called when a plugin is first created.
+  /// \sa LoadConfig
+  /// \param[in] _gzGuiElem <gz-gui> element within the <plugin>.
+  /// Will be nullptr if not present in the SDF.
+  private: virtual void LoadCommonConfig(
+      const tinyxml2::XMLElement *_gzGuiElem);
 
-      /// \brief Apply any anchors which may have been specified on the config
-      /// through the <anchor> tag and any state properties.
-      private: void ApplyAnchors();
+  /// \brief Apply any anchors which may have been specified on the config
+  /// through the <anchor> tag and any state properties.
+  private: void ApplyAnchors();
 
-      /// \internal
-      /// \brief Pointer to private data
-      private: std::unique_ptr<PluginPrivate> dataPtr;
-    };
-  }
-}
+  /// \internal
+  /// \brief Pointer to private data
+  private: std::unique_ptr<PluginPrivate> dataPtr;
+};
+}  // namespace gz::gui
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-
-#endif
+#endif  // GZ_GUI_PLUGIN_HH_

--- a/include/gz/gui/SearchModel.hh
+++ b/include/gz/gui/SearchModel.hh
@@ -20,75 +20,72 @@
 #include "gz/gui/Export.hh"
 #include "gz/gui/qt.h"
 
-namespace gz
+namespace gz::gui
 {
-namespace gui
+/// \brief Customize the proxy model to display search results.
+///
+/// Features:
+///
+/// * This has been tested with QTreeView and QTableView.
+/// * Manages expansion of nested items through DataRole::TO_EXPAND when
+///   applicable
+/// * Items with DataRole::TYPE == "title" are ignored
+///
+class GZ_GUI_VISIBLE SearchModel : public QSortFilterProxyModel
 {
-  /// \brief Customize the proxy model to display search results.
+  /// \brief Overloaded Qt method. Customize so we accept rows where:
+  /// 1. Each of the words can be found in its ancestors or itself, but not
+  /// necessarily all words on the same row, or
+  /// 2. One of its descendants matches rule 1, or
+  /// 3. One of its ancestors matches rule 1.
   ///
-  /// Features:
+  /// For example this structure:
+  /// - a
+  /// -- b
+  /// -- c
+  /// --- d
   ///
-  /// * This has been tested with QTreeView and QTableView.
-  /// * Manages expansion of nested items through DataRole::TO_EXPAND when
-  ///   applicable
-  /// * Items with DataRole::TYPE == "title" are ignored
+  /// * A search of "a" will display all rows.
+  /// * A search of "b" or "a b" will display "a" and "b".
+  /// * A search of "c", "d", "a c", "a d", "a c d" or "c d" will display
+  /// "a", "c" and "d".
+  /// * A search of "a b c d", "b c" or "b d" will display nothing.
   ///
-  class GZ_GUI_VISIBLE SearchModel : public QSortFilterProxyModel
-  {
-    /// \brief Overloaded Qt method. Customize so we accept rows where:
-    /// 1. Each of the words can be found in its ancestors or itself, but not
-    /// necessarily all words on the same row, or
-    /// 2. One of its descendants matches rule 1, or
-    /// 3. One of its ancestors matches rule 1.
-    ///
-    /// For example this structure:
-    /// - a
-    /// -- b
-    /// -- c
-    /// --- d
-    ///
-    /// * A search of "a" will display all rows.
-    /// * A search of "b" or "a b" will display "a" and "b".
-    /// * A search of "c", "d", "a c", "a d", "a c d" or "c d" will display
-    /// "a", "c" and "d".
-    /// * A search of "a b c d", "b c" or "b d" will display nothing.
-    ///
-    /// \param[in] _srcRow Row on the source model.
-    /// \param[in] _srcParent Parent on the source model.
-    /// \return True if row is accepted.
-    public: bool filterAcceptsRow(const int _srcRow,
-                                  const QModelIndex &_srcParent) const;
+  /// \param[in] _srcRow Row on the source model.
+  /// \param[in] _srcParent Parent on the source model.
+  /// \return True if row is accepted.
+  public: bool filterAcceptsRow(const int _srcRow,
+                                const QModelIndex &_srcParent) const;
 
-    /// \brief Check if row contains the word on itself.
-    /// \param[in] _srcRow Row on the source model.
-    /// \param[in] _srcParent Parent on the source model.
-    /// \param[in] _word Word to be checked.
-    /// \return True if row matches.
-    public: bool FilterAcceptsRowItself(const int _srcRow,
-                                        const QModelIndex &_srcParent,
-                                        const QString &_word) const;
+  /// \brief Check if row contains the word on itself.
+  /// \param[in] _srcRow Row on the source model.
+  /// \param[in] _srcParent Parent on the source model.
+  /// \param[in] _word Word to be checked.
+  /// \return True if row matches.
+  public: bool FilterAcceptsRowItself(const int _srcRow,
+                                      const QModelIndex &_srcParent,
+                                      const QString &_word) const;
 
-    /// \brief Check if any of the children is fully accepted.
-    /// \param[in] _srcRow Row on the source model.
-    /// \param[in] _srcParent Parent on the source model.
-    /// \return True if any of the children match.
-    public: bool HasAcceptedChildren(const int _srcRow,
-                                     const QModelIndex &_srcParent) const;
+  /// \brief Check if any of the children is fully accepted.
+  /// \param[in] _srcRow Row on the source model.
+  /// \param[in] _srcParent Parent on the source model.
+  /// \return True if any of the children match.
+  public: bool HasAcceptedChildren(const int _srcRow,
+                                   const QModelIndex &_srcParent) const;
 
-    /// \brief Check if any of the children accepts a specific word.
-    /// \param[in] _srcParent Parent on the source model.
-    /// \param[in] _word Word to be checked.
-    /// \return True if any of the children match.
-    public: bool HasChildAcceptsItself(const QModelIndex &_srcParent,
-                                       const QString &_word) const;
+  /// \brief Check if any of the children accepts a specific word.
+  /// \param[in] _srcParent Parent on the source model.
+  /// \param[in] _word Word to be checked.
+  /// \return True if any of the children match.
+  public: bool HasChildAcceptsItself(const QModelIndex &_srcParent,
+                                     const QString &_word) const;
 
-    /// \brief Set a new search value.
-    /// \param[in] _search Full search string.
-    public: void SetSearch(const QString &_search);
+  /// \brief Set a new search value.
+  /// \param[in] _search Full search string.
+  public: void SetSearch(const QString &_search);
 
-    /// \brief Full search string.
-    public: QString search;
-  };
-}
-}
+  /// \brief Full search string.
+  public: QString search;
+};
+}  // namespace gz::gui
 #endif

--- a/include/gz/gui/gz.hh
+++ b/include/gz/gui/gz.hh
@@ -42,4 +42,4 @@ extern "C" GZ_GUI_VISIBLE void cmdEmptyWindow();
 /// \param[in] _filename Path to a QSS file.
 extern "C" GZ_GUI_VISIBLE void cmdSetStyleFromFile(const char *_filename);
 
-#endif
+#endif  // GZ_GUI_GZ_HH_

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -36,60 +36,55 @@
 
 #include "gz/transport/TopicUtils.hh"
 
-namespace gz
-{
-  namespace gui
-  {
-    class ApplicationPrivate
-    {
-      /// \brief QML engine
-      public: QQmlApplicationEngine *engine{nullptr};
-
-      /// \brief Pointer to main window
-      public: MainWindow *mainWin{nullptr};
-
-      /// \brief Vector of pointers to dialogs
-      public: std::vector<Dialog *> dialogs;
-
-      /// \brief Queue of plugins which should be added to the window
-      public: std::queue<std::shared_ptr<Plugin>> pluginsToAdd;
-
-      /// \brief Vector of pointers to plugins already added, we hang on to
-      /// these until it is ok to unload the plugin's shared library.
-      public: std::vector<std::shared_ptr<Plugin>> pluginsAdded;
-
-      /// \brief Environment variable which holds paths to look for plugins
-      public: std::string pluginPathEnv = "GZ_GUI_PLUGIN_PATH";
-
-      /// \brief Vector of paths to look for plugins
-      public: std::vector<std::string> pluginPaths;
-
-      /// \brief Holds a configuration which may be applied to mainWin once it
-      /// is created by calling applyConfig(). It's no longer needed and
-      /// should not be used after that.
-      public: WindowConfig windowConfig;
-
-      /// \brief The path containing the default configuration file.
-      public: std::string defaultConfigPath;
-
-      public: common::SignalHandler signalHandler;
-
-      /// \brief QT message handler that pipes qt messages into our console
-      /// system.
-      public: static void MessageHandler(QtMsgType _type,
-          const QMessageLogContext &_context, const QString &_msg);
-    };
-  }
-}
-
-using namespace gz;
-using namespace gui;
-
+namespace {
 enum class GZ_COMMON_HIDDEN AvailableAPIs
 {
   OpenGL,
   Vulkan,
   Metal
+};
+}  // namespace
+
+namespace gz::gui
+{
+class ApplicationPrivate
+{
+  /// \brief QML engine
+  public: QQmlApplicationEngine *engine{nullptr};
+
+  /// \brief Pointer to main window
+  public: MainWindow *mainWin{nullptr};
+
+  /// \brief Vector of pointers to dialogs
+  public: std::vector<Dialog *> dialogs;
+
+  /// \brief Queue of plugins which should be added to the window
+  public: std::queue<std::shared_ptr<Plugin>> pluginsToAdd;
+
+  /// \brief Vector of pointers to plugins already added, we hang on to
+  /// these until it is ok to unload the plugin's shared library.
+  public: std::vector<std::shared_ptr<Plugin>> pluginsAdded;
+
+  /// \brief Environment variable which holds paths to look for plugins
+  public: std::string pluginPathEnv = "GZ_GUI_PLUGIN_PATH";
+
+  /// \brief Vector of paths to look for plugins
+  public: std::vector<std::string> pluginPaths;
+
+  /// \brief Holds a configuration which may be applied to mainWin once it
+  /// is created by calling applyConfig(). It's no longer needed and
+  /// should not be used after that.
+  public: WindowConfig windowConfig;
+
+  /// \brief The path containing the default configuration file.
+  public: std::string defaultConfigPath;
+
+  public: common::SignalHandler signalHandler;
+
+  /// \brief QT message handler that pipes qt messages into our console
+  /// system.
+  public: static void MessageHandler(QtMsgType _type,
+      const QMessageLogContext &_context, const QString &_msg);
 };
 
 /////////////////////////////////////////////////
@@ -279,7 +274,7 @@ QQmlApplicationEngine *Application::Engine() const
 }
 
 /////////////////////////////////////////////////
-Application *gz::gui::App()
+Application *App()
 {
   return qobject_cast<Application *>(qGuiApp);
 }
@@ -913,3 +908,4 @@ void ApplicationPrivate::MessageHandler(QtMsgType _type,
       break;
   }
 }
+}  // namepace gz::gui

--- a/src/Application_TEST.cc
+++ b/src/Application_TEST.cc
@@ -26,32 +26,35 @@
 #include "gz/gui/MainWindow.hh"
 #include "gz/gui/Plugin.hh"
 
+using Application = gz::gui::Application;
+using Dialog = gz::gui::Dialog;
+using MainWindow = gz::gui::MainWindow;
+using Plugin = gz::gui::Plugin;
+using WindowType = gz::gui::WindowType;
+
 int g_argc = 1;
 char* g_argv[] =
 {
   reinterpret_cast<char*>(const_cast<char*>("./Application_TEST")),
 };
 
-using namespace gz;
-using namespace gui;
-
 // See https://github.com/gazebosim/gz-gui/issues/75
 //////////////////////////////////////////////////
 TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Constructor))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   // No Qt app
   ASSERT_EQ(nullptr, qGuiApp);
-  ASSERT_EQ(nullptr, App());
+  ASSERT_EQ(nullptr, gz::gui::App());
 
   // One app construct - destruct
   {
     Application app(g_argc, g_argv);
 
     EXPECT_NE(nullptr, qGuiApp);
-    ASSERT_NE(nullptr, App());
-    EXPECT_NE(nullptr, App()->Engine());
+    ASSERT_NE(nullptr, gz::gui::App());
+    EXPECT_NE(nullptr, gz::gui::App()->Engine());
 
     // No crash if argc and argv were correctly set
     QCoreApplication::arguments();
@@ -59,7 +62,7 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Constructor))
 
   // No Qt app
   EXPECT_EQ(nullptr, qGuiApp);
-  EXPECT_EQ(nullptr, App());
+  EXPECT_EQ(nullptr, gz::gui::App());
 }
 
 //////////////////////////////////////////////////
@@ -172,7 +175,7 @@ TEST(ApplicationTest,
 //////////////////////////////////////////////////
 TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadConfig))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   ASSERT_EQ(nullptr, qGuiApp);
 
@@ -222,7 +225,7 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadConfig))
 //////////////////////////////////////////////////
 TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadDefaultConfig))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   ASSERT_EQ(nullptr, qGuiApp);
 
@@ -231,12 +234,12 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadDefaultConfig))
     Application app(g_argc, g_argv);
 
     // Add test plugin to path (referenced in config)
-    auto testBuildPath = common::joinPaths(
+    auto testBuildPath = gz::common::joinPaths(
       std::string(PROJECT_BINARY_PATH), "lib");
     app.AddPluginPath(testBuildPath);
 
     // Set default config file
-    auto configPath = common::joinPaths(
+    auto configPath = gz::common::joinPaths(
       std::string(PROJECT_SOURCE_PATH), "test", "config", "test.config");
     app.SetDefaultConfigPath(configPath);
 
@@ -248,7 +251,7 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(LoadDefaultConfig))
 TEST(ApplicationTest,
     GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(InitializeMainWindow))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   ASSERT_EQ(nullptr, qGuiApp);
 
@@ -272,7 +275,7 @@ TEST(ApplicationTest,
 
     EXPECT_TRUE(app.LoadPlugin("Publisher"));
 
-    auto win = App()->findChild<MainWindow *>();
+    auto win = gz::gui::App()->findChild<MainWindow *>();
     ASSERT_NE(nullptr, win);
 
     // Check plugin count
@@ -300,7 +303,7 @@ TEST(ApplicationTest,
     // Load test config file
     EXPECT_TRUE(app.LoadConfig(testSourcePath + "config/test.config"));
 
-    auto win = App()->findChild<MainWindow *>();
+    auto win = gz::gui::App()->findChild<MainWindow *>();
     ASSERT_NE(nullptr, win);
 
     // Check plugin count
@@ -318,7 +321,7 @@ TEST(ApplicationTest,
 //////////////////////////////////////////////////
 TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Dialog))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   ASSERT_EQ(nullptr, qGuiApp);
 
@@ -393,7 +396,7 @@ TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Dialog))
 /////////////////////////////////////////////////
 TEST(ApplicationTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(messageHandler))
 {
-  common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(4);
 
   ASSERT_EQ(nullptr, qGuiApp);
 

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -21,8 +21,10 @@
 
 #include "gz/gui/Conversions.hh"
 
+namespace gz::gui {
+
 //////////////////////////////////////////////////
-QColor gz::gui::convert(const gz::math::Color &_color)
+QColor convert(const gz::math::Color &_color)
 {
   return QColor(_color.R()*255.0,
                 _color.G()*255.0,
@@ -31,7 +33,7 @@ QColor gz::gui::convert(const gz::math::Color &_color)
 }
 
 //////////////////////////////////////////////////
-gz::math::Color gz::gui::convert(const QColor &_color)
+gz::math::Color convert(const QColor &_color)
 {
   return gz::math::Color(_color.red() / 255.0,
                        _color.green() / 255.0,
@@ -40,31 +42,31 @@ gz::math::Color gz::gui::convert(const QColor &_color)
 }
 
 //////////////////////////////////////////////////
-QPointF gz::gui::convert(const gz::math::Vector2d &_pt)
+QPointF convert(const gz::math::Vector2d &_pt)
 {
   return QPointF(_pt.X(), _pt.Y());
 }
 
 //////////////////////////////////////////////////
-gz::math::Vector2d gz::gui::convert(const QPointF &_pt)
+gz::math::Vector2d convert(const QPointF &_pt)
 {
   return gz::math::Vector2d(_pt.x(), _pt.y());
 }
 
 //////////////////////////////////////////////////
-QVector3D gz::gui::convert(const gz::math::Vector3d &_vec)
+QVector3D convert(const gz::math::Vector3d &_vec)
 {
   return QVector3D(_vec.X(), _vec.Y(), _vec.Z());
 }
 
 //////////////////////////////////////////////////
-gz::math::Vector3d gz::gui::convert(const QVector3D &_vec)
+gz::math::Vector3d convert(const QVector3D &_vec)
 {
   return gz::math::Vector3d(_vec.x(), _vec.y(), _vec.z());
 }
 
 //////////////////////////////////////////////////
-gz::common::MouseEvent gz::gui::convert(const QMouseEvent &_e)
+gz::common::MouseEvent convert(const QMouseEvent &_e)
 {
   common::MouseEvent event;
   event.SetPos(_e.pos().x(), _e.pos().y());
@@ -115,7 +117,7 @@ gz::common::MouseEvent gz::gui::convert(const QMouseEvent &_e)
 }
 
 //////////////////////////////////////////////////
-gz::common::MouseEvent gz::gui::convert(const QWheelEvent &_e)
+gz::common::MouseEvent convert(const QWheelEvent &_e)
 {
   common::MouseEvent event;
 
@@ -152,7 +154,7 @@ gz::common::MouseEvent gz::gui::convert(const QWheelEvent &_e)
 }
 
 //////////////////////////////////////////////////
-gz::common::KeyEvent gz::gui::convert(const QKeyEvent &_e)
+gz::common::KeyEvent convert(const QKeyEvent &_e)
 {
   common::KeyEvent event;
   event.SetKey(_e.key());
@@ -177,4 +179,4 @@ gz::common::KeyEvent gz::gui::convert(const QKeyEvent &_e)
 
   return event;
 }
-
+}  // namespace gz::gui

--- a/src/Dialog.cc
+++ b/src/Dialog.cc
@@ -21,20 +21,13 @@
 #include "gz/gui/Application.hh"
 #include "gz/gui/Dialog.hh"
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    class DialogPrivate
-    {
-      /// \brief Pointer to quick window
-      public: QQuickWindow *quickWindow{nullptr};
-    };
-  }
-}
-
-using namespace gz;
-using namespace gui;
+class DialogPrivate
+{
+  /// \brief Pointer to quick window
+  public: QQuickWindow *quickWindow{nullptr};
+};
 
 /////////////////////////////////////////////////
 Dialog::Dialog()
@@ -176,3 +169,4 @@ std::string Dialog::ReadConfigAttribute(const std::string &_path,
 
   return std::string();
 }
+}  // namespace gz::gui

--- a/src/DragDropModel.cc
+++ b/src/DragDropModel.cc
@@ -18,9 +18,8 @@
 #include "gz/gui/Enums.hh"
 #include "gz/gui/DragDropModel.hh"
 
-using namespace gz;
-using namespace gui;
-
+namespace gz::gui
+{
 /////////////////////////////////////////////////
 QMimeData *DragDropModel::mimeData(const QModelIndexList &_indexes) const
 {
@@ -39,4 +38,4 @@ QMimeData *DragDropModel::mimeData(const QModelIndexList &_indexes) const
 
   return curMimeData;
 }
-
+}  // namespace gz::gui

--- a/src/GuiEvents.cc
+++ b/src/GuiEvents.cc
@@ -17,7 +17,10 @@
 
 #include "gz/gui/GuiEvents.hh"
 
-class gz::gui::events::SnapIntervals::Implementation
+namespace gz::gui::events
+{
+
+class events::SnapIntervals::Implementation
 {
   /// \brief XYZ snapping values in meters, these values must be positive.
   public: math::Vector3d xyz;
@@ -31,85 +34,85 @@ class gz::gui::events::SnapIntervals::Implementation
   public: math::Vector3d scale;
 };
 
-class gz::gui::events::SpawnFromDescription::Implementation
+class SpawnFromDescription::Implementation
 {
   /// \brief The string of the resource to be spawned.
   public: std::string description;
 };
 
-class gz::gui::events::SpawnFromPath::Implementation
+class SpawnFromPath::Implementation
 {
   /// \brief The path of file to be previewed.
   public: std::string filePath;
 };
 
-class gz::gui::events::HoverToScene::Implementation
+class HoverToScene::Implementation
 {
   /// \brief The 3D point over which the user is hovering.
   public: math::Vector3d point;
 };
 
-class gz::gui::events::HoverOnScene::Implementation
+class HoverOnScene::Implementation
 {
   /// \brief The 2D point over which the user is hovering.
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::LeftClickToScene::Implementation
+class LeftClickToScene::Implementation
 {
   /// \brief The 3D point that the user clicked within the scene.
   public: math::Vector3d point;
 };
 
-class gz::gui::events::RightClickToScene::Implementation
+class RightClickToScene::Implementation
 {
   /// \brief The 3D point that the user clicked within the scene.
   public: math::Vector3d point;
 };
 
-class gz::gui::events::DropdownMenuEnabled::Implementation
+class DropdownMenuEnabled::Implementation
 {
   /// \brief The boolean indicating whether the menu is disabled or not
   /// for this event.
   public: bool menuEnabled;
 };
 
-class gz::gui::events::LeftClickOnScene::Implementation
+class LeftClickOnScene::Implementation
 {
   /// \brief Mouse event
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::RightClickOnScene::Implementation
+class RightClickOnScene::Implementation
 {
   /// \brief Mouse event
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::BlockOrbit::Implementation
+class BlockOrbit::Implementation
 {
   public: bool block;
 };
 
-class gz::gui::events::KeyReleaseOnScene::Implementation
+class KeyReleaseOnScene::Implementation
 {
   /// \brief Key event
   public: common::KeyEvent key;
 };
 
-class gz::gui::events::KeyPressOnScene::Implementation
+class KeyPressOnScene::Implementation
 {
   /// \brief Key event
   public: common::KeyEvent key;
 };
 
-class gz::gui::events::SpawnCloneFromName::Implementation
+class SpawnCloneFromName::Implementation
 {
   /// \brief The name of the resource to be cloned
   public: std::string name;
 };
 
-class gz::gui::events::DropOnScene::Implementation
+class DropOnScene::Implementation
 {
   /// \brief The name of the dropped thing
   public: std::string dropText;
@@ -118,37 +121,33 @@ class gz::gui::events::DropOnScene::Implementation
   public: gz::math::Vector2i mouse;
 };
 
-class gz::gui::events::ScrollOnScene::Implementation
+class ScrollOnScene::Implementation
 {
   /// \brief Mouse event with scroll information.
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::DragOnScene::Implementation
+class DragOnScene::Implementation
 {
   /// \brief Mouse event with drag information.
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::MousePressOnScene::Implementation
+class MousePressOnScene::Implementation
 {
   /// \brief Mouse event with press information.
   public: common::MouseEvent mouse;
 };
 
-class gz::gui::events::WorldControl::Implementation
+class WorldControl::Implementation
 {
   /// \brief WorldControl information.
   public: msgs::WorldControl worldControl;
 };
 
-class gz::gui::events::PreRender::Implementation
+class PreRender::Implementation
 {
 };
-
-using namespace gz;
-using namespace gui;
-using namespace events;
 
 /////////////////////////////////////////////////
 SnapIntervals::SnapIntervals(
@@ -430,3 +429,4 @@ PreRender::PreRender()
   : QEvent(kType), dataPtr(utils::MakeImpl<Implementation>())
 {
 }
+}  // namespace gz::gui::events

--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -25,8 +25,11 @@
 #include "gz/gui/Helpers.hh"
 #include "gz/gui/MainWindow.hh"
 
+namespace gz::gui
+{
+
 /////////////////////////////////////////////////
-std::string gz::gui::humanReadable(const std::string &_key)
+std::string humanReadable(const std::string &_key)
 {
   std::string humanKey = _key;
   humanKey[0] = toupper(humanKey[0]);
@@ -35,7 +38,7 @@ std::string gz::gui::humanReadable(const std::string &_key)
 }
 
 /////////////////////////////////////////////////
-std::string gz::gui::unitFromKey(const std::string &_key,
+std::string unitFromKey(const std::string &_key,
     const std::string &_type)
 {
   if (_key == "pos" || _key == "length" || _key == "min_depth")
@@ -110,7 +113,7 @@ std::string gz::gui::unitFromKey(const std::string &_key,
 }
 
 /////////////////////////////////////////////////
-void gz::gui::rangeFromKey(const std::string &_key, double &_min,
+void rangeFromKey(const std::string &_key, double &_min,
     double &_max)
 {
   // Maximum range by default
@@ -139,19 +142,19 @@ void gz::gui::rangeFromKey(const std::string &_key, double &_min,
 }
 
 /////////////////////////////////////////////////
-gz::gui::StringType gz::gui::stringTypeFromKey(
+StringType stringTypeFromKey(
     const std::string &_key)
 {
   if (_key == "innerxml")
   {
-    return gz::gui::StringType::PLAIN_TEXT;
+    return StringType::PLAIN_TEXT;
   }
 
   return StringType::LINE;
 }
 
 /////////////////////////////////////////////////
-std::string gz::gui::uniqueFilePath(const std::string &_pathAndName,
+std::string uniqueFilePath(const std::string &_pathAndName,
     const std::string &_extension)
 {
   std::string result = _pathAndName + "." + _extension;
@@ -168,7 +171,7 @@ std::string gz::gui::uniqueFilePath(const std::string &_pathAndName,
 }
 
 /////////////////////////////////////////////////
-QStringList gz::gui::worldNames()
+QStringList worldNames()
 {
   auto win = App()->findChild<MainWindow *>();
   if (nullptr == win)
@@ -182,7 +185,7 @@ QStringList gz::gui::worldNames()
 }
 
 /////////////////////////////////////////////////
-std::string gz::gui::renderEngineName()
+std::string renderEngineName()
 {
   auto win = App()->findChild<MainWindow *>();
   if (nullptr == win)
@@ -196,7 +199,7 @@ std::string gz::gui::renderEngineName()
 }
 
 /////////////////////////////////////////////////
-std::string gz::gui::renderEngineBackendApiName()
+std::string renderEngineBackendApiName()
 {
   auto win = App()->findChild<MainWindow *>();
   if (nullptr == win)
@@ -210,7 +213,8 @@ std::string gz::gui::renderEngineBackendApiName()
 }
 
 /////////////////////////////////////////////////
-const QString gz::gui::qmlQrcImportPath()
+const QString qmlQrcImportPath()
 {
   return "qrc:/gz-gui-qml/";
 }
+}  // namespace gz::gui

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -29,60 +29,53 @@
 #include "gz/msgs/server_control.pb.h"
 #include "gz/transport/Node.hh"
 
-namespace gz
+namespace gz::gui
 {
-  namespace gui
-  {
-    class MainWindowPrivate
-    {
-      /// \brief Number of plugins on the window
-      public: int pluginCount{0};
+class MainWindowPrivate
+{
+  /// \brief Number of plugins on the window
+  public: int pluginCount{0};
 
-      /// \brief Pointer to quick window
-      public: QQuickWindow *quickWindow{nullptr};
+  /// \brief Pointer to quick window
+  public: QQuickWindow *quickWindow{nullptr};
 
-      /// \brief Configuration for this window.
-      public: WindowConfig windowConfig;
+  /// \brief Configuration for this window.
+  public: WindowConfig windowConfig;
 
-      /// \brief Counts the times the window has been painted
-      public: unsigned int paintCount{0};
+  /// \brief Counts the times the window has been painted
+  public: unsigned int paintCount{0};
 
-      /// \brief Minimum number of paint events to consider the window to be
-      /// fully initialized.
-      public: const unsigned int paintCountMin{20};
+  /// \brief Minimum number of paint events to consider the window to be
+  /// fully initialized.
+  public: const unsigned int paintCountMin{20};
 
-      /// \brief The action executed when GUI is closed without prompt.
-      public: ExitAction defaultExitAction{ExitAction::CLOSE_GUI};
+  /// \brief The action executed when GUI is closed without prompt.
+  public: ExitAction defaultExitAction{ExitAction::CLOSE_GUI};
 
-      /// \brief Show the confirmation dialog on exit
-      public: bool showDialogOnExit{false};
+  /// \brief Show the confirmation dialog on exit
+  public: bool showDialogOnExit{false};
 
-      /// \brief Text of the prompt in the confirmation dialog on exit
-      public: QString dialogOnExitText;
+  /// \brief Text of the prompt in the confirmation dialog on exit
+  public: QString dialogOnExitText;
 
-      /// \brief Show "shutdown" button in exit dialog
-      public: bool exitDialogShowShutdown{false};
+  /// \brief Show "shutdown" button in exit dialog
+  public: bool exitDialogShowShutdown{false};
 
-      /// \brief Show "Close GUI" button in exit dialog
-      public: bool exitDialogShowCloseGui{true};
+  /// \brief Show "Close GUI" button in exit dialog
+  public: bool exitDialogShowCloseGui{true};
 
-      /// \brief Text of "shutdown" button in exit dialog
-      public: QString exitDialogShutdownText;
+  /// \brief Text of "shutdown" button in exit dialog
+  public: QString exitDialogShutdownText;
 
-      /// \brief Text of "Close GUI" button in exit dialog
-      public: QString exitDialogCloseGuiText;
+  /// \brief Text of "Close GUI" button in exit dialog
+  public: QString exitDialogCloseGuiText;
 
-      /// \brief Service to send server control requests
-      public: std::string controlService{"/server_control"};
+  /// \brief Service to send server control requests
+  public: std::string controlService{"/server_control"};
 
-      /// \brief Communication node
-      public: gz::transport::Node node;
-    };
-  }
-}
-
-using namespace gz;
-using namespace gui;
+  /// \brief Communication node
+  public: gz::transport::Node node;
+};
 
 /// \brief Strip last component from a path.
 /// \return Original path without its last component.
@@ -1029,3 +1022,4 @@ void MainWindow::SetServerControlService(const std::string &_service)
 {
   this->dataPtr->controlService = _service;
 }
+}  // namespace gz::gui

--- a/src/PlottingInterface.cc
+++ b/src/PlottingInterface.cc
@@ -29,9 +29,7 @@
 // 1/60 Period like the GuiSystem frequency (60Hz)
 #define MAX_PERIOD_DIFF (0.0166666667)
 
-namespace gz
-{
-namespace gui
+namespace gz::gui
 {
 class PlotDataPrivate
 {
@@ -91,12 +89,6 @@ class PlottingIfacePrivate
   /// \brief timer to update the plotting each time step
   public: QTimer timer;
 };
-
-}
-}
-
-using namespace gz;
-using namespace gui;
 
 //////////////////////////////////////////////////////
 PlotData::PlotData() :
@@ -677,3 +669,4 @@ bool PlottingInterface::exportCSV(QString _path, int _chart,
   }
   return true;
 }
+}  // namespace gz::gui

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -51,7 +51,9 @@ static const std::unordered_set<std::string> kIgnoredProps{
     "pluginName",
     "anchored"};
 
-class gz::gui::PluginPrivate
+namespace gz::gui
+{
+class PluginPrivate
 {
   /// \brief Set this to true if the plugin should be deleted as soon as it has
   ///  a parent.
@@ -583,3 +585,4 @@ void Plugin::ApplyAnchors()
   }
   this->CardItem()->setProperty("anchored", true);
 }
+}  // namespace gz::gui

--- a/src/SearchModel.cc
+++ b/src/SearchModel.cc
@@ -20,9 +20,8 @@
 #include "gz/gui/Enums.hh"
 #include "gz/gui/SearchModel.hh"
 
-using namespace gz;
-using namespace gui;
-
+namespace gz::gui
+{
 /////////////////////////////////////////////////
 bool SearchModel::filterAcceptsRow(const int _srcRow,
       const QModelIndex &_srcParent) const
@@ -155,4 +154,4 @@ void SearchModel::SetSearch(const QString &_search)
   // TopicsStats
   this->layoutChanged();
 }
-
+}  // namespace gz::gui

--- a/src/plugins/camera_fps/CameraFps.cc
+++ b/src/plugins/camera_fps/CameraFps.cc
@@ -29,8 +29,11 @@
 
 #include "CameraFps.hh"
 
+namespace gz::gui::plugins
+{
+
 /// \brief Private data class for CameraFps
-class gz::gui::plugins::CameraFpsPrivate
+class CameraFpsPrivate
 {
   /// \brief Previous camera update time
   public: std::optional<std::chrono::steady_clock::time_point>
@@ -49,10 +52,6 @@ class gz::gui::plugins::CameraFpsPrivate
   /// \brief Camera FPS string value
   public: QString cameraFPSValue;
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 void CameraFps::OnRender()
@@ -125,6 +124,7 @@ void CameraFps::SetCameraFpsValue(const QString &_value)
   this->dataPtr->cameraFPSValue = _value;
   this->CameraFpsValueChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::CameraFps,

--- a/src/plugins/camera_fps/CameraFps.hh
+++ b/src/plugins/camera_fps/CameraFps.hh
@@ -22,59 +22,54 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// Forward declarations
+class CameraFpsPrivate;
+
+/// \brief This plugin displays the GUI camera's Framerate Per Second (FPS)
+class CameraFps : public Plugin
 {
-namespace plugins
-{
-  class CameraFpsPrivate;
+  Q_OBJECT
 
-  /// \brief This plugin displays the GUI camera's Framerate Per Second (FPS)
-  class CameraFps : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Camera frames per second
+  Q_PROPERTY(
+    QString cameraFPSValue
+    READ CameraFpsValue
+    WRITE SetCameraFpsValue
+    NOTIFY CameraFpsValueChanged
+  )
 
-    /// \brief Camera frames per second
-    Q_PROPERTY(
-      QString cameraFPSValue
-      READ CameraFpsValue
-      WRITE SetCameraFpsValue
-      NOTIFY CameraFpsValueChanged
-    )
+  /// \brief Constructor
+  public: CameraFps();
 
-    /// \brief Constructor
-    public: CameraFps();
+  /// \brief Destructor
+  public: virtual ~CameraFps();
 
-    /// \brief Destructor
-    public: virtual ~CameraFps();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  /// \brief Set the camera FPS value string
+  /// \param[in] _value Camera FPS value string
+  public: Q_INVOKABLE void SetCameraFpsValue(const QString &_value);
 
-    /// \brief Set the camera FPS value string
-    /// \param[in] _value Camera FPS value string
-    public: Q_INVOKABLE void SetCameraFpsValue(const QString &_value);
+  /// \brief Get the camera FPS value string
+  /// \return Camera FPS value string
+  public: Q_INVOKABLE QString CameraFpsValue() const;
 
-    /// \brief Get the camera FPS value string
-    /// \return Camera FPS value string
-    public: Q_INVOKABLE QString CameraFpsValue() const;
+  /// \brief Notify that camera FPS value has changed
+  signals: void CameraFpsValueChanged();
 
-    /// \brief Notify that camera FPS value has changed
-    signals: void CameraFpsValueChanged();
+  /// \brief Perform rendering calls in the rendering thread.
+  private: void OnRender();
 
-    /// \brief Perform rendering calls in the rendering thread.
-    private: void OnRender();
+  // Documentation inherited
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<CameraFpsPrivate> dataPtr;
-  };
-}
-}
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<CameraFpsPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_CAMERAFPS_HH_

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -41,8 +41,10 @@
 
 #include "CameraTracking.hh"
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for CameraTracking
-class gz::gui::plugins::CameraTrackingPrivate
+class CameraTrackingPrivate
 {
   /// \brief Perform rendering calls in the rendering thread.
   public: void OnRender();
@@ -155,10 +157,6 @@ class gz::gui::plugins::CameraTrackingPrivate
   /// \brief Timer to keep publishing camera poses.
   public: QTimer *timer{nullptr};
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 void CameraTrackingPrivate::Initialize()
@@ -497,6 +495,7 @@ bool CameraTracking::eventFilter(QObject *_obj, QEvent *_event)
   // Standard event processing
   return QObject::eventFilter(_obj, _event);
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::CameraTracking,

--- a/src/plugins/camera_tracking/CameraTracking.hh
+++ b/src/plugins/camera_tracking/CameraTracking.hh
@@ -22,49 +22,43 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class CameraTrackingPrivate;
+
+/// \brief This plugin provides camera tracking capabilities such as "move to"
+/// and "follow".
+///
+/// Services:
+/// * `/gui/move_to`: Move the user camera to look at a given target,
+///                   identified by name.
+/// * `/gui/move_to/pose`: Move the user camera to a given pose.
+/// * `/gui/follow`: Set the user camera to follow a given target,
+///                   identified by name.
+/// * `/gui/follow/offset`: Set the offset for following.
+///
+/// Topics:
+/// * `/gui/camera/pose`: Publishes the current user camera pose.
+class CameraTracking : public Plugin
 {
-namespace plugins
-{
-  class CameraTrackingPrivate;
+  Q_OBJECT
 
-  /// \brief This plugin provides camera tracking capabilities such as "move to"
-  /// and "follow".
-  ///
-  /// Services:
-  /// * `/gui/move_to`: Move the user camera to look at a given target,
-  ///                   identified by name.
-  /// * `/gui/move_to/pose`: Move the user camera to a given pose.
-  /// * `/gui/follow`: Set the user camera to follow a given target,
-  ///                   identified by name.
-  /// * `/gui/follow/offset`: Set the offset for following.
-  ///
-  /// Topics:
-  /// * `/gui/camera/pose`: Publishes the current user camera pose.
-  class CameraTracking : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: CameraTracking();
 
-    /// \brief Constructor
-    public: CameraTracking();
+  /// \brief Destructor
+  public: virtual ~CameraTracking();
 
-    /// \brief Destructor
-    public: virtual ~CameraTracking();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  // Documentation inherited
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<CameraTrackingPrivate> dataPtr;
-  };
-}
-}
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<CameraTrackingPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_CAMERATRACKING_HH_

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -32,59 +32,55 @@
 
 #include "GridConfig.hh"
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-  struct GridParam
-  {
-    /// \brief Horizontal cell count
-    int hCellCount{20};
+struct GridParam
+{
+  /// \brief Horizontal cell count
+  int hCellCount{20};
 
-    /// \brief Vertical cell count
-    int vCellCount{0};
+  /// \brief Vertical cell count
+  int vCellCount{0};
 
-    /// \brief Cell length
-    double cellLength{1.0};
+  /// \brief Cell length
+  double cellLength{1.0};
 
-    /// \brief 3D pose
-    math::Pose3d pose{math::Pose3d::Zero};
+  /// \brief 3D pose
+  math::Pose3d pose{math::Pose3d::Zero};
 
-    /// \brief Grid color
-    math::Color color{math::Color(0.7f, 0.7f, 0.7f, 1.0f)};
-  };
+  /// \brief Grid color
+  math::Color color{math::Color(0.7f, 0.7f, 0.7f, 1.0f)};
+};
 
-  class GridConfigPrivate
-  {
-    /// \brief List of grid names.
-    public: QStringList nameList;
+class GridConfigPrivate
+{
+  /// \brief List of grid names.
+  public: QStringList nameList;
 
-    /// \brief
-    std::string name;
+  /// \brief
+  std::string name;
 
-    /// \brief Grid parameters
-    public: GridParam gridParam;
+  /// \brief Grid parameters
+  public: GridParam gridParam;
 
-    /// \brief Grids to add at startup
-    public: std::vector<GridParam> startupGrids;
+  /// \brief Grids to add at startup
+  public: std::vector<GridParam> startupGrids;
 
-    /// \brief Pointer to selected grid
-    rendering::GridPtr grid{nullptr};
+  /// \brief Pointer to selected grid
+  rendering::GridPtr grid{nullptr};
 
-    /// \brief Pointer to scene
-    rendering::ScenePtr scene{nullptr};
+  /// \brief Pointer to scene
+  rendering::ScenePtr scene{nullptr};
 
-    /// \brief Flag that indicates whether there are new updates to be rendered.
-    public: bool dirty{false};
+  /// \brief Flag that indicates whether there are new updates to be rendered.
+  public: bool dirty{false};
 
-    /// \brief True if name list needs to be refreshed.
-    public: bool refreshList{true};
+  /// \brief True if name list needs to be refreshed.
+  public: bool refreshList{true};
 
-    /// \brief Visible state
-    bool visible{true};
-  };
-}
-
-using namespace gz;
-using namespace gui;
+  /// \brief Visible state
+  bool visible{true};
+};
 
 /////////////////////////////////////////////////
 GridConfig::GridConfig()
@@ -409,7 +405,8 @@ void GridConfig::RefreshList()
     this->OnName(this->dataPtr->nameList.at(0));
   this->NameListChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(GridConfig,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::GridConfig,
+              gz::gui::Plugin)

--- a/src/plugins/grid_config/GridConfig.hh
+++ b/src/plugins/grid_config/GridConfig.hh
@@ -15,135 +15,131 @@
  *
 */
 
-#ifndef GZ_GUI_GRIDCONFIG_HH_
-#define GZ_GUI_GRIDCONFIG_HH_
+#ifndef GZ_GUI_PLUGINS_GRIDCONFIG_HH_
+#define GZ_GUI_PLUGINS_GRIDCONFIG_HH_
 
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class GridConfigPrivate;
+
+/// \brief Manages grids in a Gazebo Rendering scene. This plugin can be
+/// used for:
+/// * Introspecting grids
+/// * Editing grids
+///
+/// ## Configuration
+///
+/// * \<insert\> : One grid will be inserted at startup for each \<insert\>
+///                tag.
+///   * \<horizontal_cell_count\> : Number of cells in the horizontal
+///                                 direction, defaults to 20.
+///   * \<vertical_cell_count\> : Number of cells in the vertical direction,
+///                               defaults to 0;
+///   * \<cell_length\> : Length of each cell, defaults to 1.
+///   * \<pose\> : Grid pose, defaults to the origin.
+///   * \<color\> : Grid color, defaults to (0.7, 0.7, 0.7, 1.0)
+class GridConfig : public gz::gui::Plugin
 {
-  class GridConfigPrivate;
+  Q_OBJECT
 
-  /// \brief Manages grids in a Gazebo Rendering scene. This plugin can be
-  /// used for:
-  /// * Introspecting grids
-  /// * Editing grids
-  ///
-  /// ## Configuration
-  ///
-  /// * \<insert\> : One grid will be inserted at startup for each \<insert\>
-  ///                tag.
-  ///   * \<horizontal_cell_count\> : Number of cells in the horizontal
-  ///                                 direction, defaults to 20.
-  ///   * \<vertical_cell_count\> : Number of cells in the vertical direction,
-  ///                               defaults to 0;
-  ///   * \<cell_length\> : Length of each cell, defaults to 1.
-  ///   * \<pose\> : Grid pose, defaults to the origin.
-  ///   * \<color\> : Grid color, defaults to (0.7, 0.7, 0.7, 1.0)
-  class GridConfig : public gz::gui::Plugin
-  {
-    Q_OBJECT
+  /// \brief Name list
+  Q_PROPERTY(
+    QStringList nameList
+    READ NameList
+    WRITE SetNameList
+    NOTIFY NameListChanged
+  )
 
-    /// \brief Name list
-    Q_PROPERTY(
-      QStringList nameList
-      READ NameList
-      WRITE SetNameList
-      NOTIFY NameListChanged
-    )
+  /// \brief Constructor
+  public: GridConfig();
 
-    /// \brief Constructor
-    public: GridConfig();
+  /// \brief Destructor
+  public: ~GridConfig() override;
 
-    /// \brief Destructor
-    public: ~GridConfig() override;
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *) override;
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *) override;
+  // Documentation inherited
+  protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
+  /// \brief Create grids defined at startup
+  public: void CreateGrids();
 
-    /// \brief Create grids defined at startup
-    public: void CreateGrids();
+  /// \brief Update grid
+  public: void UpdateGrid();
 
-    /// \brief Update grid
-    public: void UpdateGrid();
+  /// \brief Callback to retrieve existing grid.
+  public: void ConnectToGrid();
 
-    /// \brief Callback to retrieve existing grid.
-    public: void ConnectToGrid();
+  /// \brief Refresh list of grids. This is called in the rendering thread.
+  public: void RefreshList();
 
-    /// \brief Refresh list of grids. This is called in the rendering thread.
-    public: void RefreshList();
+  /// \brief Callback when refresh button is pressed.
+  public slots: void OnRefresh();
 
-    /// \brief Callback when refresh button is pressed.
-    public slots: void OnRefresh();
+  /// \brief Callback when a new name is chosen on the combo box.
+  /// \param[in] _name Grid name
+  public slots: void OnName(const QString &_name);
 
-    /// \brief Callback when a new name is chosen on the combo box.
-    /// \param[in] _name Grid name
-    public slots: void OnName(const QString &_name);
+  /// \brief Get the list of grid names
+  /// \return List of grids.
+  public slots: QStringList NameList() const;
 
-    /// \brief Get the list of grid names
-    /// \return List of grids.
-    public slots: QStringList NameList() const;
+  /// \brief Set the list of names
+  /// \param[in] _nameList List of names
+  public slots: void SetNameList(const QStringList &_nameList);
 
-    /// \brief Set the list of names
-    /// \param[in] _nameList List of names
-    public slots: void SetNameList(const QStringList &_nameList);
+  /// \brief Notify that name list has changed
+  signals: void NameListChanged();
 
-    /// \brief Notify that name list has changed
-    signals: void NameListChanged();
+  /// \brief Callback to update vertical cell count
+  /// \param[in] _cellCount new vertical cell count
+  public slots: void UpdateVCellCount(int _cellCount);
 
-    /// \brief Callback to update vertical cell count
-    /// \param[in] _cellCount new vertical cell count
-    public slots: void UpdateVCellCount(int _cellCount);
+  /// \brief Callback to update horizontal cell count
+  /// \param[in] _cellCount new horizontal cell count
+  public slots: void UpdateHCellCount(int _cellCount);
 
-    /// \brief Callback to update horizontal cell count
-    /// \param[in] _cellCount new horizontal cell count
-    public slots: void UpdateHCellCount(int _cellCount);
+  /// \brief Callback to update cell length
+  /// \param[in] _length new cell length
+  public slots: void UpdateCellLength(double _length);
 
-    /// \brief Callback to update cell length
-    /// \param[in] _length new cell length
-    public slots: void UpdateCellLength(double _length);
+  /// \brief Callback to update grid pose
+  /// \param[in] _x, _y, _z cartesion coordinates
+  /// \param[in] _roll, _pitch, _yaw principal coordinates
+  public slots: void SetPose(double _x, double _y, double _z,
+                             double _roll, double _pitch, double _yaw);
 
-    /// \brief Callback to update grid pose
-    /// \param[in] _x, _y, _z cartesion coordinates
-    /// \param[in] _roll, _pitch, _yaw principal coordinates
-    public slots: void SetPose(double _x, double _y, double _z,
-                               double _roll, double _pitch, double _yaw);
+  /// \brief Callback to update grid color
+  /// \param[in] _r, _g, _b, _a RGB color model with fourth alpha channel
+  public slots: void SetColor(double _r, double _g, double _b, double _a);
 
-    /// \brief Callback to update grid color
-    /// \param[in] _r, _g, _b, _a RGB color model with fourth alpha channel
-    public slots: void SetColor(double _r, double _g, double _b, double _a);
+  /// \brief Callback when checkbox is clicked.
+  /// \param[in] _checked indicates show or hide grid
+  public slots: void OnShow(bool _checked);
 
-    /// \brief Callback when checkbox is clicked.
-    /// \param[in] _checked indicates show or hide grid
-    public slots: void OnShow(bool _checked);
+  /// \brief Notify QML that grid values have changed.
+  /// \param[in] _hCellCount Horizontal cell count
+  /// \param[in] _vCellCount Vertical cell count
+  /// \param[in] _cellLength Cell length
+  /// \param[in] _pos XYZ Position
+  /// \param[in] _rot RPY orientation
+  /// \param[in] _color Grid color
+  signals: void newParams(
+      int _hCellCount,
+      int _vCellCount,
+      double _cellLength,
+      QVector3D _pos,
+      QVector3D _rot,
+      QColor _color);
 
-    /// \brief Notify QML that grid values have changed.
-    /// \param[in] _hCellCount Horizontal cell count
-    /// \param[in] _vCellCount Vertical cell count
-    /// \param[in] _cellLength Cell length
-    /// \param[in] _pos XYZ Position
-    /// \param[in] _rot RPY orientation
-    /// \param[in] _color Grid color
-    signals: void newParams(
-        int _hCellCount,
-        int _vCellCount,
-        double _cellLength,
-        QVector3D _pos,
-        QVector3D _rot,
-        QColor _color);
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<GridConfigPrivate> dataPtr;
-  };
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<GridConfigPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_GRIDCONFIG_HH_

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -33,36 +33,25 @@
 #include "gz/gui/Application.hh"
 #include "gz/gui/MainWindow.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class ImageDisplayPrivate
 {
-namespace plugins
-{
-  class ImageDisplayPrivate
-  {
-    /// \brief List of topics publishing image messages.
-    public: QStringList topicList;
+  /// \brief List of topics publishing image messages.
+  public: QStringList topicList;
 
-    /// \brief Holds data to set as the next image
-    public: msgs::Image imageMsg;
+  /// \brief Holds data to set as the next image
+  public: msgs::Image imageMsg;
 
-    /// \brief Node for communication.
-    public: transport::Node node;
+  /// \brief Node for communication.
+  public: transport::Node node;
 
-    /// \brief Mutex for accessing image data
-    public: std::recursive_mutex imageMutex;
+  /// \brief Mutex for accessing image data
+  public: std::recursive_mutex imageMutex;
 
-    /// \brief To provide images for QML.
-    public: ImageProvider *provider{nullptr};
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief To provide images for QML.
+  public: ImageProvider *provider{nullptr};
+};
 
 /////////////////////////////////////////////////
 ImageDisplay::ImageDisplay()
@@ -274,7 +263,8 @@ void ImageDisplay::SetTopicList(const QStringList &_topicList)
   this->dataPtr->topicList = _topicList;
   this->TopicListChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(ImageDisplay,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::ImageDisplay,
+              gz::gui::Plugin)

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -36,108 +36,101 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
-{
-namespace plugins
-{
-  class ImageDisplayPrivate;
+class ImageDisplayPrivate;
 
-  class ImageProvider : public QQuickImageProvider
+class ImageProvider : public QQuickImageProvider
+{
+  public: ImageProvider()
+     : QQuickImageProvider(QQuickImageProvider::Image)
   {
-    public: ImageProvider()
-       : QQuickImageProvider(QQuickImageProvider::Image)
-    {
-    }
+  }
 
-    public: QImage requestImage(const QString &, QSize *,
-        const QSize &) override
-    {
-      if (!this->img.isNull())
-      {
-        // Must return a copy
-        QImage copy(this->img);
-        return copy;
-      }
-
-      // Placeholder in case we have no image yet
-      QImage i(400, 400, QImage::Format_RGB888);
-      i.fill(QColor(128, 128, 128, 100));
-      return i;
-    }
-
-    public: void SetImage(const QImage &_image)
-    {
-      this->img = _image;
-    }
-
-    private: QImage img;
-  };
-
-  /// \brief Display images coming through a Gazebo Transport topic.
-  ///
-  /// ## Configuration
-  ///
-  /// \<topic\> : Set the topic to receive image messages.
-  /// \<topic_picker\> : Whether to show the topic picker, true by default. If
-  ///                    this is false, a \<topic\> must be specified.
-  class ImageDisplay_EXPORTS_API ImageDisplay : public Plugin
+  public: QImage requestImage(const QString &, QSize *,
+      const QSize &) override
   {
-    Q_OBJECT
+    if (!this->img.isNull())
+    {
+      // Must return a copy
+      QImage copy(this->img);
+      return copy;
+    }
 
-    /// \brief Topic list
-    Q_PROPERTY(
-      QStringList topicList
-      READ TopicList
-      WRITE SetTopicList
-      NOTIFY TopicListChanged
-    )
+    // Placeholder in case we have no image yet
+    QImage i(400, 400, QImage::Format_RGB888);
+    i.fill(QColor(128, 128, 128, 100));
+    return i;
+  }
 
-    /// \brief Constructor
-    public: ImageDisplay();
+  public: void SetImage(const QImage &_image)
+  {
+    this->img = _image;
+  }
 
-    /// \brief Destructor
-    public: virtual ~ImageDisplay();
+  private: QImage img;
+};
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+/// \brief Display images coming through a Gazebo Transport topic.
+///
+/// ## Configuration
+///
+/// \<topic\> : Set the topic to receive image messages.
+/// \<topic_picker\> : Whether to show the topic picker, true by default. If
+///                    this is false, a \<topic\> must be specified.
+class ImageDisplay_EXPORTS_API ImageDisplay : public Plugin
+{
+  Q_OBJECT
 
-    /// \brief Callback when refresh button is pressed.
-    public slots: void OnRefresh();
+  /// \brief Topic list
+  Q_PROPERTY(
+    QStringList topicList
+    READ TopicList
+    WRITE SetTopicList
+    NOTIFY TopicListChanged
+  )
 
-    /// \brief Callback when a new topic is chosen on the combo box.
-    public slots: void OnTopic(const QString _topic);
+  /// \brief Constructor
+  public: ImageDisplay();
 
-    /// \brief Get the topic list as a string, for example
-    /// 'gz.msgs.StringMsg'
-    /// \return Message type
-    public: Q_INVOKABLE QStringList TopicList() const;
+  /// \brief Destructor
+  public: virtual ~ImageDisplay();
 
-    /// \brief Set the topic list from a string, for example
-    /// 'gz.msgs.StringMsg'
-    /// \param[in] _topicList Message type
-    public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    /// \brief Notify that topic list has changed
-    signals: void TopicListChanged();
+  /// \brief Callback when refresh button is pressed.
+  public slots: void OnRefresh();
 
-    /// \brief Notify that a new image has been received.
-    signals: void newImage();
+  /// \brief Callback when a new topic is chosen on the combo box.
+  public slots: void OnTopic(const QString _topic);
 
-    /// \brief Callback in main thread when image changes
-    private slots: void ProcessImage();
+  /// \brief Get the topic list as a string, for example
+  /// 'gz.msgs.StringMsg'
+  /// \return Message type
+  public: Q_INVOKABLE QStringList TopicList() const;
 
-    /// \brief Subscriber callback when new image is received
-    /// \param[in] _msg New image
-    private: void OnImageMsg(const gz::msgs::Image &_msg);
+  /// \brief Set the topic list from a string, for example
+  /// 'gz.msgs.StringMsg'
+  /// \param[in] _topicList Message type
+  public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
 
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<ImageDisplayPrivate> dataPtr;
-  };
-}
-}
-}
+  /// \brief Notify that topic list has changed
+  signals: void TopicListChanged();
 
-#endif
+  /// \brief Notify that a new image has been received.
+  signals: void newImage();
+
+  /// \brief Callback in main thread when image changes
+  private slots: void ProcessImage();
+
+  /// \brief Subscriber callback when new image is received
+  /// \param[in] _msg New image
+  private: void OnImageMsg(const gz::msgs::Image &_msg);
+
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<ImageDisplayPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -43,8 +43,10 @@
 
 #include "InteractiveViewControl.hh"
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for InteractiveViewControl
-class gz::gui::plugins::InteractiveViewControlPrivate
+class InteractiveViewControlPrivate
 {
   /// \brief Perform rendering calls in the rendering thread.
   public: void OnRender();
@@ -143,10 +145,6 @@ class gz::gui::plugins::InteractiveViewControlPrivate
   /// \brief View control sensitivity value. Must be greater than 0.
   public: double viewControlSensitivity = 1.0;
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 void InteractiveViewControlPrivate::OnRender()
@@ -502,6 +500,7 @@ bool InteractiveViewControl::eventFilter(QObject *_obj, QEvent *_event)
   // Standard event processing
   return QObject::eventFilter(_obj, _event);
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::InteractiveViewControl,

--- a/src/plugins/interactive_view_control/InteractiveViewControl.hh
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.hh
@@ -22,56 +22,49 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class InteractiveViewControlPrivate;
+
+/// \brief This Plugin allows to control a user camera with the mouse:
+///
+/// * Drag left button to pan
+/// * Drag middle button to orbit
+/// * Drag right button or scroll wheel to zoom
+///
+/// This plugin also supports changing between perspective and orthographic
+/// projections through the `/gui/camera/view_control` service. Perspective
+/// projection is used by default. For example:
+///
+///     gz service -s /gui/camera/view_control
+///         --reqtype gz.msgs.StringMsg
+///         --reptype gz.msgs.Boolean
+///         --timeout 2000 --req 'data: "ortho"'
+///
+/// Supported options are:
+///
+/// * `orbit`: perspective projection
+/// * `ortho`: orthographic projection
+class InteractiveViewControl : public Plugin
 {
-namespace plugins
-{
-  class InteractiveViewControlPrivate;
+  Q_OBJECT
 
-  /// \brief This Plugin allows to control a user camera with the mouse:
-  ///
-  /// * Drag left button to pan
-  /// * Drag middle button to orbit
-  /// * Drag right button or scroll wheel to zoom
-  ///
-  /// This plugin also supports changing between perspective and orthographic
-  /// projections through the `/gui/camera/view_control` service. Perspective
-  /// projection is used by default. For example:
-  ///
-  ///     gz service -s /gui/camera/view_control
-  ///         --reqtype gz.msgs.StringMsg
-  ///         --reptype gz.msgs.Boolean
-  ///         --timeout 2000 --req 'data: "ortho"'
-  ///
-  /// Supported options are:
-  ///
-  /// * `orbit`: perspective projection
-  /// * `ortho`: orthographic projection
-  class InteractiveViewControl : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: InteractiveViewControl();
 
-    /// \brief Constructor
-    public: InteractiveViewControl();
+  /// \brief Destructor
+  public: virtual ~InteractiveViewControl();
 
-    /// \brief Destructor
-    public: virtual ~InteractiveViewControl();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  // Documentation inherited
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<InteractiveViewControlPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<InteractiveViewControlPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_INTERACTIVEVIEWCONTROL_HH_

--- a/src/plugins/key_publisher/KeyPublisher.cc
+++ b/src/plugins/key_publisher/KeyPublisher.cc
@@ -25,35 +25,28 @@
 
 #include "KeyPublisher.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class KeyPublisherPrivate
 {
-  class KeyPublisherPrivate
+  /// \brief Node for communication
+  public: gz::transport::Node node;
+
+  /// \brief Publisher
+  public: gz::transport::Node::Publisher pub;
+
+  /// \brief Topic
+  public: std::string topic = "keyboard/keypress";
+
+  /// \brief Publish keyboard strokes
+  /// \param[in] key_press Pointer to the keyevent
+  public: void KeyPub(QKeyEvent *_keyPress)
   {
-    /// \brief Node for communication
-    public: gz::transport::Node node;
-
-    /// \brief Publisher
-    public: gz::transport::Node::Publisher pub;
-
-    /// \brief Topic
-    public: std::string topic = "keyboard/keypress";
-
-    /// \brief Publish keyboard strokes
-    /// \param[in] key_press Pointer to the keyevent
-    public: void KeyPub(QKeyEvent *_keyPress)
-    {
-      gz::msgs::Int32 Msg;
-      Msg.set_data(_keyPress->key());
-      pub.Publish(Msg);
-    }
-  };
-}
-}
-
-using namespace gz;
-using namespace gui;
+    gz::msgs::Int32 Msg;
+    Msg.set_data(_keyPress->key());
+    pub.Publish(Msg);
+  }
+};
 
 /////////////////////////////////////////////////
 KeyPublisher::KeyPublisher(): Plugin(), dataPtr(new KeyPublisherPrivate)
@@ -88,7 +81,8 @@ bool KeyPublisher::eventFilter(QObject *_obj, QEvent *_event)
   }
   return QObject::eventFilter(_obj, _event);
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(KeyPublisher,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::KeyPublisher,
+              gz::gui::Plugin)

--- a/src/plugins/key_publisher/KeyPublisher.hh
+++ b/src/plugins/key_publisher/KeyPublisher.hh
@@ -35,9 +35,7 @@
 #include <gz/gui/Plugin.hh>
 #include <gz/transport/Node.hh>
 
-namespace gz
-{
-namespace gui
+namespace gz::gui::plugins
 {
   class KeyPublisherPrivate;
 
@@ -68,7 +66,5 @@ namespace gui
     /// \brief Pointer to private data.
     private: std::unique_ptr<KeyPublisherPrivate> dataPtr;
   };
-}
-}
-
-#endif
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_KEYPUBLISHER_HH_

--- a/src/plugins/key_publisher/KeyPublisher_TEST.cc
+++ b/src/plugins/key_publisher/KeyPublisher_TEST.cc
@@ -30,24 +30,24 @@
 
 #include "KeyPublisher.hh"
 
+using KeyPublisher = gz::gui::plugins::KeyPublisher;
+using MainWindow = gz::gui::MainWindow;
+
 int g_argc = 1;
 char* g_argv[] =
 {
   reinterpret_cast<char*>(const_cast<char*>("./KeyPublisher_TEST")),
 };
 
-using namespace gz;
-using namespace gui;
-
 class KeyPublisherTest : public ::testing::Test
 {
   // Set up function.
   protected: void SetUp() override
     {
-      common::Console::SetVerbosity(4);
+      gz::common::Console::SetVerbosity(4);
 
       this->app.AddPluginPath(
-        common::joinPaths(std::string(PROJECT_BINARY_PATH), "lib"));
+        gz::common::joinPaths(std::string(PROJECT_BINARY_PATH), "lib"));
 
       // Load plugin
       EXPECT_TRUE(this->app.LoadPlugin("KeyPublisher"));
@@ -75,7 +75,7 @@ class KeyPublisherTest : public ::testing::Test
     }
 
   // Callback function to verify key message was sent correctly
-  protected: void VerifyKeypressCb(const msgs::Int32 &_msg)
+  protected: void VerifyKeypressCb(const gz::msgs::Int32 &_msg)
     {
       this->received = true;
       EXPECT_EQ(_msg.data(), this->currentKey);
@@ -102,18 +102,18 @@ class KeyPublisherTest : public ::testing::Test
     }
 
   // Provides an API to load plugins and configuration files.
-  protected: Application app{g_argc, g_argv};
+  protected: gz::gui::Application app{g_argc, g_argv};
 
   // Instance of the main window.
-  protected: MainWindow *win;
+  protected: gz::gui::MainWindow *win;
 
   // List of plugins.
   protected: QList<KeyPublisher *> plugins;
-  protected: KeyPublisher *plugin;
+  protected: gz::gui::plugins::KeyPublisher *plugin;
 
   // Checks if a new key has been received.
   protected: bool received = false;
-  protected: transport::Node node;
+  protected: gz::transport::Node node;
 
   // Current key
   protected: int currentKey = 0;

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -49,8 +49,10 @@
 
 #include "MarkerManager.hh"
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for MarkerManager
-class gz::gui::plugins::MarkerManagerPrivate
+class MarkerManagerPrivate
 {
   /// \brief Update markers based on msgs received
   public: void OnRender();
@@ -139,10 +141,6 @@ class gz::gui::plugins::MarkerManagerPrivate
   /// action with an inexistent marker.
   public: bool warnOnActionFailure{true};
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 void MarkerManagerPrivate::Initialize()
@@ -777,6 +775,7 @@ bool MarkerManager::eventFilter(QObject *_obj, QEvent *_event)
   // Standard event processing
   return QObject::eventFilter(_obj, _event);
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::MarkerManager,

--- a/src/plugins/marker_manager/MarkerManager.hh
+++ b/src/plugins/marker_manager/MarkerManager.hh
@@ -22,47 +22,41 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class MarkerManagerPrivate;
+
+/// \brief This plugin will be in charge of handling the markers in the
+/// scene. It will allow to add, modify or remove markers.
+///
+/// ## Parameters
+///
+/// * `<topic_name>`: Optional. Name of topic for marker service. Defaults
+/// to `/marker`.
+/// * `<stats_topic>`: Optional. Name of topic to receive world stats.
+/// Defaults to `/world/[world name]/stats`.
+/// * `<warn_on_action_failure>`: True to display warnings if the user
+/// attempts to perform an invalid action. Defaults to true.
+class MarkerManager : public Plugin
 {
-namespace plugins
-{
-  class MarkerManagerPrivate;
+  Q_OBJECT
 
-  /// \brief This plugin will be in charge of handling the markers in the
-  /// scene. It will allow to add, modify or remove markers.
-  ///
-  /// ## Parameters
-  ///
-  /// * `<topic_name>`: Optional. Name of topic for marker service. Defaults
-  /// to `/marker`.
-  /// * `<stats_topic>`: Optional. Name of topic to receive world stats.
-  /// Defaults to `/world/[world name]/stats`.
-  /// * `<warn_on_action_failure>`: True to display warnings if the user
-  /// attempts to perform an invalid action. Defaults to true.
-  class MarkerManager : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: MarkerManager();
 
-    /// \brief Constructor
-    public: MarkerManager();
+  /// \brief Destructor
+  public: virtual ~MarkerManager();
 
-    /// \brief Destructor
-    public: virtual ~MarkerManager();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  // Documentation inherited
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<MarkerManagerPrivate> dataPtr;
-  };
-}
-}
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<MarkerManagerPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_MARKERMANAGER_HH_

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -58,8 +58,10 @@
 
 Q_DECLARE_METATYPE(gz::gui::plugins::RenderSync*)
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for GzRenderer
-class gz::gui::plugins::GzRenderer::Implementation
+class GzRenderer::Implementation
 {
   /// \brief Flag to indicate if mouse event is dirty
   public: bool mouseDirty{false};
@@ -151,7 +153,7 @@ class gz::gui::plugins::GzRenderer::Implementation
 ///
 /// For more info see
 /// https://github.com/gazebosim/gz-rendering/issues/304
-class gz::gui::plugins::RenderSync
+class RenderSync
 {
   /// \brief Cond. variable to synchronize rendering on specific events
   /// (e.g. texture resize) or for debugging (e.g. keep
@@ -1683,7 +1685,8 @@ void MinimalScene::SetLoadingError(const QString &_loadingError)
   this->loadingError = _loadingError;
   this->LoadingErrorChanged();
 }
-
+}  // namespace gz::gui::plugins
+//
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::MinimalScene,
               gz::gui::Plugin)

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -33,461 +33,454 @@
 
 #include "MinimalSceneRhi.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief Creates a Gazebo rendering scene and user camera.
+/// It is possible to orbit the camera around the scene with
+/// the mouse. Use other plugins to manage objects in the scene.
+///
+/// Only one plugin displaying a Gazebo Rendering scene can be used at a
+/// time.
+///
+/// ## Configuration
+///
+/// * \<engine\> : Optional render engine name, defaults to 'ogre'. If another
+///                engine is already loaded, that will be used, because only
+///                one engine is supported at a time currently.
+/// * \<scene\> : Optional scene name, defaults to 'scene'. The plugin will
+///               create a scene with this name if there isn't one yet. If
+///               there is already one, a new camera is added to it.
+/// * \<ambient_light\> : Optional color for ambient light, defaults to
+///                       (0.3, 0.3, 0.3, 1.0)
+/// * \<background_color\> : Optional background color, defaults to
+///                          (0.3, 0.3, 0.3, 1.0)
+/// * \<camera_pose\> : Optional starting pose for the camera, defaults to
+///                     (0, 0, 5, 0, 0, 0)
+/// * \<camera_clip\> : Optional near/far clipping distance for camera
+///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
+///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
+/// * \<sky\> : If present, sky is enabled.
+/// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
+///                        defaults to 90
+/// * \<graphics_api\> : Optional graphics API name. Valid choices are:
+///                      'opengl', 'metal'. Defaults to 'opengl'.
+/// * \<view_controller> : Set the view controller (InteractiveViewControl
+///                        currently supports types: ortho or orbit).
+class MinimalScene : public Plugin
 {
-namespace plugins
+  Q_OBJECT
+
+  /// \brief Loading error message
+  Q_PROPERTY(
+    QString loadingError
+    READ LoadingError
+    WRITE SetLoadingError
+    NOTIFY LoadingErrorChanged
+  )
+
+  /// \brief Constructor
+  public: MinimalScene();
+
+  /// \brief Callback when the mouse hovers to a new position.
+  /// \param[in] _mouseX x coordinate of the hovered mouse position.
+  /// \param[in] _mouseY y coordinate of the hovered mouse position.
+  public slots: void OnHovered(int _mouseX, int _mouseY);
+
+  /// \brief Callback when the mouse enters the render window to
+  /// focus the window for mouse/key events
+  public slots: void OnFocusWindow();
+
+  /// \brief Callback when receives a drop event.
+  /// \param[in] _drop Dropped string.
+  /// \param[in] _mouseX x coordinate of mouse position.
+  /// \param[in] _mouseY y coordinate of mouse position.
+  public slots: void OnDropped(const QString &_drop,
+      int _mouseX, int _mouseY);
+
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
+
+  /// \brief Get the loading error string.
+  /// \return String explaining the loading error. If empty, there's no error.
+  public: Q_INVOKABLE QString LoadingError() const;
+
+  /// \brief Set the loading error message.
+  /// \param[in] _loadingError Error message.
+  public: Q_INVOKABLE void SetLoadingError(const QString &_loadingError);
+
+  /// \brief Notify that loading error has changed
+  signals: void LoadingErrorChanged();
+
+  /// \brief Loading error message
+  public: QString loadingError;
+
+  /// \internal
+  /// \brief Pointer to private data.
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
+
+class RenderSync;
+
+/// \brief gz-rendering renderer.
+/// All gz-rendering calls should be performed inside this class as it makes
+/// sure that opengl calls in the underlying render engine do not interfere
+/// with QtQuick's opengl render operations. The main Render function will
+/// render to an offscreen texture and notify via signal and slots when it's
+/// ready to be displayed.
+class GzRenderer
 {
-  /// \brief Creates a Gazebo rendering scene and user camera.
-  /// It is possible to orbit the camera around the scene with
-  /// the mouse. Use other plugins to manage objects in the scene.
-  ///
-  /// Only one plugin displaying a Gazebo Rendering scene can be used at a
-  /// time.
-  ///
-  /// ## Configuration
-  ///
-  /// * \<engine\> : Optional render engine name, defaults to 'ogre'. If another
-  ///                engine is already loaded, that will be used, because only
-  ///                one engine is supported at a time currently.
-  /// * \<scene\> : Optional scene name, defaults to 'scene'. The plugin will
-  ///               create a scene with this name if there isn't one yet. If
-  ///               there is already one, a new camera is added to it.
-  /// * \<ambient_light\> : Optional color for ambient light, defaults to
-  ///                       (0.3, 0.3, 0.3, 1.0)
-  /// * \<background_color\> : Optional background color, defaults to
-  ///                          (0.3, 0.3, 0.3, 1.0)
-  /// * \<camera_pose\> : Optional starting pose for the camera, defaults to
-  ///                     (0, 0, 5, 0, 0, 0)
-  /// * \<camera_clip\> : Optional near/far clipping distance for camera
-  ///     * \<near\> : Camera's near clipping plane distance, defaults to 0.01
-  ///     * \<far\> : Camera's far clipping plane distance, defaults to 1000.0
-  /// * \<sky\> : If present, sky is enabled.
-  /// * \<horizontal_fov\> : Horizontal FOV of the user camera in degrees,
-  ///                        defaults to 90
-  /// * \<graphics_api\> : Optional graphics API name. Valid choices are:
-  ///                      'opengl', 'metal'. Defaults to 'opengl'.
-  /// * \<view_controller> : Set the view controller (InteractiveViewControl
-  ///                        currently supports types: ortho or orbit).
-  class MinimalScene : public Plugin
-  {
-    Q_OBJECT
-
-    /// \brief Loading error message
-    Q_PROPERTY(
-      QString loadingError
-      READ LoadingError
-      WRITE SetLoadingError
-      NOTIFY LoadingErrorChanged
-    )
-
-    /// \brief Constructor
-    public: MinimalScene();
-
-    /// \brief Callback when the mouse hovers to a new position.
-    /// \param[in] _mouseX x coordinate of the hovered mouse position.
-    /// \param[in] _mouseY y coordinate of the hovered mouse position.
-    public slots: void OnHovered(int _mouseX, int _mouseY);
-
-    /// \brief Callback when the mouse enters the render window to
-    /// focus the window for mouse/key events
-    public slots: void OnFocusWindow();
-
-    /// \brief Callback when receives a drop event.
-    /// \param[in] _drop Dropped string.
-    /// \param[in] _mouseX x coordinate of mouse position.
-    /// \param[in] _mouseY y coordinate of mouse position.
-    public slots: void OnDropped(const QString &_drop,
-        int _mouseX, int _mouseY);
-
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
-
-    /// \brief Get the loading error string.
-    /// \return String explaining the loading error. If empty, there's no error.
-    public: Q_INVOKABLE QString LoadingError() const;
-
-    /// \brief Set the loading error message.
-    /// \param[in] _loadingError Error message.
-    public: Q_INVOKABLE void SetLoadingError(const QString &_loadingError);
-
-    /// \brief Notify that loading error has changed
-    signals: void LoadingErrorChanged();
-
-    /// \brief Loading error message
-    public: QString loadingError;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
-  };
-
-  class RenderSync;
-
-  /// \brief gz-rendering renderer.
-  /// All gz-rendering calls should be performed inside this class as it makes
-  /// sure that opengl calls in the underlying render engine do not interfere
-  /// with QtQuick's opengl render operations. The main Render function will
-  /// render to an offscreen texture and notify via signal and slots when it's
-  /// ready to be displayed.
-  class GzRenderer
-  {
-    ///  \brief Constructor
-    public: GzRenderer();
-
-    /// \param[in] _renderSync RenderSync to safely
-    /// synchronize Qt and worker thread (this)
-    /// \param[in] _renderThreadRhi Our caller
-    public: void Render(RenderSync *_renderSync,
-                        RenderThreadRhi &_renderThreadRhi);
+  ///  \brief Constructor
+  public: GzRenderer();
 
-    /// \brief Initialize the render engine and scene.
-    /// On macOS this must be called on the main thread.
-    /// \param[in] _rhi our caller
-    /// \return Error message if initialization failed. If empty, no errors
-    /// occurred.
-    public: std::string Initialize(RenderThreadRhi &_rhi);
+  /// \param[in] _renderSync RenderSync to safely
+  /// synchronize Qt and worker thread (this)
+  /// \param[in] _renderThreadRhi Our caller
+  public: void Render(RenderSync *_renderSync,
+                      RenderThreadRhi &_renderThreadRhi);
 
-    /// \brief Set the graphics API
-    /// \param[in] _graphicsAPI The type of graphics API
-    public: void SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI);
+  /// \brief Initialize the render engine and scene.
+  /// On macOS this must be called on the main thread.
+  /// \param[in] _rhi our caller
+  /// \return Error message if initialization failed. If empty, no errors
+  /// occurred.
+  public: std::string Initialize(RenderThreadRhi &_rhi);
 
-    /// \brief Destroy camera associated with this renderer
-    public: void Destroy();
+  /// \brief Set the graphics API
+  /// \param[in] _graphicsAPI The type of graphics API
+  public: void SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI);
 
-    /// \brief New mouse event triggered
-    /// \param[in] _e New mouse event
-    public: void NewMouseEvent(const common::MouseEvent &_e);
+  /// \brief Destroy camera associated with this renderer
+  public: void Destroy();
 
-    /// \brief New hover event triggered.
-    /// \param[in] _hoverPos Mouse hover screen position
-    public: void NewHoverEvent(const math::Vector2i &_hoverPos);
+  /// \brief New mouse event triggered
+  /// \param[in] _e New mouse event
+  public: void NewMouseEvent(const common::MouseEvent &_e);
 
-    /// \brief New hover event triggered.
-    /// \param[in] _dropText Text dropped on the scene
-    /// \param[in] _dropPos Mouse drop screen position
-    public: void NewDropEvent(const std::string &_dropText,
-      const math::Vector2i &_dropPos);
+  /// \brief New hover event triggered.
+  /// \param[in] _hoverPos Mouse hover screen position
+  public: void NewHoverEvent(const math::Vector2i &_hoverPos);
 
-    /// \brief Handle key press event for snapping
-    /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(const common::KeyEvent &_e);
+  /// \brief New hover event triggered.
+  /// \param[in] _dropText Text dropped on the scene
+  /// \param[in] _dropPos Mouse drop screen position
+  public: void NewDropEvent(const std::string &_dropText,
+    const math::Vector2i &_dropPos);
 
-    /// \brief Handle key release event for snapping
-    /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(const common::KeyEvent &_e);
+  /// \brief Handle key press event for snapping
+  /// \param[in] _e The key event to process.
+  public: void HandleKeyPress(const common::KeyEvent &_e);
 
-    /// \brief Handle mouse event for view control
-    private: void HandleMouseEvent();
+  /// \brief Handle key release event for snapping
+  /// \param[in] _e The key event to process.
+  public: void HandleKeyRelease(const common::KeyEvent &_e);
 
-    /// \brief Broadcasts the currently hovered 3d scene location.
-    private: void BroadcastHoverPos();
+  /// \brief Handle mouse event for view control
+  private: void HandleMouseEvent();
 
-    /// \brief Broadcasts drag events.
-    private: void BroadcastDrag();
+  /// \brief Broadcasts the currently hovered 3d scene location.
+  private: void BroadcastHoverPos();
 
-    /// \brief Broadcasts a left click (release) within the scene
-    private: void BroadcastLeftClick();
+  /// \brief Broadcasts drag events.
+  private: void BroadcastDrag();
 
-    /// \brief Broadcasts a right click (release) within the scene
-    private: void BroadcastRightClick();
+  /// \brief Broadcasts a left click (release) within the scene
+  private: void BroadcastLeftClick();
 
-    /// \brief Broadcasts a mouse press within the scene
-    private: void BroadcastMousePress();
+  /// \brief Broadcasts a right click (release) within the scene
+  private: void BroadcastRightClick();
 
-    /// \brief Broadcasts a scroll event within the scene.
-    private: void BroadcastScroll();
+  /// \brief Broadcasts a mouse press within the scene
+  private: void BroadcastMousePress();
 
-    /// \brief Broadcasts a key release event within the scene
-    private: void BroadcastKeyRelease();
+  /// \brief Broadcasts a scroll event within the scene.
+  private: void BroadcastScroll();
 
-    /// \brief Broadcasts a drop event within the scene
-    private: void BroadcastDrop();
+  /// \brief Broadcasts a key release event within the scene
+  private: void BroadcastKeyRelease();
 
-    /// \brief Broadcasts a key press event within the scene
-    private: void BroadcastKeyPress();
+  /// \brief Broadcasts a drop event within the scene
+  private: void BroadcastDrop();
 
-    /// \brief Render engine to use
-    public: std::string engineName = "ogre";
+  /// \brief Broadcasts a key press event within the scene
+  private: void BroadcastKeyPress();
 
-    /// \brief Unique scene name
-    public: std::string sceneName = "scene";
+  /// \brief Render engine to use
+  public: std::string engineName = "ogre";
 
-    /// \brief Initial Camera pose
-    public: math::Pose3d cameraPose = math::Pose3d(0, 0, 2, 0, 0.4, 0);
+  /// \brief Unique scene name
+  public: std::string sceneName = "scene";
 
-    /// \brief Default camera near clipping plane distance
-    public: double cameraNearClip = 0.01;
+  /// \brief Initial Camera pose
+  public: math::Pose3d cameraPose = math::Pose3d(0, 0, 2, 0, 0.4, 0);
 
-    /// \brief Default camera far clipping plane distance
-    public: double cameraFarClip = 1000.0;
+  /// \brief Default camera near clipping plane distance
+  public: double cameraNearClip = 0.01;
 
-    /// \brief Scene background color
-    public: math::Color backgroundColor = math::Color::Black;
+  /// \brief Default camera far clipping plane distance
+  public: double cameraFarClip = 1000.0;
 
-    /// \brief Ambient color
-    public: math::Color ambientLight = math::Color(0.3f, 0.3f, 0.3f, 1.0f);
+  /// \brief Scene background color
+  public: math::Color backgroundColor = math::Color::Black;
 
-    /// \brief True if engine has been initialized;
-    public: bool initialized = false;
+  /// \brief Ambient color
+  public: math::Color ambientLight = math::Color(0.3f, 0.3f, 0.3f, 1.0f);
 
-    /// \brief Render texture size
-    public: QSize textureSize = QSize(1024, 1024);
+  /// \brief True if engine has been initialized;
+  public: bool initialized = false;
 
-    /// \brief Flag to indicate texture size has changed.
-    public: bool textureDirty = true;
+  /// \brief Render texture size
+  public: QSize textureSize = QSize(1024, 1024);
 
-    /// \brief True if sky is enabled;
-    public: bool skyEnable = false;
+  /// \brief Flag to indicate texture size has changed.
+  public: bool textureDirty = true;
 
-    /// \brief Horizontal FOV of the camera;
-    public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
+  /// \brief True if sky is enabled;
+  public: bool skyEnable = false;
 
-    /// \brief View controller type
-    public: std::string cameraViewController{""};
+  /// \brief Horizontal FOV of the camera;
+  public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 
-    /// \brief Retrieves the internal camera.
-    /// TODO(darksylinc): Remove this hack.
-    public: rendering::CameraPtr Camera();
+  /// \brief View controller type
+  public: std::string cameraViewController{""};
 
-    /// \internal
-    /// \brief Pointer to private data.
-    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
-  };
+  /// \brief Retrieves the internal camera.
+  /// TODO(darksylinc): Remove this hack.
+  public: rendering::CameraPtr Camera();
 
-  /// \brief Rendering thread
-  class RenderThread : public QThread
-  {
-    Q_OBJECT
+  /// \internal
+  /// \brief Pointer to private data.
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
 
-    /// \brief Constructor
-    public: RenderThread();
+/// \brief Rendering thread
+class RenderThread : public QThread
+{
+  Q_OBJECT
 
-    /// \brief Render when safe
-    /// \param[in] _renderSync RenderSync to safely
-    /// synchronize Qt and worker thread (this)
-    public slots: void RenderNext(RenderSync *_renderSync);
+  /// \brief Constructor
+  public: RenderThread();
 
-    /// \brief Shutdown the thread and the render engine
-    public slots: void ShutDown();
+  /// \brief Render when safe
+  /// \param[in] _renderSync RenderSync to safely
+  /// synchronize Qt and worker thread (this)
+  public slots: void RenderNext(RenderSync *_renderSync);
 
-    /// \brief Slot called to update render texture size
-    public slots: void SizeChanged();
+  /// \brief Shutdown the thread and the render engine
+  public slots: void ShutDown();
 
-    /// \brief Signal to indicate that a frame has been rendered and ready
-    /// to be displayed
-    /// \param[in] _texturePtr Pointer to a texture Id
-    /// \param[in] _size Size of the texture
-    signals: void TextureReady(void* _texturePtr, const QSize &_size);
+  /// \brief Slot called to update render texture size
+  public slots: void SizeChanged();
 
-    /// \brief Set a callback to be called in case there are errors.
-    /// \param[in] _cb Error callback
-    public: void SetErrorCb(std::function<void(const QString &)> _cb);
+  /// \brief Signal to indicate that a frame has been rendered and ready
+  /// to be displayed
+  /// \param[in] _texturePtr Pointer to a texture Id
+  /// \param[in] _size Size of the texture
+  signals: void TextureReady(void* _texturePtr, const QSize &_size);
 
-    /// \brief Function to be called if there are errors.
-    public: std::function<void(const QString &)> errorCb;
+  /// \brief Set a callback to be called in case there are errors.
+  /// \param[in] _cb Error callback
+  public: void SetErrorCb(std::function<void(const QString &)> _cb);
 
-    /// \brief Offscreen surface to render to
-    public: QOffscreenSurface *Surface() const;
+  /// \brief Function to be called if there are errors.
+  public: std::function<void(const QString &)> errorCb;
 
-    /// \brief Set the offscreen surface to render to
-    /// \param[in] _surface Off-screen surface format
-    public: void SetSurface(QOffscreenSurface *_surface);
+  /// \brief Offscreen surface to render to
+  public: QOffscreenSurface *Surface() const;
 
-    /// \brief OpenGL context to be passed to the render engine
-    public: QOpenGLContext *Context() const;
+  /// \brief Set the offscreen surface to render to
+  /// \param[in] _surface Off-screen surface format
+  public: void SetSurface(QOffscreenSurface *_surface);
 
-    /// \brief Set the OpenGL context to be passed to the render engine
-    /// \param[in] _context OpenGL context
-    public: void SetContext(QOpenGLContext *_context);
+  /// \brief OpenGL context to be passed to the render engine
+  public: QOpenGLContext *Context() const;
 
-    /// \brief Set the graphics API
-    /// \param[in] _graphicsAPI The type of graphics API
-    public: void SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI);
+  /// \brief Set the OpenGL context to be passed to the render engine
+  /// \param[in] _context OpenGL context
+  public: void SetContext(QOpenGLContext *_context);
 
-    /// \brief Carry out initialisation.
-    /// On macOS this must be run on the main thread
-    public: std::string Initialize();
+  /// \brief Set the graphics API
+  /// \param[in] _graphicsAPI The type of graphics API
+  public: void SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI);
 
-    /// \brief gz-rendering renderer
-    public: GzRenderer gzRenderer;
+  /// \brief Carry out initialisation.
+  /// On macOS this must be run on the main thread
+  public: std::string Initialize();
 
-    /// \brief Pointer to render interface to handle OpenGL/Metal compatibility
-    private: std::unique_ptr<RenderThreadRhi> rhi;
-  };
+  /// \brief gz-rendering renderer
+  public: GzRenderer gzRenderer;
 
-  /// \brief A QQUickItem that manages the render window
-  class RenderWindowItem : public QQuickItem
-  {
-    Q_OBJECT
+  /// \brief Pointer to render interface to handle OpenGL/Metal compatibility
+  private: std::unique_ptr<RenderThreadRhi> rhi;
+};
 
-    /// \brief Constructor
-    /// \param[in] _parent Parent item
-    public: explicit RenderWindowItem(QQuickItem *_parent = nullptr);
+/// \brief A QQUickItem that manages the render window
+class RenderWindowItem : public QQuickItem
+{
+  Q_OBJECT
 
-    public: ~RenderWindowItem();
+  /// \brief Constructor
+  /// \param[in] _parent Parent item
+  public: explicit RenderWindowItem(QQuickItem *_parent = nullptr);
 
-    /// \brief Set background color of render window
-    /// \param[in] _color Color of render window background
-    public: void SetBackgroundColor(const math::Color &_color);
+  public: ~RenderWindowItem();
 
-    /// \brief Set ambient light of render window
-    /// \param[in] _ambient Color of ambient light
-    public: void SetAmbientLight(const math::Color &_ambient);
+  /// \brief Set background color of render window
+  /// \param[in] _color Color of render window background
+  public: void SetBackgroundColor(const math::Color &_color);
 
-    /// \brief Set engine name used to create the render window
-    /// \param[in] _name Name of render engine
-    public: void SetEngineName(const std::string &_name);
+  /// \brief Set ambient light of render window
+  /// \param[in] _ambient Color of ambient light
+  public: void SetAmbientLight(const math::Color &_ambient);
 
-    /// \brief Set name of scene created inside the render window
-    /// \param[in] _name Name of scene
-    public: void SetSceneName(const std::string &_name);
+  /// \brief Set engine name used to create the render window
+  /// \param[in] _name Name of render engine
+  public: void SetEngineName(const std::string &_name);
 
-    /// \brief Set the initial pose the render window camera
-    /// \param[in] _pose Initial camera pose
-    public: void SetCameraPose(const math::Pose3d &_pose);
+  /// \brief Set name of scene created inside the render window
+  /// \param[in] _name Name of scene
+  public: void SetSceneName(const std::string &_name);
 
-    /// \brief Set the render window camera's near clipping plane distance
-    /// \param[in] _near Near clipping plane distance
-    public: void SetCameraNearClip(double _near);
+  /// \brief Set the initial pose the render window camera
+  /// \param[in] _pose Initial camera pose
+  public: void SetCameraPose(const math::Pose3d &_pose);
+
+  /// \brief Set the render window camera's near clipping plane distance
+  /// \param[in] _near Near clipping plane distance
+  public: void SetCameraNearClip(double _near);
+
+  /// \brief Set the render window camera's far clipping plane distance
+  /// \param[in] _far Far clipping plane distance
+  public: void SetCameraFarClip(double _far);
+
+  /// \brief Called when the mouse hovers to a new position.
+  /// \param[in] _hoverPos 2D coordinates of the hovered mouse position on
+  /// the render window.
+  public: void OnHovered(const gz::math::Vector2i &_hoverPos);
+
+  /// \brief Callback when receives a drop event.
+  /// \param[in] _drop Dropped string.
+  /// \param[in] _dropPos x coordinate of mouse position.
+  public: void OnDropped(const QString &_drop,
+      const gz::math::Vector2i &_dropPos);
+
+  /// \brief Set if sky is enabled
+  /// \param[in] _sky True to enable the sky, false otherwise.
+  public: void SetSkyEnabled(const bool &_sky);
+
+  /// \brief Set the Horizontal FOV of the camera
+  /// \param[in] _fov FOV of the camera in degree
+  public: void SetCameraHFOV(const math::Angle &_fov);
+
+  /// \brief Set the graphics API
+  /// \param[in] _graphicsAPI The type of graphics API
+  public: void SetGraphicsAPI(const rendering::GraphicsAPI& _graphicsAPI);
+
+  /// \brief Set the camera view controller
+  /// \param[in] _view_controller The camera view controller type to set
+  public: void SetCameraViewController(const std::string &_view_controller);
 
-    /// \brief Set the render window camera's far clipping plane distance
-    /// \param[in] _far Far clipping plane distance
-    public: void SetCameraFarClip(double _far);
+  /// \brief Slot called when thread is ready to be started
+  public Q_SLOTS: void Ready();
 
-    /// \brief Called when the mouse hovers to a new position.
-    /// \param[in] _hoverPos 2D coordinates of the hovered mouse position on
-    /// the render window.
-    public: void OnHovered(const gz::math::Vector2i &_hoverPos);
-
-    /// \brief Callback when receives a drop event.
-    /// \param[in] _drop Dropped string.
-    /// \param[in] _dropPos x coordinate of mouse position.
-    public: void OnDropped(const QString &_drop,
-        const gz::math::Vector2i &_dropPos);
-
-    /// \brief Set if sky is enabled
-    /// \param[in] _sky True to enable the sky, false otherwise.
-    public: void SetSkyEnabled(const bool &_sky);
-
-    /// \brief Set the Horizontal FOV of the camera
-    /// \param[in] _fov FOV of the camera in degree
-    public: void SetCameraHFOV(const math::Angle &_fov);
-
-    /// \brief Set the graphics API
-    /// \param[in] _graphicsAPI The type of graphics API
-    public: void SetGraphicsAPI(const rendering::GraphicsAPI& _graphicsAPI);
-
-    /// \brief Set the camera view controller
-    /// \param[in] _view_controller The camera view controller type to set
-    public: void SetCameraViewController(const std::string &_view_controller);
-
-    /// \brief Slot called when thread is ready to be started
-    public Q_SLOTS: void Ready();
-
-    /// \brief Handle key press event for snapping
-    /// \param[in] _e The key event to process.
-    public: void HandleKeyPress(const common::KeyEvent &_e);
-
-    /// \brief Handle key release event for snapping
-    /// \param[in] _e The key event to process.
-    public: void HandleKeyRelease(const common::KeyEvent &_e);
-
-    /// \brief Set a callback to be called in case there are errors.
-    /// \param[in] _cb Error callback
-    public: void SetErrorCb(std::function<void(const QString &)> _cb);
-
-    /// \brief Stop rendering and shutdown resources.
-    public: void StopRendering();
-
-    // Documentation inherited
-    protected: virtual void mousePressEvent(QMouseEvent *_e) override;
-
-    // Documentation inherited
-    protected: virtual void mouseReleaseEvent(QMouseEvent *_e) override;
-
-    // Documentation inherited
-    protected: virtual void mouseMoveEvent(QMouseEvent *_e) override;
-
-    // Documentation inherited
-    protected: virtual void keyPressEvent(QKeyEvent *_e) override;
-
-    // Documentation inherited
-    protected: virtual void keyReleaseEvent(QKeyEvent *_e) override;
-
-    // Documentation inherited
-    protected: virtual void wheelEvent(QWheelEvent *_e) override;
-
-    /// \brief Overrides the paint event to render the render engine
-    /// camera view
-    /// \param[in] _oldNode The node passed in previous updatePaintNode
-    /// function. It represents the visual representation of the item.
-    /// \param[in] _data The node transformation data.
-    /// \return Updated node.
-    private: QSGNode *updatePaintNode(QSGNode *_oldNode,
-        QQuickItem::UpdatePaintNodeData *_data) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
-  };
-
-  /// \brief Texture node for displaying the render texture from gz-renderer
-  class TextureNode : public QObject, public QSGSimpleTextureNode
-  {
-    Q_OBJECT
-
-    /// \brief Constructor
-    /// \param[in] _window Window to display the texture
-    /// \param[in] _renderSync RenderSync to safely
-    /// synchronize Qt (this) and worker thread
-    /// \param[in] _graphicsAPI The type of graphics API
-    /// \param[in] _camera Camera owning the Texture Handle
-    public: explicit TextureNode(QQuickWindow *_window,
-                                 RenderSync &_renderSync,
-                                 const rendering::GraphicsAPI &_graphicsAPI,
-                                 rendering::CameraPtr &_camera);
-
-    /// \brief Destructor
-    public: ~TextureNode() override;
-
-    /// \brief This function gets called on the FBO rendering thread and will
-    ///  store the texture id and size and schedule an update on the window.
-    /// \param[in] _texturePtr Pointer to a texture Id
-    /// \param[in] _size Texture size
-    // public slots: void NewTexture(uint _id, const QSize &_size);
-    public slots: void NewTexture(void* _texturePtr, const QSize &_size);
-
-    /// \brief Before the scene graph starts to render, we update to the
-    /// pending texture
-    public slots: void PrepareNode();
-
-    /// \param[in] _renderSync RenderSync to send to the worker thread
-    signals: void TextureInUse(RenderSync *_renderSync);
-
-    /// \brief Signal emitted when a new texture is ready to trigger window
-    /// update
-    signals: void PendingNewTexture();
-
-    /// \brief Texture size
-    public: QSize size = QSize(0, 0);
-
-    /// \brief Mutex to protect the texture variables
-    public: QMutex mutex;
-
-    /// \brief See RenderSync
-    public: RenderSync &renderSync;
-
-    /// \brief Qt quick window
-    public: QQuickWindow *window = nullptr;
-
-    /// \brief Pointer to render interface to handle OpenGL/Metal compatibility
-    private: std::unique_ptr<TextureNodeRhi> rhi;
-   };
-}
-}
-}
-
-#endif
+  /// \brief Handle key press event for snapping
+  /// \param[in] _e The key event to process.
+  public: void HandleKeyPress(const common::KeyEvent &_e);
+
+  /// \brief Handle key release event for snapping
+  /// \param[in] _e The key event to process.
+  public: void HandleKeyRelease(const common::KeyEvent &_e);
+
+  /// \brief Set a callback to be called in case there are errors.
+  /// \param[in] _cb Error callback
+  public: void SetErrorCb(std::function<void(const QString &)> _cb);
+
+  /// \brief Stop rendering and shutdown resources.
+  public: void StopRendering();
+
+  // Documentation inherited
+  protected: virtual void mousePressEvent(QMouseEvent *_e) override;
+
+  // Documentation inherited
+  protected: virtual void mouseReleaseEvent(QMouseEvent *_e) override;
+
+  // Documentation inherited
+  protected: virtual void mouseMoveEvent(QMouseEvent *_e) override;
+
+  // Documentation inherited
+  protected: virtual void keyPressEvent(QKeyEvent *_e) override;
+
+  // Documentation inherited
+  protected: virtual void keyReleaseEvent(QKeyEvent *_e) override;
+
+  // Documentation inherited
+  protected: virtual void wheelEvent(QWheelEvent *_e) override;
+
+  /// \brief Overrides the paint event to render the render engine
+  /// camera view
+  /// \param[in] _oldNode The node passed in previous updatePaintNode
+  /// function. It represents the visual representation of the item.
+  /// \param[in] _data The node transformation data.
+  /// \return Updated node.
+  private: QSGNode *updatePaintNode(QSGNode *_oldNode,
+      QQuickItem::UpdatePaintNodeData *_data) override;
+
+  /// \internal
+  /// \brief Pointer to private data.
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
+
+/// \brief Texture node for displaying the render texture from gz-renderer
+class TextureNode : public QObject, public QSGSimpleTextureNode
+{
+  Q_OBJECT
+
+  /// \brief Constructor
+  /// \param[in] _window Window to display the texture
+  /// \param[in] _renderSync RenderSync to safely
+  /// synchronize Qt (this) and worker thread
+  /// \param[in] _graphicsAPI The type of graphics API
+  /// \param[in] _camera Camera owning the Texture Handle
+  public: explicit TextureNode(QQuickWindow *_window,
+                               RenderSync &_renderSync,
+                               const rendering::GraphicsAPI &_graphicsAPI,
+                               rendering::CameraPtr &_camera);
+
+  /// \brief Destructor
+  public: ~TextureNode() override;
+
+  /// \brief This function gets called on the FBO rendering thread and will
+  ///  store the texture id and size and schedule an update on the window.
+  /// \param[in] _texturePtr Pointer to a texture Id
+  /// \param[in] _size Texture size
+  // public slots: void NewTexture(uint _id, const QSize &_size);
+  public slots: void NewTexture(void* _texturePtr, const QSize &_size);
+
+  /// \brief Before the scene graph starts to render, we update to the
+  /// pending texture
+  public slots: void PrepareNode();
+
+  /// \param[in] _renderSync RenderSync to send to the worker thread
+  signals: void TextureInUse(RenderSync *_renderSync);
+
+  /// \brief Signal emitted when a new texture is ready to trigger window
+  /// update
+  signals: void PendingNewTexture();
+
+  /// \brief Texture size
+  public: QSize size = QSize(0, 0);
+
+  /// \brief Mutex to protect the texture variables
+  public: QMutex mutex;
+
+  /// \brief See RenderSync
+  public: RenderSync &renderSync;
+
+  /// \brief Qt quick window
+  public: QQuickWindow *window = nullptr;
+
+  /// \brief Pointer to render interface to handle OpenGL/Metal compatibility
+  private: std::unique_ptr<TextureNodeRhi> rhi;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_HH_

--- a/src/plugins/minimal_scene/MinimalSceneRhi.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhi.hh
@@ -26,111 +26,104 @@
 #include <QSGTexture>
 #include <QSize>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief Render interface class to handle OpenGL / Metal compatibility
+/// of camera textures in GzRenderer
+//
+/// Each supported graphics API must implement this interface
+/// to provide access to the underlying render system's texture.
+///
+/// TODO(anyone): This class doesn't seem to be doing anything at all
+/// Anyone should try to remove it, and if nothing bad happens
+/// (on Ubuntu & macOS) it should be deprecated and removed
+class GzCameraTextureRhi
 {
-namespace plugins
+  /// \brief Destructor
+  public: virtual ~GzCameraTextureRhi();
+
+  /// \brief Update the texture for a camera
+  /// \param[in] _camera Pointer to the camera providing the texture
+  public: virtual void Update(rendering::CameraPtr _camera) = 0;
+};
+
+/// \brief gz-rendering renderer.
+class GzRenderer;
+class RenderSync;
+
+/// \brief Render interface class to handle OpenGL / Metal compatibility
+/// in RenderThread
+class RenderThreadRhi
 {
-  /// \brief Render interface class to handle OpenGL / Metal compatibility
-  /// of camera textures in GzRenderer
+  /// \brief Destructor
+  public: virtual ~RenderThreadRhi();
+
+  /// \brief Offscreen surface to render to
+  public: virtual QOffscreenSurface *Surface() const;
+
+  /// \brief Set the offscreen surface to render to
   //
-  /// Each supported graphics API must implement this interface
-  /// to provide access to the underlying render system's texture.
-  ///
-  /// TODO(anyone): This class doesn't seem to be doing anything at all
-  /// Anyone should try to remove it, and if nothing bad happens
-  /// (on Ubuntu & macOS) it should be deprecated and removed
-  class GzCameraTextureRhi
-  {
-    /// \brief Destructor
-    public: virtual ~GzCameraTextureRhi();
+  /// \param[in] _surface Off-screen surface format
+  public: virtual void SetSurface(QOffscreenSurface *_surface);
 
-    /// \brief Update the texture for a camera
-    /// \param[in] _camera Pointer to the camera providing the texture
-    public: virtual void Update(rendering::CameraPtr _camera) = 0;
-  };
+  /// \brief OpenGL context to be passed to the render engine
+  public: virtual QOpenGLContext *Context() const;
 
-  /// \brief gz-rendering renderer.
-  class GzRenderer;
-  class RenderSync;
+  /// \brief Set the OpenGL context to be passed to the render engine
+  //
+  /// \param[in] _context OpenGL context
+  public: virtual void SetContext(QOpenGLContext *_context);
 
-  /// \brief Render interface class to handle OpenGL / Metal compatibility
-  /// in RenderThread
-  class RenderThreadRhi
-  {
-    /// \brief Destructor
-    public: virtual ~RenderThreadRhi();
+  /// \brief Carry out initialization
+  //
+  /// On macOS this must be run on the main thread
+  /// \return Error message if initialization failed. If empty, no errors
+  /// occurred.
+  public: virtual std::string Initialize() = 0;
 
-    /// \brief Offscreen surface to render to
-    public: virtual QOffscreenSurface *Surface() const;
+  /// \brief Render when safe
+  /// \param[in] _renderSync RenderSync to safely
+  /// synchronize Qt and worker thread (this)
+  public: virtual void RenderNext(RenderSync *_renderSync) = 0;
 
-    /// \brief Set the offscreen surface to render to
-    //
-    /// \param[in] _surface Off-screen surface format
-    public: virtual void SetSurface(QOffscreenSurface *_surface);
+  /// \brief Update the texture for a camera
+  /// \param[in] _camera Pointer to the camera providing the texture
+  public: virtual void Update(rendering::CameraPtr _camera) = 0;
 
-    /// \brief OpenGL context to be passed to the render engine
-    public: virtual QOpenGLContext *Context() const;
+  /// \brief Return a pointer to the graphics API texture Id
+  public: virtual void* TexturePtr() const = 0;
 
-    /// \brief Set the OpenGL context to be passed to the render engine
-    //
-    /// \param[in] _context OpenGL context
-    public: virtual void SetContext(QOpenGLContext *_context);
+  /// \brief Return the size of the texture
+  public: virtual QSize TextureSize() const = 0;
 
-    /// \brief Carry out initialization
-    //
-    /// On macOS this must be run on the main thread
-    /// \return Error message if initialization failed. If empty, no errors
-    /// occurred.
-    public: virtual std::string Initialize() = 0;
+  /// \brief Shutdown the thread and the render engine
+  public: virtual void ShutDown() = 0;
+};
 
-    /// \brief Render when safe
-    /// \param[in] _renderSync RenderSync to safely
-    /// synchronize Qt and worker thread (this)
-    public: virtual void RenderNext(RenderSync *_renderSync) = 0;
+/// \brief Render interface class to handle OpenGL / Metal compatibility
+/// in TextureNode
+class TextureNodeRhi
+{
+  /// \brief Destructor
+  public: virtual ~TextureNodeRhi();
 
-    /// \brief Update the texture for a camera
-    /// \param[in] _camera Pointer to the camera providing the texture
-    public: virtual void Update(rendering::CameraPtr _camera) = 0;
+  /// \brief Get the Qt scene graph texture
+  public: virtual QSGTexture *Texture() const = 0;
 
-    /// \brief Return a pointer to the graphics API texture Id
-    public: virtual void* TexturePtr() const = 0;
+  /// \brief Return true if a new texture has been received
+  /// from the render thread
+  public: virtual bool HasNewTexture() const = 0;
 
-    /// \brief Return the size of the texture
-    public: virtual QSize TextureSize() const = 0;
+  /// \brief This function gets called on the render thread and will
+  ///  store the texture id and size and schedule an update on the window.
+  /// \param[in] _texturePtr Pointer to a texture Id
+  /// \param[in] _size Texture size
+  public: virtual void NewTexture(
+      void* _texturePtr, const QSize &_size) = 0;
 
-    /// \brief Shutdown the thread and the render engine
-    public: virtual void ShutDown() = 0;
-  };
-
-  /// \brief Render interface class to handle OpenGL / Metal compatibility
-  /// in TextureNode
-  class TextureNodeRhi
-  {
-    /// \brief Destructor
-    public: virtual ~TextureNodeRhi();
-
-    /// \brief Get the Qt scene graph texture
-    public: virtual QSGTexture *Texture() const = 0;
-
-    /// \brief Return true if a new texture has been received
-    /// from the render thread
-    public: virtual bool HasNewTexture() const = 0;
-
-    /// \brief This function gets called on the render thread and will
-    ///  store the texture id and size and schedule an update on the window.
-    /// \param[in] _texturePtr Pointer to a texture Id
-    /// \param[in] _size Texture size
-    public: virtual void NewTexture(
-        void* _texturePtr, const QSize &_size) = 0;
-
-    /// \brief Before the scene graph starts to render, we update to the
-    /// pending texture
-    public: virtual void PrepareNode() = 0;
-   };
-}
-}
-}
-
-#endif
+  /// \brief Before the scene graph starts to render, we update to the
+  /// pending texture
+  public: virtual void PrepareNode() = 0;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHI_HH_

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.hh
@@ -28,109 +28,102 @@
 #include <memory>
 #include <string>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief Private data for GzCameraTextureRhiMetal
+class GzCameraTextureRhiMetalPrivate;
+
+/// \brief Implementation of GzCameraTextureRhi for the Metal graphics API
+class GzCameraTextureRhiMetal : public GzCameraTextureRhi
 {
-namespace plugins
+  // Documentation inherited
+  public: virtual ~GzCameraTextureRhiMetal() override;
+
+  /// \brief Constructor
+  public: GzCameraTextureRhiMetal();
+
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
+
+  /// \internal Pointer to private data
+  private: std::unique_ptr<GzCameraTextureRhiMetalPrivate> dataPtr;
+};
+
+/// \brief Private data for RenderThreadRhiMetal
+class RenderThreadRhiMetalPrivate;
+
+/// \brief Implementation of RenderThreadRhi for the Metal graphics API
+class RenderThreadRhiMetal : public RenderThreadRhi
 {
-  /// \brief Private data for GzCameraTextureRhiMetal
-  class GzCameraTextureRhiMetalPrivate;
+  // Documentation inherited
+  public: virtual ~RenderThreadRhiMetal() override;
 
-  /// \brief Implementation of GzCameraTextureRhi for the Metal graphics API
-  class GzCameraTextureRhiMetal : public GzCameraTextureRhi
-  {
-    // Documentation inherited
-    public: virtual ~GzCameraTextureRhiMetal() override;
+  /// \brief Constructor
+  /// \param[in] _renderer The gz-rendering renderer
+  public: explicit RenderThreadRhiMetal(GzRenderer *_renderer);
 
-    /// \brief Constructor
-    public: GzCameraTextureRhiMetal();
+  // Documentation inherited
+  public: virtual std::string Initialize() override;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<GzCameraTextureRhiMetalPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual void RenderNext(RenderSync *_renderSync) override;
 
-  /// \brief Private data for RenderThreadRhiMetal
-  class RenderThreadRhiMetalPrivate;
+  // Documentation inherited
+  public: virtual void* TexturePtr() const override;
 
-  /// \brief Implementation of RenderThreadRhi for the Metal graphics API
-  class RenderThreadRhiMetal : public RenderThreadRhi
-  {
-    // Documentation inherited
-    public: virtual ~RenderThreadRhiMetal() override;
+  // Documentation inherited
+  public: virtual QSize TextureSize() const override;
 
-    /// \brief Constructor
-    /// \param[in] _renderer The gz-rendering renderer
-    public: explicit RenderThreadRhiMetal(GzRenderer *_renderer);
+  // Documentation inherited
+  public: virtual void ShutDown() override;
 
-    // Documentation inherited
-    public: virtual std::string Initialize() override;
+  /// \internal Prevent copy and assignment
+  private: RenderThreadRhiMetal(
+      const RenderThreadRhiMetal &_other) = delete;
+  private: RenderThreadRhiMetal& operator=(
+      const RenderThreadRhiMetal &_other) = delete;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  /// \internal Pointer to private data
+  private: std::unique_ptr<RenderThreadRhiMetalPrivate> dataPtr;
+};
 
-    // Documentation inherited
-    public: virtual void RenderNext(RenderSync *_renderSync) override;
+/// \brief Private data for TextureNodeRhiMetal
+class TextureNodeRhiMetalPrivate;
 
-    // Documentation inherited
-    public: virtual void* TexturePtr() const override;
+/// \brief Implementation of TextureNodeRhi for the Metal graphics API
+class TextureNodeRhiMetal : public TextureNodeRhi
+{
+  // Documentation inherited
+  public: virtual ~TextureNodeRhiMetal() override;
 
-    // Documentation inherited
-    public: virtual QSize TextureSize() const override;
+  /// \brief Constructor
+  /// \param[in] _window Window to display the texture
+  public: explicit TextureNodeRhiMetal(QQuickWindow *_window);
 
-    // Documentation inherited
-    public: virtual void ShutDown() override;
+  // Documentation inherited
+  public: virtual QSGTexture *Texture() const override;
 
-    /// \internal Prevent copy and assignment
-    private: RenderThreadRhiMetal(
-        const RenderThreadRhiMetal &_other) = delete;
-    private: RenderThreadRhiMetal& operator=(
-        const RenderThreadRhiMetal &_other) = delete;
+  // Documentation inherited
+  public: virtual bool HasNewTexture() const override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<RenderThreadRhiMetalPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual void NewTexture(
+      void* _texturePtr, const QSize &_size)override;
 
-  /// \brief Private data for TextureNodeRhiMetal
-  class TextureNodeRhiMetalPrivate;
+  // Documentation inherited
+  public: virtual void PrepareNode() override;
 
-  /// \brief Implementation of TextureNodeRhi for the Metal graphics API
-  class TextureNodeRhiMetal : public TextureNodeRhi
-  {
-    // Documentation inherited
-    public: virtual ~TextureNodeRhiMetal() override;
+  /// \internal Prevent copy and assignment
+  private: TextureNodeRhiMetal(
+      const TextureNodeRhiMetal &_other) = delete;
+  private: TextureNodeRhiMetal& operator=(
+      const TextureNodeRhiMetal &_other) = delete;
 
-    /// \brief Constructor
-    /// \param[in] _window Window to display the texture
-    public: explicit TextureNodeRhiMetal(QQuickWindow *_window);
-
-    // Documentation inherited
-    public: virtual QSGTexture *Texture() const override;
-
-    // Documentation inherited
-    public: virtual bool HasNewTexture() const override;
-
-    // Documentation inherited
-    public: virtual void NewTexture(
-        void* _texturePtr, const QSize &_size)override;
-
-    // Documentation inherited
-    public: virtual void PrepareNode() override;
-
-    /// \internal Prevent copy and assignment
-    private: TextureNodeRhiMetal(
-        const TextureNodeRhiMetal &_other) = delete;
-    private: TextureNodeRhiMetal& operator=(
-        const TextureNodeRhiMetal &_other) = delete;
-
-    /// \internal Pointer to private data
-    private: std::unique_ptr<TextureNodeRhiMetalPrivate> dataPtr;
-   };
-}
-}
-}
-
-#endif
+  /// \internal Pointer to private data
+  private: std::unique_ptr<TextureNodeRhiMetalPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHIMETAL_HH_

--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
@@ -35,40 +35,29 @@
 #endif
 
 /////////////////////////////////////////////////
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class GzCameraTextureRhiMetalPrivate
 {
-namespace plugins
+  public: id<MTLTexture> metalTexture = nil;
+};
+
+class RenderThreadRhiMetalPrivate
 {
-  class GzCameraTextureRhiMetalPrivate
-  {
-    public: id<MTLTexture> metalTexture = nil;
-  };
+  public: GzRenderer *renderer = nullptr;
+  public: id<MTLTexture> metalTexture = nil;
+};
 
-  class RenderThreadRhiMetalPrivate
-  {
-    public: GzRenderer *renderer = nullptr;
-    public: id<MTLTexture> metalTexture = nil;
-  };
-
-  class TextureNodeRhiMetalPrivate
-  {
-    public: id<MTLTexture> metalTexture = nil;
-    public: id<MTLTexture> newMetalTexture = nil;
-    public: QSize size {0, 0};
-    public: QSize newSize {0, 0};
-    public: QMutex mutex;
-    public: QSGTexture *texture = nullptr;
-    public: QQuickWindow *window = nullptr;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+class TextureNodeRhiMetalPrivate
+{
+  public: id<MTLTexture> metalTexture = nil;
+  public: id<MTLTexture> newMetalTexture = nil;
+  public: QSize size {0, 0};
+  public: QSize newSize {0, 0};
+  public: QMutex mutex;
+  public: QSGTexture *texture = nullptr;
+  public: QQuickWindow *window = nullptr;
+};
 
 /////////////////////////////////////////////////
 GzCameraTextureRhiMetal::~GzCameraTextureRhiMetal() = default;
@@ -217,3 +206,4 @@ void TextureNodeRhiMetal::PrepareNode()
             this->dataPtr->newSize);
   }
 }
+}  // namespace gz::gui::plugins

--- a/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.hh
@@ -28,121 +28,115 @@
 #include <memory>
 #include <string>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief Private data for GzCameraTextureRhiOpenGL
+class GzCameraTextureRhiOpenGLPrivate;
+
+/// \brief Implementation of GzCameraTextureRhi for the OpenGL graphics API
+class GzCameraTextureRhiOpenGL : public GzCameraTextureRhi
 {
-namespace plugins
+  // Documentation inherited
+  public: virtual ~GzCameraTextureRhiOpenGL() override;
+
+  /// \brief Constructor
+  public: GzCameraTextureRhiOpenGL();
+
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
+
+  /// \internal Pointer to private data
+  private: std::unique_ptr<GzCameraTextureRhiOpenGLPrivate> dataPtr;
+};
+
+/// \brief Private data for RenderThreadRhiOpenGLPrivate
+class RenderThreadRhiOpenGLPrivate;
+
+/// \brief Implementation of RenderThreadRhi for the OpenGL graphics API
+class RenderThreadRhiOpenGL : public RenderThreadRhi
 {
-  /// \brief Private data for GzCameraTextureRhiOpenGL
-  class GzCameraTextureRhiOpenGLPrivate;
+  // Documentation inherited
+  public: virtual ~RenderThreadRhiOpenGL() override;
 
-  /// \brief Implementation of GzCameraTextureRhi for the OpenGL graphics API
-  class GzCameraTextureRhiOpenGL : public GzCameraTextureRhi
-  {
-    // Documentation inherited
-    public: virtual ~GzCameraTextureRhiOpenGL() override;
+  /// \brief Constructor
+  /// \param[in] _renderer The gz-rendering renderer
+  public: explicit RenderThreadRhiOpenGL(GzRenderer *_renderer);
 
-    /// \brief Constructor
-    public: GzCameraTextureRhiOpenGL();
+  // Documentation inherited
+  public: virtual QOffscreenSurface *Surface() const override;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  // Documentation inherited
+  public: virtual void SetSurface(QOffscreenSurface *_surface) override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<GzCameraTextureRhiOpenGLPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual QOpenGLContext *Context() const override;
 
-  /// \brief Private data for RenderThreadRhiOpenGLPrivate
-  class RenderThreadRhiOpenGLPrivate;
+  // Documentation inherited
+  public: virtual void SetContext(QOpenGLContext *_context) override;
 
-  /// \brief Implementation of RenderThreadRhi for the OpenGL graphics API
-  class RenderThreadRhiOpenGL : public RenderThreadRhi
-  {
-    // Documentation inherited
-    public: virtual ~RenderThreadRhiOpenGL() override;
+  // Documentation inherited
+  public: virtual std::string Initialize() override;
 
-    /// \brief Constructor
-    /// \param[in] _renderer The gz-rendering renderer
-    public: explicit RenderThreadRhiOpenGL(GzRenderer *_renderer);
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
 
-    // Documentation inherited
-    public: virtual QOffscreenSurface *Surface() const override;
+  // Documentation inherited
+  public: virtual void RenderNext(RenderSync *_renderSync) override;
 
-    // Documentation inherited
-    public: virtual void SetSurface(QOffscreenSurface *_surface) override;
+  // Documentation inherited
+  public: virtual void* TexturePtr() const override;
 
-    // Documentation inherited
-    public: virtual QOpenGLContext *Context() const override;
+  // Documentation inherited
+  public: virtual QSize TextureSize() const override;
 
-    // Documentation inherited
-    public: virtual void SetContext(QOpenGLContext *_context) override;
+  // Documentation inherited
+  public: virtual void ShutDown() override;
 
-    // Documentation inherited
-    public: virtual std::string Initialize() override;
+  /// \internal Prevent copy and assignment
+  private: RenderThreadRhiOpenGL(
+      const RenderThreadRhiOpenGL &_other) = delete;
+  private: RenderThreadRhiOpenGL& operator=(
+      const RenderThreadRhiOpenGL &_other) = delete;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  /// \internal Pointer to private data
+  private: std::unique_ptr<RenderThreadRhiOpenGLPrivate> dataPtr;
+};
 
-    // Documentation inherited
-    public: virtual void RenderNext(RenderSync *_renderSync) override;
+/// \brief Private data for TextureNodeRhiOpenGL
+class TextureNodeRhiOpenGLPrivate;
 
-    // Documentation inherited
-    public: virtual void* TexturePtr() const override;
+/// \brief Implementation of TextureNodeRhi for the OpenGL graphics API
+class TextureNodeRhiOpenGL : public TextureNodeRhi
+{
+  // Documentation inherited
+  public: virtual ~TextureNodeRhiOpenGL() override;
 
-    // Documentation inherited
-    public: virtual QSize TextureSize() const override;
+  /// \brief Constructor
+  /// \param[in] _window Window to display the texture
+  public: explicit TextureNodeRhiOpenGL(QQuickWindow *_window);
 
-    // Documentation inherited
-    public: virtual void ShutDown() override;
+  // Documentation inherited
+  public: virtual QSGTexture *Texture() const override;
 
-    /// \internal Prevent copy and assignment
-    private: RenderThreadRhiOpenGL(
-        const RenderThreadRhiOpenGL &_other) = delete;
-    private: RenderThreadRhiOpenGL& operator=(
-        const RenderThreadRhiOpenGL &_other) = delete;
+  // Documentation inherited
+  public: virtual bool HasNewTexture() const override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<RenderThreadRhiOpenGLPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual void NewTexture(
+      void* _texturePtr, const QSize &_size) override;
 
-  /// \brief Private data for TextureNodeRhiOpenGL
-  class TextureNodeRhiOpenGLPrivate;
+  // Documentation inherited
+  public: virtual void PrepareNode() override;
 
-  /// \brief Implementation of TextureNodeRhi for the OpenGL graphics API
-  class TextureNodeRhiOpenGL : public TextureNodeRhi
-  {
-    // Documentation inherited
-    public: virtual ~TextureNodeRhiOpenGL() override;
+  /// \internal Prevent copy and assignment
+  private: TextureNodeRhiOpenGL(
+      const TextureNodeRhiOpenGL &_other) = delete;
+  private: TextureNodeRhiOpenGL& operator=(
+      const TextureNodeRhiOpenGL &_other) = delete;
 
-    /// \brief Constructor
-    /// \param[in] _window Window to display the texture
-    public: explicit TextureNodeRhiOpenGL(QQuickWindow *_window);
-
-    // Documentation inherited
-    public: virtual QSGTexture *Texture() const override;
-
-    // Documentation inherited
-    public: virtual bool HasNewTexture() const override;
-
-    // Documentation inherited
-    public: virtual void NewTexture(
-        void* _texturePtr, const QSize &_size) override;
-
-    // Documentation inherited
-    public: virtual void PrepareNode() override;
-
-    /// \internal Prevent copy and assignment
-    private: TextureNodeRhiOpenGL(
-        const TextureNodeRhiOpenGL &_other) = delete;
-    private: TextureNodeRhiOpenGL& operator=(
-        const TextureNodeRhiOpenGL &_other) = delete;
-
-    /// \internal Pointer to private data
-    private: std::unique_ptr<TextureNodeRhiOpenGLPrivate> dataPtr;
-   };
-}
-}
-}
-
-#endif
+  /// \internal Pointer to private data
+  private: std::unique_ptr<TextureNodeRhiOpenGLPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHIOPENGL_HH_
+//

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
@@ -28,120 +28,115 @@
 #include <memory>
 #include <string>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
-namespace gz
+#define HAVE_QT_VULKAN \
+  QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+
+#if HAVE_QT_VULKAN
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief Private data for GzCameraTextureRhiVulkan
+class GzCameraTextureRhiVulkanPrivate;
+
+/// \brief Implementation of GzCameraTextureRhi for the Vulkan graphics API
+class GzCameraTextureRhiVulkan : public GzCameraTextureRhi
 {
-namespace plugins
+  // Documentation inherited
+  public: virtual ~GzCameraTextureRhiVulkan() override;
+
+  /// \brief Constructor
+  public: GzCameraTextureRhiVulkan();
+
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
+
+  /// \internal Pointer to private data
+  private: std::unique_ptr<GzCameraTextureRhiVulkanPrivate> dataPtr;
+};
+
+/// \brief Private data for RenderThreadRhiVulkanPrivate
+class RenderThreadRhiVulkanPrivate;
+
+/// \brief Implementation of RenderThreadRhi for the Vulkan graphics API
+class RenderThreadRhiVulkan : public RenderThreadRhi
 {
-  /// \brief Private data for GzCameraTextureRhiVulkan
-  class GzCameraTextureRhiVulkanPrivate;
+  // Documentation inherited
+  public: virtual ~RenderThreadRhiVulkan() override;
 
-  /// \brief Implementation of GzCameraTextureRhi for the Vulkan graphics API
-  class GzCameraTextureRhiVulkan : public GzCameraTextureRhi
-  {
-    // Documentation inherited
-    public: virtual ~GzCameraTextureRhiVulkan() override;
+  /// \brief Constructor
+  /// \param[in] _renderer The gz-rendering renderer
+  public: explicit RenderThreadRhiVulkan(GzRenderer *_renderer);
 
-    /// \brief Constructor
-    public: GzCameraTextureRhiVulkan();
+  // Documentation inherited
+  public: virtual QOffscreenSurface *Surface() const override;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  // Documentation inherited
+  public: virtual void SetSurface(QOffscreenSurface *_surface) override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<GzCameraTextureRhiVulkanPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual std::string Initialize() override;
 
-  /// \brief Private data for RenderThreadRhiVulkanPrivate
-  class RenderThreadRhiVulkanPrivate;
+  // Documentation inherited
+  public: virtual void Update(rendering::CameraPtr _camera) override;
 
-  /// \brief Implementation of RenderThreadRhi for the Vulkan graphics API
-  class RenderThreadRhiVulkan : public RenderThreadRhi
-  {
-    // Documentation inherited
-    public: virtual ~RenderThreadRhiVulkan() override;
+  // Documentation inherited
+  public: virtual void RenderNext(RenderSync *_renderSync) override;
 
-    /// \brief Constructor
-    /// \param[in] _renderer The gz-rendering renderer
-    public: explicit RenderThreadRhiVulkan(GzRenderer *_renderer);
+  // Documentation inherited
+  public: virtual void* TexturePtr() const override;
 
-    // Documentation inherited
-    public: virtual QOffscreenSurface *Surface() const override;
+  // Documentation inherited
+  public: virtual QSize TextureSize() const override;
 
-    // Documentation inherited
-    public: virtual void SetSurface(QOffscreenSurface *_surface) override;
+  // Documentation inherited
+  public: virtual void ShutDown() override;
 
-    // Documentation inherited
-    public: virtual std::string Initialize() override;
+  /// \internal Prevent copy and assignment
+  private: RenderThreadRhiVulkan(
+      const RenderThreadRhiVulkan &_other) = delete;
+  private: RenderThreadRhiVulkan& operator=(
+      const RenderThreadRhiVulkan &_other) = delete;
 
-    // Documentation inherited
-    public: virtual void Update(rendering::CameraPtr _camera) override;
+  /// \internal Pointer to private data
+  private: std::unique_ptr<RenderThreadRhiVulkanPrivate> dataPtr;
+};
 
-    // Documentation inherited
-    public: virtual void RenderNext(RenderSync *_renderSync) override;
+/// \brief Private data for TextureNodeRhiVulkan
+class TextureNodeRhiVulkanPrivate;
 
-    // Documentation inherited
-    public: virtual void* TexturePtr() const override;
+/// \brief Implementation of TextureNodeRhi for the Vulkan graphics API
+class TextureNodeRhiVulkan : public TextureNodeRhi
+{
+  // Documentation inherited
+  public: virtual ~TextureNodeRhiVulkan() override;
 
-    // Documentation inherited
-    public: virtual QSize TextureSize() const override;
+  /// \brief Constructor
+  /// \param[in] _window Window to display the texture
+  /// \param[in] _camera Camera owning the API texture handle
+  public: explicit TextureNodeRhiVulkan(QQuickWindow *_window,
+                                        rendering::CameraPtr &_camera);
 
-    // Documentation inherited
-    public: virtual void ShutDown() override;
+  // Documentation inherited
+  public: virtual QSGTexture *Texture() const override;
 
-    /// \internal Prevent copy and assignment
-    private: RenderThreadRhiVulkan(
-        const RenderThreadRhiVulkan &_other) = delete;
-    private: RenderThreadRhiVulkan& operator=(
-        const RenderThreadRhiVulkan &_other) = delete;
+  // Documentation inherited
+  public: virtual bool HasNewTexture() const override;
 
-    /// \internal Pointer to private data
-    private: std::unique_ptr<RenderThreadRhiVulkanPrivate> dataPtr;
-  };
+  // Documentation inherited
+  public: virtual void NewTexture(
+      void* _texturePtr, const QSize &_size) override;
 
-  /// \brief Private data for TextureNodeRhiVulkan
-  class TextureNodeRhiVulkanPrivate;
+  // Documentation inherited
+  public: virtual void PrepareNode() override;
 
-  /// \brief Implementation of TextureNodeRhi for the Vulkan graphics API
-  class TextureNodeRhiVulkan : public TextureNodeRhi
-  {
-    // Documentation inherited
-    public: virtual ~TextureNodeRhiVulkan() override;
+  /// \internal Prevent copy and assignment
+  private: TextureNodeRhiVulkan(
+      const TextureNodeRhiVulkan &_other) = delete;
+  private: TextureNodeRhiVulkan& operator=(
+      const TextureNodeRhiVulkan &_other) = delete;
 
-    /// \brief Constructor
-    /// \param[in] _window Window to display the texture
-    /// \param[in] _camera Camera owning the API texture handle
-    public: explicit TextureNodeRhiVulkan(QQuickWindow *_window,
-                                          rendering::CameraPtr &_camera);
-
-    // Documentation inherited
-    public: virtual QSGTexture *Texture() const override;
-
-    // Documentation inherited
-    public: virtual bool HasNewTexture() const override;
-
-    // Documentation inherited
-    public: virtual void NewTexture(
-        void* _texturePtr, const QSize &_size) override;
-
-    // Documentation inherited
-    public: virtual void PrepareNode() override;
-
-    /// \internal Prevent copy and assignment
-    private: TextureNodeRhiVulkan(
-        const TextureNodeRhiVulkan &_other) = delete;
-    private: TextureNodeRhiVulkan& operator=(
-        const TextureNodeRhiVulkan &_other) = delete;
-
-    /// \internal Pointer to private data
-    private: std::unique_ptr<TextureNodeRhiVulkanPrivate> dataPtr;
-   };
-}
-}
-}
-
-#endif
-
-#endif
+  /// \internal Pointer to private data
+  private: std::unique_ptr<TextureNodeRhiVulkanPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // HAVE_QT_VULKAN
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_MINIMALSCENERHIVULKAN_HH_

--- a/src/plugins/navsat_map/NavSatMap.cc
+++ b/src/plugins/navsat_map/NavSatMap.cc
@@ -29,33 +29,22 @@
 
 #include "gz/gui/Application.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class NavSatMapPrivate
 {
-namespace plugins
-{
-  class NavSatMapPrivate
-  {
-    /// \brief List of topics publishing navSat messages.
-    public: QStringList topicList;
+  /// \brief List of topics publishing navSat messages.
+  public: QStringList topicList;
 
-    /// \brief Holds data to set as the next navSat
-    public: msgs::NavSat navSatMsg;
+  /// \brief Holds data to set as the next navSat
+  public: msgs::NavSat navSatMsg;
 
-    /// \brief Node for communication.
-    public: transport::Node node;
+  /// \brief Node for communication.
+  public: transport::Node node;
 
-    /// \brief Mutex for accessing navSat data
-    public: std::recursive_mutex navSatMutex;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Mutex for accessing navSat data
+  public: std::recursive_mutex navSatMutex;
+};
 
 /////////////////////////////////////////////////
 NavSatMap::NavSatMap()
@@ -186,6 +175,7 @@ void NavSatMap::SetTopicList(const QStringList &_topicList)
   this->dataPtr->topicList = _topicList;
   this->TopicListChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::NavSatMap,

--- a/src/plugins/navsat_map/NavSatMap.hh
+++ b/src/plugins/navsat_map/NavSatMap.hh
@@ -24,78 +24,71 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class NavSatMapPrivate;
+
+/// \brief Display NavSat messages coming through a Gazebo Transport topic
+/// on top of a map.
+///
+/// ## Configuration
+///
+/// \<topic\> : Set the topic to receive NavSat messages.
+/// \<topic_picker\> : Whether to show the topic picker, true by default. If
+///                    this is false, a \<topic\> must be specified.
+class NavSatMap : public Plugin
 {
-namespace plugins
-{
-  class NavSatMapPrivate;
+  Q_OBJECT
 
-  /// \brief Display NavSat messages coming through a Gazebo Transport topic
-  /// on top of a map.
-  ///
-  /// ## Configuration
-  ///
-  /// \<topic\> : Set the topic to receive NavSat messages.
-  /// \<topic_picker\> : Whether to show the topic picker, true by default. If
-  ///                    this is false, a \<topic\> must be specified.
-  class NavSatMap : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Topic list
+  Q_PROPERTY(
+    QStringList topicList
+    READ TopicList
+    WRITE SetTopicList
+    NOTIFY TopicListChanged
+  )
 
-    /// \brief Topic list
-    Q_PROPERTY(
-      QStringList topicList
-      READ TopicList
-      WRITE SetTopicList
-      NOTIFY TopicListChanged
-    )
+  /// \brief Constructor
+  public: NavSatMap();
 
-    /// \brief Constructor
-    public: NavSatMap();
+  /// \brief Destructor
+  public: virtual ~NavSatMap();
 
-    /// \brief Destructor
-    public: virtual ~NavSatMap();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Callback when refresh button is pressed.
+  public slots: void OnRefresh();
 
-    /// \brief Callback when refresh button is pressed.
-    public slots: void OnRefresh();
+  /// \brief Callback when a new topic is chosen on the combo box.
+  public slots: void OnTopic(const QString _topic);
 
-    /// \brief Callback when a new topic is chosen on the combo box.
-    public slots: void OnTopic(const QString _topic);
+  /// \brief Get the list of topics publishing NavSat messages
+  /// \return List of topics
+  public: Q_INVOKABLE QStringList TopicList() const;
 
-    /// \brief Get the list of topics publishing NavSat messages
-    /// \return List of topics
-    public: Q_INVOKABLE QStringList TopicList() const;
+  /// \brief Set the topic list
+  /// \param[in] _topicList List of topics
+  public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
 
-    /// \brief Set the topic list
-    /// \param[in] _topicList List of topics
-    public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
+  /// \brief Notify that topic list has changed
+  signals: void TopicListChanged();
 
-    /// \brief Notify that topic list has changed
-    signals: void TopicListChanged();
+  /// \brief Notify that a new message has been received.
+  /// \param[in] _latitudeDeg Latitude in degrees
+  /// \param[in] _longitudeDeg Longitude in degrees
+  signals: void newMessage(double _latitudeDeg, double _longitudeDeg);
 
-    /// \brief Notify that a new message has been received.
-    /// \param[in] _latitudeDeg Latitude in degrees
-    /// \param[in] _longitudeDeg Longitude in degrees
-    signals: void newMessage(double _latitudeDeg, double _longitudeDeg);
+  /// \brief Callback in main thread when message changes
+  private slots: void ProcessMessage();
 
-    /// \brief Callback in main thread when message changes
-    private slots: void ProcessMessage();
+  /// \brief Subscriber callback when new message is received
+  /// \param[in] _msg New message
+  private: void OnMessage(const gz::msgs::NavSat &_msg);
 
-    /// \brief Subscriber callback when new message is received
-    /// \param[in] _msg New message
-    private: void OnMessage(const gz::msgs::NavSat &_msg);
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<NavSatMapPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<NavSatMapPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_

--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -17,10 +17,8 @@
 #include <gz/plugin/Register.hh>
 #include "TransportPlotting.hh"
 
-using namespace gz;
-using namespace gui;
-using namespace plugins;
-
+namespace gz::gui::plugins
+{
 TransportPlotting::~TransportPlotting()
 {
 }
@@ -37,8 +35,8 @@ TransportPlotting::TransportPlotting() : Plugin(),
     dataPtr(new PlottingInterface)
 {
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::TransportPlotting,
               gz::gui::Plugin)
-

--- a/src/plugins/plotting/TransportPlotting.hh
+++ b/src/plugins/plotting/TransportPlotting.hh
@@ -23,13 +23,8 @@
 
 #include <memory>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
-{
-namespace plugins
-{
-
 /// \brief Plots fields from Gazebo Transport topics.
 /// Fields can be dragged from the Topic Viewer or the Component Inspector.
 class TransportPlotting : public gz::gui::Plugin
@@ -50,8 +45,5 @@ class TransportPlotting : public gz::gui::Plugin
   private: std::unique_ptr<PlottingInterface> dataPtr;
   GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
 };
-
-}
-}
-}
-#endif
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TRANSPORTPLOTTING_HH_

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -43,8 +43,10 @@
 
 #include "PointCloud.hh"
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for PointCloud
-class gz::gui::plugins::PointCloudPrivate
+class PointCloudPrivate
 {
   /// \brief Makes a request to populate the scene with markers
   public: void PublishMarkers();
@@ -94,10 +96,6 @@ class gz::gui::plugins::PointCloudPrivate
   /// \brief True if showing, changeable at runtime
   public: bool showing{true};
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 PointCloud::PointCloud()
@@ -520,6 +518,7 @@ void PointCloud::SetPointSize(float _pointSize)
   this->PointSizeChanged();
   this->dataPtr->PublishMarkers();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::PointCloud,

--- a/src/plugins/point_cloud/PointCloud.hh
+++ b/src/plugins/point_cloud/PointCloud.hh
@@ -25,220 +25,214 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class PointCloudPrivate;
+
+/// \brief Visualize `gz::msgs::PointCloudPacked` messages in a 3D
+/// scene.
+///
+/// By default, the whole cloud is displayed using a single color. Users
+/// can optionally choose a topic publishing `gz::msgs::FloatV` messages
+/// which will be used to color all points with a color gradient according to
+/// their values. The float message must have the same number of elements as
+/// the point cloud and be indexed the same way. NaN values on the FloatV
+/// message aren't displayed.
+///
+/// Requirements:
+/// * A plugin that loads a 3D scene, such as `MinimalScene`
+/// * The `MarkerManager` plugin
+///
+/// Parameters:
+///
+/// * `<point_cloud_topic>`: Topic to receive
+///      `gz::msgs::PointCloudPacked` messages.
+/// * `<float_v_topic>`: Topic to receive `gz::msgs::FloatV` messages.
+class PointCloud : public gz::gui::Plugin
 {
-namespace plugins
-{
-  class PointCloudPrivate;
+  Q_OBJECT
 
-  /// \brief Visualize `gz::msgs::PointCloudPacked` messages in a 3D
-  /// scene.
-  ///
-  /// By default, the whole cloud is displayed using a single color. Users
-  /// can optionally choose a topic publishing `gz::msgs::FloatV` messages
-  /// which will be used to color all points with a color gradient according to
-  /// their values. The float message must have the same number of elements as
-  /// the point cloud and be indexed the same way. NaN values on the FloatV
-  /// message aren't displayed.
-  ///
-  /// Requirements:
-  /// * A plugin that loads a 3D scene, such as `MinimalScene`
-  /// * The `MarkerManager` plugin
-  ///
-  /// Parameters:
-  ///
-  /// * `<point_cloud_topic>`: Topic to receive
-  ///      `gz::msgs::PointCloudPacked` messages.
-  /// * `<float_v_topic>`: Topic to receive `gz::msgs::FloatV` messages.
-  class PointCloud : public gz::gui::Plugin
-  {
-    Q_OBJECT
+  /// \brief List of topics publishing PointCloudPacked messages
+  Q_PROPERTY(
+    QStringList pointCloudTopicList
+    READ PointCloudTopicList
+    WRITE SetPointCloudTopicList
+    NOTIFY PointCloudTopicListChanged
+  )
 
-    /// \brief List of topics publishing PointCloudPacked messages
-    Q_PROPERTY(
-      QStringList pointCloudTopicList
-      READ PointCloudTopicList
-      WRITE SetPointCloudTopicList
-      NOTIFY PointCloudTopicListChanged
-    )
+  /// \brief List of topics publishing FloatV messages
+  Q_PROPERTY(
+    QStringList floatVTopicList
+    READ FloatVTopicList
+    WRITE SetFloatVTopicList
+    NOTIFY FloatVTopicListChanged
+  )
 
-    /// \brief List of topics publishing FloatV messages
-    Q_PROPERTY(
-      QStringList floatVTopicList
-      READ FloatVTopicList
-      WRITE SetFloatVTopicList
-      NOTIFY FloatVTopicListChanged
-    )
+  /// \brief Color for minimum value
+  Q_PROPERTY(
+    QColor minColor
+    READ MinColor
+    WRITE SetMinColor
+    NOTIFY MinColorChanged
+  )
 
-    /// \brief Color for minimum value
-    Q_PROPERTY(
-      QColor minColor
-      READ MinColor
-      WRITE SetMinColor
-      NOTIFY MinColorChanged
-    )
+  /// \brief Color for maximum value
+  Q_PROPERTY(
+    QColor maxColor
+    READ MaxColor
+    WRITE SetMaxColor
+    NOTIFY MaxColorChanged
+  )
 
-    /// \brief Color for maximum value
-    Q_PROPERTY(
-      QColor maxColor
-      READ MaxColor
-      WRITE SetMaxColor
-      NOTIFY MaxColorChanged
-    )
+  /// \brief Minimum value
+  Q_PROPERTY(
+    float minFloatV
+    READ MinFloatV
+    WRITE SetMinFloatV
+    NOTIFY MinFloatVChanged
+  )
 
-    /// \brief Minimum value
-    Q_PROPERTY(
-      float minFloatV
-      READ MinFloatV
-      WRITE SetMinFloatV
-      NOTIFY MinFloatVChanged
-    )
+  /// \brief Maximum value
+  Q_PROPERTY(
+    float maxFloatV
+    READ MaxFloatV
+    WRITE SetMaxFloatV
+    NOTIFY MaxFloatVChanged
+  )
 
-    /// \brief Maximum value
-    Q_PROPERTY(
-      float maxFloatV
-      READ MaxFloatV
-      WRITE SetMaxFloatV
-      NOTIFY MaxFloatVChanged
-    )
+  /// \brief Point size
+  Q_PROPERTY(
+    float pointSize
+    READ PointSize
+    WRITE SetPointSize
+    NOTIFY PointSizeChanged
+  )
 
-    /// \brief Point size
-    Q_PROPERTY(
-      float pointSize
-      READ PointSize
-      WRITE SetPointSize
-      NOTIFY PointSizeChanged
-    )
+  /// \brief Constructor
+  public: PointCloud();
 
-    /// \brief Constructor
-    public: PointCloud();
+  /// \brief Destructor
+  public: ~PointCloud() override;
 
-    /// \brief Destructor
-    public: ~PointCloud() override;
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+  /// \brief Callback function for point cloud topic.
+  /// \param[in] _msg Point cloud message
+  public: void OnPointCloud(const msgs::PointCloudPacked &_msg);
 
-    /// \brief Callback function for point cloud topic.
-    /// \param[in] _msg Point cloud message
-    public: void OnPointCloud(const msgs::PointCloudPacked &_msg);
+  /// \brief Callback function for point cloud service
+  /// \param[in] _msg Point cloud message
+  /// \param[out] _result True on success.
+  public: void OnPointCloudService(const msgs::PointCloudPacked &_msg,
+      bool _result);
 
-    /// \brief Callback function for point cloud service
-    /// \param[in] _msg Point cloud message
-    /// \param[out] _result True on success.
-    public: void OnPointCloudService(const msgs::PointCloudPacked &_msg,
-        bool _result);
+  /// \brief Get the topic list
+  /// \return List of topics
+  public: Q_INVOKABLE QStringList PointCloudTopicList() const;
 
-    /// \brief Get the topic list
-    /// \return List of topics
-    public: Q_INVOKABLE QStringList PointCloudTopicList() const;
+  /// \brief Set the topic list from a string
+  /// \param[in] _pointCloudTopicList List of topics.
+  public: Q_INVOKABLE void SetPointCloudTopicList(
+      const QStringList &_pointCloudTopicList);
 
-    /// \brief Set the topic list from a string
-    /// \param[in] _pointCloudTopicList List of topics.
-    public: Q_INVOKABLE void SetPointCloudTopicList(
-        const QStringList &_pointCloudTopicList);
+  /// \brief Notify that topic list has changed
+  signals: void PointCloudTopicListChanged();
 
-    /// \brief Notify that topic list has changed
-    signals: void PointCloudTopicListChanged();
+  /// \brief Set topic to subscribe to for point cloud.
+  /// \param[in] _topicName Name of selected topic
+  public: Q_INVOKABLE void OnPointCloudTopic(const QString &_topicName);
 
-    /// \brief Set topic to subscribe to for point cloud.
-    /// \param[in] _topicName Name of selected topic
-    public: Q_INVOKABLE void OnPointCloudTopic(const QString &_topicName);
+  /// \brief Callback function for float vector topic.
+  /// \param[in] _msg Float vector message
+  public: void OnFloatV(const msgs::Float_V &_msg);
 
-    /// \brief Callback function for float vector topic.
-    /// \param[in] _msg Float vector message
-    public: void OnFloatV(const msgs::Float_V &_msg);
+  /// \brief Callback function for point cloud service
+  /// \param[in] _msg Float vector message
+  /// \param[out] _result True on success.
+  public: void OnFloatVService(const msgs::Float_V &_msg, bool _result);
 
-    /// \brief Callback function for point cloud service
-    /// \param[in] _msg Float vector message
-    /// \param[out] _result True on success.
-    public: void OnFloatVService(const msgs::Float_V &_msg, bool _result);
+  /// \brief Get the topic list
+  /// \return List of topics
+  public: Q_INVOKABLE QStringList FloatVTopicList() const;
 
-    /// \brief Get the topic list
-    /// \return List of topics
-    public: Q_INVOKABLE QStringList FloatVTopicList() const;
+  /// \brief Set the topic list from a string
+  /// \param[in] _floatVTopicList List of topics.
+  public: Q_INVOKABLE void SetFloatVTopicList(
+      const QStringList &_floatVTopicList);
 
-    /// \brief Set the topic list from a string
-    /// \param[in] _floatVTopicList List of topics.
-    public: Q_INVOKABLE void SetFloatVTopicList(
-        const QStringList &_floatVTopicList);
+  /// \brief Notify that topic list has changed
+  signals: void FloatVTopicListChanged();
 
-    /// \brief Notify that topic list has changed
-    signals: void FloatVTopicListChanged();
+  /// \brief Set topic to subscribe to for float vectors.
+  /// \param[in] _topicName Name of selected topic
+  public: Q_INVOKABLE void OnFloatVTopic(const QString &_topicName);
 
-    /// \brief Set topic to subscribe to for float vectors.
-    /// \param[in] _topicName Name of selected topic
-    public: Q_INVOKABLE void OnFloatVTopic(const QString &_topicName);
+  /// \brief Get the minimum color
+  /// \return Minimum color
+  public: Q_INVOKABLE QColor MinColor() const;
 
-    /// \brief Get the minimum color
-    /// \return Minimum color
-    public: Q_INVOKABLE QColor MinColor() const;
+  /// \brief Set the minimum color
+  /// \param[in] _minColor Minimum color.
+  public: Q_INVOKABLE void SetMinColor(const QColor &_minColor);
 
-    /// \brief Set the minimum color
-    /// \param[in] _minColor Minimum color.
-    public: Q_INVOKABLE void SetMinColor(const QColor &_minColor);
+  /// \brief Notify that minimum color has changed
+  signals: void MinColorChanged();
 
-    /// \brief Notify that minimum color has changed
-    signals: void MinColorChanged();
+  /// \brief Get the maximum color
+  /// \return Maximum color
+  public: Q_INVOKABLE QColor MaxColor() const;
 
-    /// \brief Get the maximum color
-    /// \return Maximum color
-    public: Q_INVOKABLE QColor MaxColor() const;
+  /// \brief Set the maximum color
+  /// \param[in] _maxColor Maximum color.
+  public: Q_INVOKABLE void SetMaxColor(const QColor &_maxColor);
 
-    /// \brief Set the maximum color
-    /// \param[in] _maxColor Maximum color.
-    public: Q_INVOKABLE void SetMaxColor(const QColor &_maxColor);
+  /// \brief Notify that maximum color has changed
+  signals: void MaxColorChanged();
 
-    /// \brief Notify that maximum color has changed
-    signals: void MaxColorChanged();
+  /// \brief Get the minimum value
+  /// \return Minimum value
+  public: Q_INVOKABLE float MinFloatV() const;
 
-    /// \brief Get the minimum value
-    /// \return Minimum value
-    public: Q_INVOKABLE float MinFloatV() const;
+  /// \brief Set the minimum value
+  /// \param[in] _minFloatV Minimum value.
+  public: Q_INVOKABLE void SetMinFloatV(float _minFloatV);
 
-    /// \brief Set the minimum value
-    /// \param[in] _minFloatV Minimum value.
-    public: Q_INVOKABLE void SetMinFloatV(float _minFloatV);
+  /// \brief Notify that minimum value has changed
+  signals: void MinFloatVChanged();
 
-    /// \brief Notify that minimum value has changed
-    signals: void MinFloatVChanged();
+  /// \brief Get the maximum value
+  /// \return Maximum value
+  public: Q_INVOKABLE float MaxFloatV() const;
 
-    /// \brief Get the maximum value
-    /// \return Maximum value
-    public: Q_INVOKABLE float MaxFloatV() const;
+  /// \brief Set the maximum value
+  /// \param[in] _maxFloatV Maximum value.
+  public: Q_INVOKABLE void SetMaxFloatV(float _maxFloatV);
 
-    /// \brief Set the maximum value
-    /// \param[in] _maxFloatV Maximum value.
-    public: Q_INVOKABLE void SetMaxFloatV(float _maxFloatV);
+  /// \brief Notify that maximum value has changed
+  signals: void MaxFloatVChanged();
 
-    /// \brief Notify that maximum value has changed
-    signals: void MaxFloatVChanged();
+  /// \brief Get the point size
+  /// \return Maximum value
+  public: Q_INVOKABLE float PointSize() const;
 
-    /// \brief Get the point size
-    /// \return Maximum value
-    public: Q_INVOKABLE float PointSize() const;
+  /// \brief Set the point size
+  /// \param[in] _pointSize Maximum value.
+  public: Q_INVOKABLE void SetPointSize(float _pointSize);
 
-    /// \brief Set the point size
-    /// \param[in] _pointSize Maximum value.
-    public: Q_INVOKABLE void SetPointSize(float _pointSize);
+  /// \brief Notify that point size has changed
+  signals: void PointSizeChanged();
 
-    /// \brief Notify that point size has changed
-    signals: void PointSizeChanged();
+  /// \brief Set whether to show the point cloud.
+  /// \param[in] _show Boolean value for displaying the points.
+  public: Q_INVOKABLE void Show(bool _show);
 
-    /// \brief Set whether to show the point cloud.
-    /// \param[in] _show Boolean value for displaying the points.
-    public: Q_INVOKABLE void Show(bool _show);
+  /// \brief Callback when refresh button is pressed.
+  public: Q_INVOKABLE void OnRefresh();
 
-    /// \brief Callback when refresh button is pressed.
-    public: Q_INVOKABLE void OnRefresh();
-
-    /// \internal
-    /// \brief Pointer to private data
-    private: std::unique_ptr<PointCloudPrivate> dataPtr;
-  };
-}
-}
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data
+  private: std::unique_ptr<PointCloudPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_POINTCLOUD_HH_

--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -23,42 +23,31 @@
 
 #include "Publisher.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class PublisherPrivate
 {
-namespace plugins
-{
-  class PublisherPrivate
-  {
-    /// \brief Message type
-    public: QString msgType = "gz.msgs.StringMsg";
+  /// \brief Message type
+  public: QString msgType = "gz.msgs.StringMsg";
 
-    /// \brief Message contents
-    public: QString msgData = "data: \"Hello\"";
+  /// \brief Message contents
+  public: QString msgData = "data: \"Hello\"";
 
-    /// \brief Topic
-    public: QString topic = "/echo";
+  /// \brief Topic
+  public: QString topic = "/echo";
 
-    /// \brief Frequency
-    public: double frequency = 1.0;
+  /// \brief Frequency
+  public: double frequency = 1.0;
 
-    /// \brief Timer to keep publishing
-    public: QTimer *timer;
+  /// \brief Timer to keep publishing
+  public: QTimer *timer;
 
-    /// \brief Node for communication
-    public: gz::transport::Node node;
+  /// \brief Node for communication
+  public: gz::transport::Node node;
 
-    /// \brief Publisher
-    public: gz::transport::Node::Publisher pub;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Publisher
+  public: gz::transport::Node::Publisher pub;
+};
 
 /////////////////////////////////////////////////
 Publisher::Publisher()
@@ -206,7 +195,8 @@ void Publisher::SetFrequency(const double _frequency)
   this->dataPtr->frequency = _frequency;
   this->FrequencyChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(Publisher,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::Publisher,
+              gz::gui::Plugin)

--- a/src/plugins/publisher/Publisher.hh
+++ b/src/plugins/publisher/Publisher.hh
@@ -32,123 +32,115 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class PublisherPrivate;
+/// \brief Widget which publishes a custom Gazebo Transport message.
+///
+/// ## Configuration
+/// This plugin doesn't accept any custom configuration.
+class Publisher_EXPORTS_API Publisher : public Plugin
 {
-namespace plugins
-{
-  class PublisherPrivate;
+  Q_OBJECT
 
-  /// \brief Widget which publishes a custom Gazebo Transport message.
-  ///
-  /// ## Configuration
-  /// This plugin doesn't accept any custom configuration.
-  class Publisher_EXPORTS_API Publisher : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Message type
+  Q_PROPERTY(
+    QString msgType
+    READ MsgType
+    WRITE SetMsgType
+    NOTIFY MsgTypeChanged
+  )
 
-    /// \brief Message type
-    Q_PROPERTY(
-      QString msgType
-      READ MsgType
-      WRITE SetMsgType
-      NOTIFY MsgTypeChanged
-    )
+  /// \brief Message data
+  Q_PROPERTY(
+    QString msgData
+    READ MsgData
+    WRITE SetMsgData
+    NOTIFY MsgDataChanged
+  )
 
-    /// \brief Message data
-    Q_PROPERTY(
-      QString msgData
-      READ MsgData
-      WRITE SetMsgData
-      NOTIFY MsgDataChanged
-    )
+  /// \brief Topic
+  Q_PROPERTY(
+    QString topic
+    READ Topic
+    WRITE SetTopic
+    NOTIFY TopicChanged
+  )
 
-    /// \brief Topic
-    Q_PROPERTY(
-      QString topic
-      READ Topic
-      WRITE SetTopic
-      NOTIFY TopicChanged
-    )
+  /// \brief Frequency
+  Q_PROPERTY(
+    double frequency
+    READ Frequency
+    WRITE SetFrequency
+    NOTIFY FrequencyChanged
+  )
 
-    /// \brief Frequency
-    Q_PROPERTY(
-      double frequency
-      READ Frequency
-      WRITE SetFrequency
-      NOTIFY FrequencyChanged
-    )
+  /// \brief Constructor
+  public: Publisher();
 
-    /// \brief Constructor
-    public: Publisher();
+  /// \brief Destructor
+  public: virtual ~Publisher();
 
-    /// \brief Destructor
-    public: virtual ~Publisher();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Callback when publish button is checked or unchecked.
+  /// \param[in] _checked True if button is checked.
+  public slots: void OnPublish(const bool _checked);
 
-    /// \brief Callback when publish button is checked or unchecked.
-    /// \param[in] _checked True if button is checked.
-    public slots: void OnPublish(const bool _checked);
+  /// \brief Get the message type as a string, for example
+  /// 'gz.msgs.StringMsg'
+  /// \return Message type
+  public: Q_INVOKABLE QString MsgType() const;
 
-    /// \brief Get the message type as a string, for example
-    /// 'gz.msgs.StringMsg'
-    /// \return Message type
-    public: Q_INVOKABLE QString MsgType() const;
+  /// \brief Set the message type from a string, for example
+  /// 'gz.msgs.StringMsg'
+  /// \param[in] _msgType Message type
+  public: Q_INVOKABLE void SetMsgType(const QString &_msgType);
 
-    /// \brief Set the message type from a string, for example
-    /// 'gz.msgs.StringMsg'
-    /// \param[in] _msgType Message type
-    public: Q_INVOKABLE void SetMsgType(const QString &_msgType);
+  /// \brief Notify that message type has changed
+  signals: void MsgTypeChanged();
 
-    /// \brief Notify that message type has changed
-    signals: void MsgTypeChanged();
+  /// \brief Get the message data as a string, for example
+  /// 'data: "Hello"'
+  /// \return Message data
+  public: Q_INVOKABLE QString MsgData() const;
 
-    /// \brief Get the message data as a string, for example
-    /// 'data: "Hello"'
-    /// \return Message data
-    public: Q_INVOKABLE QString MsgData() const;
+  /// \brief Set the message data from a string, for example
+  /// 'data: "Hello"'
+  /// \param[in] _msgData Message data
+  public: Q_INVOKABLE void SetMsgData(const QString &_msgData);
 
-    /// \brief Set the message data from a string, for example
-    /// 'data: "Hello"'
-    /// \param[in] _msgData Message data
-    public: Q_INVOKABLE void SetMsgData(const QString &_msgData);
+  /// \brief Notify that message data has changed
+  signals: void MsgDataChanged();
 
-    /// \brief Notify that message data has changed
-    signals: void MsgDataChanged();
+  /// \brief Get the topic as a string, for example
+  /// '/echo'
+  /// \return Topic
+  public: Q_INVOKABLE QString Topic() const;
 
-    /// \brief Get the topic as a string, for example
-    /// '/echo'
-    /// \return Topic
-    public: Q_INVOKABLE QString Topic() const;
+  /// \brief Set the topic from a string, for example
+  /// '/echo'
+  /// \param[in] _topic Topic
+  public: Q_INVOKABLE void SetTopic(const QString &_topic);
 
-    /// \brief Set the topic from a string, for example
-    /// '/echo'
-    /// \param[in] _topic Topic
-    public: Q_INVOKABLE void SetTopic(const QString &_topic);
+  /// \brief Notify that topic has changed
+  signals: void TopicChanged();
 
-    /// \brief Notify that topic has changed
-    signals: void TopicChanged();
+  /// \brief Get the frequency, in Hz
+  /// \return Frequency
+  public: Q_INVOKABLE double Frequency() const;
 
-    /// \brief Get the frequency, in Hz
-    /// \return Frequency
-    public: Q_INVOKABLE double Frequency() const;
+  /// \brief Set the frequency, in Hz
+  /// \param[in] _frequency Frequency
+  public: Q_INVOKABLE void SetFrequency(const double _frequency);
 
-    /// \brief Set the frequency, in Hz
-    /// \param[in] _frequency Frequency
-    public: Q_INVOKABLE void SetFrequency(const double _frequency);
+  /// \brief Notify that frequency has changed
+  signals: void FrequencyChanged();
 
-    /// \brief Notify that frequency has changed
-    signals: void FrequencyChanged();
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<PublisherPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<PublisherPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_PUBLISHER_HH_

--- a/src/plugins/screenshot/Screenshot.cc
+++ b/src/plugins/screenshot/Screenshot.cc
@@ -32,39 +32,28 @@
 #include "gz/gui/GuiEvents.hh"
 #include "gz/gui/MainWindow.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class ScreenshotPrivate
 {
-namespace plugins
-{
-  class ScreenshotPrivate
-  {
-    /// \brief Node for communication
-    public: gz::transport::Node node;
+  /// \brief Node for communication
+  public: gz::transport::Node node;
 
-    /// \brief Screenshot service name
-    public: std::string screenshotService;
+  /// \brief Screenshot service name
+  public: std::string screenshotService;
 
-    /// \brief Directory to save screenshots
-    public: std::string directory;
+  /// \brief Directory to save screenshots
+  public: std::string directory;
 
-    /// \brief Whether a screenshot has been requested but not processed yet.
-    public: bool dirty{false};
+  /// \brief Whether a screenshot has been requested but not processed yet.
+  public: bool dirty{false};
 
-    /// \brief Pointer to the user camera.
-    public: gz::rendering::CameraPtr userCamera{nullptr};
+  /// \brief Pointer to the user camera.
+  public: gz::rendering::CameraPtr userCamera{nullptr};
 
-    /// \brief Saved screenshot filepath
-    public: QString savedScreenshotPath = "";
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Saved screenshot filepath
+  public: QString savedScreenshotPath = "";
+};
 
 /////////////////////////////////////////////////
 Screenshot::Screenshot()
@@ -226,7 +215,8 @@ void Screenshot::SetSavedScreenshotPath(const QString &_filename)
   this->SavedScreenshotPathChanged();
   this->savedScreenshot();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(Screenshot,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::Screenshot,
+              gz::gui::Plugin)

--- a/src/plugins/screenshot/Screenshot.hh
+++ b/src/plugins/screenshot/Screenshot.hh
@@ -25,106 +25,99 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class ScreenshotPrivate;
+
+/// \brief Provides a button and a transport service for taking a screenshot
+/// of current 3D scene.
+///
+/// /gui/screenshot service:
+///     Data: Path to save to, leave empty to save to latest path.
+///     Response: True if screenshot has been queued succesfully.
+class Screenshot : public Plugin
 {
-namespace plugins
-{
-  class ScreenshotPrivate;
+Q_OBJECT
 
-  /// \brief Provides a button and a transport service for taking a screenshot
-  /// of current 3D scene.
-  ///
-  /// /gui/screenshot service:
-  ///     Data: Path to save to, leave empty to save to latest path.
-  ///     Response: True if screenshot has been queued succesfully.
-  class Screenshot : public Plugin
-  {
-    Q_OBJECT
+/// \brief Directory to save screenshots
+Q_PROPERTY(
+  QString directory
+  READ Directory
+  WRITE SetDirectory
+  NOTIFY DirectoryChanged
+)
 
-    /// \brief Directory to save screenshots
-    Q_PROPERTY(
-      QString directory
-      READ Directory
-      WRITE SetDirectory
-      NOTIFY DirectoryChanged
-    )
+/// \brief Saved screenshot filepath
+Q_PROPERTY(
+  QString savedScreenshotPath
+  READ SavedScreenshotPath
+  WRITE SetSavedScreenshotPath
+  NOTIFY SavedScreenshotPathChanged
+)
 
-    /// \brief Saved screenshot filepath
-    Q_PROPERTY(
-      QString savedScreenshotPath
-      READ SavedScreenshotPath
-      WRITE SetSavedScreenshotPath
-      NOTIFY SavedScreenshotPathChanged
-    )
+/// \brief Constructor
+public: Screenshot();
 
-    /// \brief Constructor
-    public: Screenshot();
+/// \brief Destructor
+public: ~Screenshot() override;
 
-    /// \brief Destructor
-    public: ~Screenshot() override;
+// Documentation inherited
+public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+/// \brief Callback when screenshot is requested from the GUI.
+public slots: void OnScreenshot();
 
-    /// \brief Callback when screenshot is requested from the GUI.
-    public slots: void OnScreenshot();
+/// \brief Callback for all installed event filders.
+/// \param[in] _obj Object that received the event
+/// \param[in] _event Event
+private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    /// \brief Callback for all installed event filders.
-    /// \param[in] _obj Object that received the event
-    /// \param[in] _event Event
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
+/// \brief Callback for saving a screenshot (from the user camera) request
+/// \param[in] _msg Request message of the directory path to save
+/// screenshots
+/// \param[in] _res Response data
+/// \return True if the request is received
+private: bool ScreenshotService(const msgs::StringMsg &_msg,
+    msgs::Boolean &_res);
 
-    /// \brief Callback for saving a screenshot (from the user camera) request
-    /// \param[in] _msg Request message of the directory path to save
-    /// screenshots
-    /// \param[in] _res Response data
-    /// \return True if the request is received
-    private: bool ScreenshotService(const msgs::StringMsg &_msg,
-        msgs::Boolean &_res);
+/// \brief Encapsulates the logic to find the user camera through the
+/// render engine singleton.
+private: void FindUserCamera();
 
-    /// \brief Encapsulates the logic to find the user camera through the
-    /// render engine singleton.
-    private: void FindUserCamera();
+/// \brief Save a screenshot from the user camera
+private: void SaveScreenshot();
 
-    /// \brief Save a screenshot from the user camera
-    private: void SaveScreenshot();
+/// \brief Get the directory path as a string, for example '/home/Pictures'
+/// \return Directory
+public: Q_INVOKABLE QString Directory() const;
 
-    /// \brief Get the directory path as a string, for example '/home/Pictures'
-    /// \return Directory
-    public: Q_INVOKABLE QString Directory() const;
+/// \brief Set the directory path from a string, for example
+/// '/home/Pictures'
+/// \param[in] _dirUrl The new directory path
+public: Q_INVOKABLE void SetDirectory(const QString &_dirUrl);
 
-    /// \brief Set the directory path from a string, for example
-    /// '/home/Pictures'
-    /// \param[in] _dirUrl The new directory path
-    public: Q_INVOKABLE void SetDirectory(const QString &_dirUrl);
+/// \brief Notify that the directory path has changed
+signals: void DirectoryChanged();
 
-    /// \brief Notify that the directory path has changed
-    signals: void DirectoryChanged();
+/// \brief Get the filepath of the saved screenshot as a string, for example
+/// '/home/Pictures/[timestamp].png'
+/// \return Saved screenshot filename
+public: Q_INVOKABLE QString SavedScreenshotPath() const;
 
-    /// \brief Get the filepath of the saved screenshot as a string, for example
-    /// '/home/Pictures/[timestamp].png'
-    /// \return Saved screenshot filename
-    public: Q_INVOKABLE QString SavedScreenshotPath() const;
+/// \brief Set the filepath of the saved screenshot from a string,
+/// for example '/home/Pictures/[timestamp].png'
+/// \param[in] _filename The filename (including path) of the screenshot
+public: Q_INVOKABLE void SetSavedScreenshotPath(const QString &_filename);
 
-    /// \brief Set the filepath of the saved screenshot from a string,
-    /// for example '/home/Pictures/[timestamp].png'
-    /// \param[in] _filename The filename (including path) of the screenshot
-    public: Q_INVOKABLE void SetSavedScreenshotPath(const QString &_filename);
+/// \brief Notify that the screenshot filename has changed
+signals: void SavedScreenshotPathChanged();
 
-    /// \brief Notify that the screenshot filename has changed
-    signals: void SavedScreenshotPathChanged();
+/// \brief Notify that the screenshot has been saved (opens popup)
+signals: void savedScreenshot();
 
-    /// \brief Notify that the screenshot has been saved (opens popup)
-    signals: void savedScreenshot();
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<ScreenshotPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+/// \internal
+/// \brief Pointer to private data.
+private: std::unique_ptr<ScreenshotPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_SCREENSHOT_HH_

--- a/src/plugins/shutdown_button/ShutdownButton.cc
+++ b/src/plugins/shutdown_button/ShutdownButton.cc
@@ -22,10 +22,8 @@
 #include "gz/gui/Application.hh"
 #include "gz/gui/MainWindow.hh"
 
-using namespace gz;
-using namespace gui;
-using namespace plugins;
-
+namespace gz::gui::plugins
+{
 /////////////////////////////////////////////////
 ShutdownButton::ShutdownButton() : Plugin()
 {
@@ -47,7 +45,8 @@ void ShutdownButton::OnStop()
 {
   gui::App()->findChild<MainWindow *>()->QuickWindow()->close();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(ShutdownButton,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::ShutdownButton,
+              gz::gui::Plugin)

--- a/src/plugins/shutdown_button/ShutdownButton.hh
+++ b/src/plugins/shutdown_button/ShutdownButton.hh
@@ -30,31 +30,24 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+/// \brief This plugin provides a shutdown button.
+class ShutdownButton_EXPORTS_API ShutdownButton: public gz::gui::Plugin
 {
-namespace plugins
-{
-  /// \brief This plugin provides a shutdown button.
-  class ShutdownButton_EXPORTS_API ShutdownButton: public gz::gui::Plugin
-  {
-    Q_OBJECT
+  Q_OBJECT
 
-    /// \brief Constructor
-    public: ShutdownButton();
+  /// \brief Constructor
+  public: ShutdownButton();
 
-    /// \brief Destructor
-    public: virtual ~ShutdownButton();
+  /// \brief Destructor
+  public: virtual ~ShutdownButton();
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-    /// \brief Callback in Qt thread when close button is clicked.
-    public slots: void OnStop();
-  };
-}
-}
-}
-
-#endif
+  /// \brief Callback in Qt thread when close button is clicked.
+  public slots: void OnStop();
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_SHUTDOWNBUTTON_HH_

--- a/src/plugins/tape_measure/TapeMeasure.cc
+++ b/src/plugins/tape_measure/TapeMeasure.cc
@@ -33,64 +33,60 @@
 
 #include "TapeMeasure.hh"
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-  class TapeMeasurePrivate
-  {
-    /// \brief Gazebo communication node.
-    public: transport::Node node;
+class TapeMeasurePrivate
+{
+  /// \brief Gazebo communication node.
+  public: transport::Node node;
 
-    /// \brief True if currently measuring, else false.
-    public: bool measure = false;
+  /// \brief True if currently measuring, else false.
+  public: bool measure = false;
 
-    /// \brief The id of the start point marker.
-    public: const int kStartPointId = 1;
+  /// \brief The id of the start point marker.
+  public: const int kStartPointId = 1;
 
-    /// \brief The id of the end point marker.
-    public: const int kEndPointId = 2;
+  /// \brief The id of the end point marker.
+  public: const int kEndPointId = 2;
 
-    /// \brief The id of the line marker.
-    public: const int kLineId = 3;
+  /// \brief The id of the line marker.
+  public: const int kLineId = 3;
 
-    /// \brief The id of the start or end point marker that is currently
-    /// being placed. This is primarily used to track the state machine of
-    /// the plugin.
-    public: int currentId = kStartPointId;
+  /// \brief The id of the start or end point marker that is currently
+  /// being placed. This is primarily used to track the state machine of
+  /// the plugin.
+  public: int currentId = kStartPointId;
 
-    /// \brief The location of the placed starting point of the tape measure
-    /// tool, only set when the user clicks to set the point.
-    public: gz::math::Vector3d startPoint =
-            gz::math::Vector3d::Zero;
+  /// \brief The location of the placed starting point of the tape measure
+  /// tool, only set when the user clicks to set the point.
+  public: gz::math::Vector3d startPoint =
+          gz::math::Vector3d::Zero;
 
-    /// \brief The location of the placed ending point of the tape measure
-    /// tool, only set when the user clicks to set the point.
-    public: gz::math::Vector3d endPoint = gz::math::Vector3d::Zero;
+  /// \brief The location of the placed ending point of the tape measure
+  /// tool, only set when the user clicks to set the point.
+  public: gz::math::Vector3d endPoint = gz::math::Vector3d::Zero;
 
-    /// \brief The color to set the marker when hovering the mouse over the
-    /// scene.
-    public: gz::math::Color
-            hoverColor{gz::math::Color(0.2f, 0.2f, 0.2f, 0.5f)};
+  /// \brief The color to set the marker when hovering the mouse over the
+  /// scene.
+  public: gz::math::Color
+          hoverColor{gz::math::Color(0.2f, 0.2f, 0.2f, 0.5f)};
 
-    /// \brief The color to draw the marker when the user clicks to confirm
-    /// its location.
-    public: gz::math::Color
-            drawColor{gz::math::Color(0.2f, 0.2f, 0.2f, 1.0f)};
+  /// \brief The color to draw the marker when the user clicks to confirm
+  /// its location.
+  public: gz::math::Color
+          drawColor{gz::math::Color(0.2f, 0.2f, 0.2f, 1.0f)};
 
-    /// \brief A set of the currently placed markers.  Used to make sure a
-    /// non-existent marker is not deleted.
-    public: std::unordered_set<int> placedMarkers;
+  /// \brief A set of the currently placed markers.  Used to make sure a
+  /// non-existent marker is not deleted.
+  public: std::unordered_set<int> placedMarkers;
 
-    /// \brief The current distance between the two points.  This distance
-    /// is updated as the user hovers the end point as well.
-    public: double distance = 0.0;
+  /// \brief The current distance between the two points.  This distance
+  /// is updated as the user hovers the end point as well.
+  public: double distance = 0.0;
 
-    /// \brief The namespace that the markers for this plugin are placed in.
-    public: std::string ns = "tape_measure";
-  };
-}
-
-using namespace gz;
-using namespace gui;
+  /// \brief The namespace that the markers for this plugin are placed in.
+  public: std::string ns = "tape_measure";
+};
 
 /////////////////////////////////////////////////
 TapeMeasure::TapeMeasure()
@@ -326,7 +322,8 @@ bool TapeMeasure::eventFilter(QObject *_obj, QEvent *_event)
 
   return QObject::eventFilter(_obj, _event);
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(gz::gui::TapeMeasure,
+GZ_ADD_PLUGIN(gz::gui::plugins::TapeMeasure,
               gz::gui::Plugin)

--- a/src/plugins/tape_measure/TapeMeasure.hh
+++ b/src/plugins/tape_measure/TapeMeasure.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef GZ_GUI_TAPEMEASURE_HH_
-#define GZ_GUI_TAPEMEASURE_HH_
+#ifndef GZ_GUI_PLUGINS_TAPEMEASURE_HH_
+#define GZ_GUI_PLUGINS_TAPEMEASURE_HH_
 
 #include <memory>
 
@@ -23,83 +23,79 @@
 #include <gz/math/Vector3.hh>
 #include <gz/math/Color.hh>
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TapeMeasurePrivate;
+
+/// \brief Provides buttons for the tape measure tool.
+class TapeMeasure : public gz::gui::Plugin
 {
-  class TapeMeasurePrivate;
+  Q_OBJECT
 
-  /// \brief Provides buttons for the tape measure tool.
-  class TapeMeasure : public gz::gui::Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: TapeMeasure();
 
-    /// \brief Constructor
-    public: TapeMeasure();
+  /// \brief Destructor
+  public: ~TapeMeasure() override;
 
-    /// \brief Destructor
-    public: ~TapeMeasure() override;
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+  /// \brief Deletes the marker with the provided id within the
+  /// "tape_measure" namespace.
+  /// \param[in] _id The id of the marker
+  public: void DeleteMarker(int _id);
 
-    /// \brief Deletes the marker with the provided id within the
-    /// "tape_measure" namespace.
-    /// \param[in] _id The id of the marker
-    public: void DeleteMarker(int _id);
+  /// \brief Resets all of the relevant data for this plugin.  Called when
+  /// the user clicks the reset button and when the user starts a new
+  /// measurement.
+  public: void Reset();
 
-    /// \brief Resets all of the relevant data for this plugin.  Called when
-    /// the user clicks the reset button and when the user starts a new
-    /// measurement.
-    public: void Reset();
+  /// \brief Starts a new measurement.  Erases any previous measurement in
+  /// progress or already made.
+  public: void Measure();
 
-    /// \brief Starts a new measurement.  Erases any previous measurement in
-    /// progress or already made.
-    public: void Measure();
+  /// \brief Draws a point marker.  Called to display the start and end
+  /// point of the tape measure.
+  /// \param[in] _id The id of the marker
+  /// \param[in] _point The x, y, z coordinates of where to place the marker
+  /// \param[in] _color The rgba color to set the marker
+  public: void DrawPoint(int _id,
+              gz::math::Vector3d &_point,
+              gz::math::Color &_color);
 
-    /// \brief Draws a point marker.  Called to display the start and end
-    /// point of the tape measure.
-    /// \param[in] _id The id of the marker
-    /// \param[in] _point The x, y, z coordinates of where to place the marker
-    /// \param[in] _color The rgba color to set the marker
-    public: void DrawPoint(int _id,
-                gz::math::Vector3d &_point,
-                gz::math::Color &_color);
+  /// \brief Draws a line marker.  Called to display the line between the
+  /// start and end point of the tape measure.
+  /// \param[in] _id The id of the marker
+  /// \param[in] _startPoint The x, y, z coordinates of the line start point
+  /// \param[in] _endPoint The x, y, z coordinates of the line end point
+  /// \param[in] _color The rgba color to set the marker
+  public: void DrawLine(int _id,
+              gz::math::Vector3d &_startPoint,
+              gz::math::Vector3d &_endPoint,
+              gz::math::Color &_color);
 
-    /// \brief Draws a line marker.  Called to display the line between the
-    /// start and end point of the tape measure.
-    /// \param[in] _id The id of the marker
-    /// \param[in] _startPoint The x, y, z coordinates of the line start point
-    /// \param[in] _endPoint The x, y, z coordinates of the line end point
-    /// \param[in] _color The rgba color to set the marker
-    public: void DrawLine(int _id,
-                gz::math::Vector3d &_startPoint,
-                gz::math::Vector3d &_endPoint,
-                gz::math::Color &_color);
+  /// \brief Callback in Qt thread when the new measurement button is
+  /// clicked.
+  public slots: void OnMeasure();
 
-    /// \brief Callback in Qt thread when the new measurement button is
-    /// clicked.
-    public slots: void OnMeasure();
+  /// \brief Callback in Qt thread when the reset button is clicked.
+  public slots: void OnReset();
 
-    /// \brief Callback in Qt thread when the reset button is clicked.
-    public slots: void OnReset();
+  /// \brief Callback in Qt thread to get the distance to display in the
+  /// gui window.
+  /// \return The distance between the start and end point of the measurement
+  public slots: double Distance();
 
-    /// \brief Callback in Qt thread to get the distance to display in the
-    /// gui window.
-    /// \return The distance between the start and end point of the measurement
-    public slots: double Distance();
+  // Documentation inherited
+  protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
+  /// \brief Signal fired when a new tape measure distance is set.
+  signals: void newDistance();
 
-    /// \brief Signal fired when a new tape measure distance is set.
-    signals: void newDistance();
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<TapeMeasurePrivate> dataPtr;
-  };
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<TapeMeasurePrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TAPEMEASURE_HH_

--- a/src/plugins/teleop/Teleop.cc
+++ b/src/plugins/teleop/Teleop.cc
@@ -27,87 +27,79 @@
 #include <gz/gui/Application.hh>
 #include <gz/gui/MainWindow.hh>
 
-namespace gz
+namespace
 {
-namespace gui
+enum class KeyForward{
+  kForward,
+  kBackward,
+  kStop,
+};
+
+enum class KeyVertical{
+  kUp,
+  kDown,
+  kStop,
+};
+
+enum class KeyYaw{
+  kLeft,
+  kRight,
+  kStop,
+};
+}  // namespace
+
+namespace gz::gui::plugins
 {
-namespace plugins
+class TeleopPrivate
 {
-  enum class KeyForward{
-    kForward,
-    kBackward,
-    kStop,
-  };
+  /// \brief Node for communication.
+  public: gz::transport::Node node;
 
-  enum class KeyVertical{
-    kUp,
-    kDown,
-    kStop,
-  };
+  /// \brief Topic. Set '/cmd_vel' as default.
+  public: std::string topic = "/cmd_vel";
 
-  enum class KeyYaw{
-    kLeft,
-    kRight,
-    kStop,
-  };
+  /// \brief Publisher.
+  public: gz::transport::Node::Publisher cmdVelPub;
 
-  class TeleopPrivate
-  {
-    /// \brief Node for communication.
-    public: gz::transport::Node node;
+  /// \brief Maximum forward velocity in m/s. GUI buttons and key presses
+  /// will use this velocity. Sliders will scale up to this value.
+  public: double maxForwardVel = 1.0;
 
-    /// \brief Topic. Set '/cmd_vel' as default.
-    public: std::string topic = "/cmd_vel";
+  /// \brief Maximum vertical velocity in m/s. GUI buttons and key presses
+  /// will use this velocity. Sliders will scale up to this value.
+  public: double maxVerticalVel = 1.0;
 
-    /// \brief Publisher.
-    public: gz::transport::Node::Publisher cmdVelPub;
+  /// \brief Maximum yaw velocity in rad/s. GUI buttons and key presses
+  /// will use this velocity. Sliders will scale up to this value.
+  public: double maxYawVel = 0.5;
 
-    /// \brief Maximum forward velocity in m/s. GUI buttons and key presses
-    /// will use this velocity. Sliders will scale up to this value.
-    public: double maxForwardVel = 1.0;
+  /// \brief Forward scale to multiply by maxForwardVel, in the [-1, 1] range.
+  /// Negative values go backwards, zero stops movement in the forward axis.
+  public: int forwardKeyScale = 0;
 
-    /// \brief Maximum vertical velocity in m/s. GUI buttons and key presses
-    /// will use this velocity. Sliders will scale up to this value.
-    public: double maxVerticalVel = 1.0;
+  /// \brief Vertical scale to multiply by maxVerticalVel, in the [-1, 1]
+  /// range. Negative values go down, zero stops movement in the vertical
+  /// axis.
+  public: int verticalKeyScale = 0;
 
-    /// \brief Maximum yaw velocity in rad/s. GUI buttons and key presses
-    /// will use this velocity. Sliders will scale up to this value.
-    public: double maxYawVel = 0.5;
+  /// \brief Yaw scale to multiply by maxYawVel, in the [-1, 1] range.
+  /// Negative values rotate clockwise when looking from above, zero stops
+  /// movement in the yaw axis.
+  public: int yawKeyScale = 0;
 
-    /// \brief Forward scale to multiply by maxForwardVel, in the [-1, 1] range.
-    /// Negative values go backwards, zero stops movement in the forward axis.
-    public: int forwardKeyScale = 0;
+  /// \brief Forward state set by keyboard input.
+  public: KeyForward forwardKeyState = KeyForward::kStop;
 
-    /// \brief Vertical scale to multiply by maxVerticalVel, in the [-1, 1]
-    /// range. Negative values go down, zero stops movement in the vertical
-    /// axis.
-    public: int verticalKeyScale = 0;
+  /// \brief Vertical state set by keyboard input.
+  public: KeyVertical verticalKeyState = KeyVertical::kStop;
 
-    /// \brief Yaw scale to multiply by maxYawVel, in the [-1, 1] range.
-    /// Negative values rotate clockwise when looking from above, zero stops
-    /// movement in the yaw axis.
-    public: int yawKeyScale = 0;
+  /// \brief Yaw state set by keyboard input.
+  public: KeyYaw yawKeyState = KeyYaw::kStop;
 
-    /// \brief Forward state set by keyboard input.
-    public: KeyForward forwardKeyState = KeyForward::kStop;
-
-    /// \brief Vertical state set by keyboard input.
-    public: KeyVertical verticalKeyState = KeyVertical::kStop;
-
-    /// \brief Yaw state set by keyboard input.
-    public: KeyYaw yawKeyState = KeyYaw::kStop;
-
-    /// \brief Indicates if the keyboard is enabled or
-    /// disabled.
-    public: bool keyEnable = false;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Indicates if the keyboard is enabled or
+  /// disabled.
+  public: bool keyEnable = false;
+};
 
 /////////////////////////////////////////////////
 Teleop::Teleop(): Plugin(), dataPtr(std::make_unique<TeleopPrivate>())
@@ -324,7 +316,8 @@ void Teleop::SetKeyScale()
       KeyYaw::kLeft ? 1 : this->dataPtr->yawKeyState ==
       KeyYaw::kRight ? -1 : 0;
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(Teleop,
+GZ_ADD_PLUGIN(gz::gui::plugins::Teleop,
               gui::Plugin)

--- a/src/plugins/teleop/Teleop.hh
+++ b/src/plugins/teleop/Teleop.hh
@@ -35,135 +35,128 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TeleopPrivate;
+
+/// \brief Publish teleop stokes to a user selected topic,
+/// or to '/cmd_vel' if no topic is selected.
+/// Buttons, the keyboard or sliders can be used to move a
+/// vehicle in the world.
+/// ## Configuration
+/// * `<topic>`: Topic to publish twist messages to.
+class Teleop_EXPORTS_API Teleop : public Plugin
 {
-namespace plugins
-{
-  class TeleopPrivate;
+  Q_OBJECT
 
-  /// \brief Publish teleop stokes to a user selected topic,
-  /// or to '/cmd_vel' if no topic is selected.
-  /// Buttons, the keyboard or sliders can be used to move a
-  /// vehicle in the world.
-  /// ## Configuration
-  /// * `<topic>`: Topic to publish twist messages to.
-  class Teleop_EXPORTS_API Teleop : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Topic
+  Q_PROPERTY(
+    QString topic
+    READ Topic
+    WRITE SetTopic
+    NOTIFY TopicChanged
+  )
 
-    /// \brief Topic
-    Q_PROPERTY(
-      QString topic
-      READ Topic
-      WRITE SetTopic
-      NOTIFY TopicChanged
-    )
+  /// \brief Forward velocity
+  Q_PROPERTY(
+    double maxForwardVel
+    READ MaxForwardVel
+    WRITE SetMaxForwardVel
+    NOTIFY MaxForwardVelChanged
+  )
 
-    /// \brief Forward velocity
-    Q_PROPERTY(
-      double maxForwardVel
-      READ MaxForwardVel
-      WRITE SetMaxForwardVel
-      NOTIFY MaxForwardVelChanged
-    )
+  /// \brief Vertical velocity
+  Q_PROPERTY(
+    double maxVerticalVel
+    READ MaxVerticalVel
+    WRITE SetMaxVerticalVel
+    NOTIFY MaxVerticalVelChanged
+  )
 
-    /// \brief Vertical velocity
-    Q_PROPERTY(
-      double maxVerticalVel
-      READ MaxVerticalVel
-      WRITE SetMaxVerticalVel
-      NOTIFY MaxVerticalVelChanged
-    )
+  /// \brief Yaw velocity
+  Q_PROPERTY(
+    double maxYawVel
+    READ MaxYawVel
+    WRITE SetMaxYawVel
+    NOTIFY MaxYawVelChanged
+  )
 
-    /// \brief Yaw velocity
-    Q_PROPERTY(
-      double maxYawVel
-      READ MaxYawVel
-      WRITE SetMaxYawVel
-      NOTIFY MaxYawVelChanged
-    )
+  /// \brief Constructor
+  public: Teleop();
 
-    /// \brief Constructor
-    public: Teleop();
+  /// \brief Destructor
+  public: virtual ~Teleop();
 
-    /// \brief Destructor
-    public: virtual ~Teleop();
+  // Documentation inherited.
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *) override;
 
-    // Documentation inherited.
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *) override;
+  /// \brief Filters events of type 'keypress' and 'keyrelease'.
+  protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    /// \brief Filters events of type 'keypress' and 'keyrelease'.
-    protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
+  /// \brief Publish the twist message to the selected command velocity topic.
+  /// \param[in] _forwardVel Forward velocity
+  /// \param[in] _verticalVel Vertical velocity
+  /// \param[in] _angVel Yaw velocity
+  public slots: void OnTeleopTwist(double _forwardVel, double _verticalVel,
+      double _angVel);
 
-    /// \brief Publish the twist message to the selected command velocity topic.
-    /// \param[in] _forwardVel Forward velocity
-    /// \param[in] _verticalVel Vertical velocity
-    /// \param[in] _angVel Yaw velocity
-    public slots: void OnTeleopTwist(double _forwardVel, double _verticalVel,
-        double _angVel);
+  /// \brief Get the topic as a string, for example
+  /// '/echo'
+  /// \return Topic
+  public: Q_INVOKABLE QString Topic() const;
 
-    /// \brief Get the topic as a string, for example
-    /// '/echo'
-    /// \return Topic
-    public: Q_INVOKABLE QString Topic() const;
+  /// \brief Callback in Qt thread when the topic changes.
+  /// \param[in] _topic variable to indicate the topic to
+  /// publish the Twist commands.
+  public slots: void SetTopic(const QString &_topic);
 
-    /// \brief Callback in Qt thread when the topic changes.
-    /// \param[in] _topic variable to indicate the topic to
-    /// publish the Twist commands.
-    public slots: void SetTopic(const QString &_topic);
+  /// \brief Notify that topic has changed
+  signals: void TopicChanged();
 
-    /// \brief Notify that topic has changed
-    signals: void TopicChanged();
+  /// \brief Get the forward velocity.
+  /// \return Forward velocity.
+  public: Q_INVOKABLE double MaxForwardVel() const;
 
-    /// \brief Get the forward velocity.
-    /// \return Forward velocity.
-    public: Q_INVOKABLE double MaxForwardVel() const;
+  /// \brief Callback in Qt thread when the forward velocity changes.
+  /// \param[in] _velocity variable to indicate the forward velocity.
+  public slots: void SetMaxForwardVel(double _velocity);
 
-    /// \brief Callback in Qt thread when the forward velocity changes.
-    /// \param[in] _velocity variable to indicate the forward velocity.
-    public slots: void SetMaxForwardVel(double _velocity);
+  /// \brief Notify that forward velocity has changed
+  signals: void MaxForwardVelChanged();
 
-    /// \brief Notify that forward velocity has changed
-    signals: void MaxForwardVelChanged();
+  /// \brief Get the vertical velocity.
+  /// \return Vertical velocity.
+  public: Q_INVOKABLE double MaxVerticalVel() const;
 
-    /// \brief Get the vertical velocity.
-    /// \return Vertical velocity.
-    public: Q_INVOKABLE double MaxVerticalVel() const;
+  /// \brief Callback in Qt thread when the vertical velocity changes.
+  /// \param[in] _velocity variable to indicate the vertical velocity.
+  public slots: void SetMaxVerticalVel(double _velocity);
 
-    /// \brief Callback in Qt thread when the vertical velocity changes.
-    /// \param[in] _velocity variable to indicate the vertical velocity.
-    public slots: void SetMaxVerticalVel(double _velocity);
+  /// \brief Notify that vertical velocity has changed
+  signals: void MaxVerticalVelChanged();
 
-    /// \brief Notify that vertical velocity has changed
-    signals: void MaxVerticalVelChanged();
+  /// \brief Get the yaw velocity.
+  /// \return Yaw velocity.
+  public: Q_INVOKABLE double MaxYawVel() const;
 
-    /// \brief Get the yaw velocity.
-    /// \return Yaw velocity.
-    public: Q_INVOKABLE double MaxYawVel() const;
+  /// \brief Callback in Qt thread when the yaw velocity changes.
+  /// \param[in] _velocity variable to indicate the yaw velocity.
+  public slots: void SetMaxYawVel(double _velocity);
 
-    /// \brief Callback in Qt thread when the yaw velocity changes.
-    /// \param[in] _velocity variable to indicate the yaw velocity.
-    public slots: void SetMaxYawVel(double _velocity);
+  /// \brief Notify that yaw velocity has changed
+  signals: void MaxYawVelChanged();
 
-    /// \brief Notify that yaw velocity has changed
-    signals: void MaxYawVelChanged();
+  /// \brief Callback in Qt thread when the keyboard is enabled or disabled.
+  /// \param[in] _checked variable to indicate the state of the switch.
+  public slots: void OnKeySwitch(bool _checked);
 
-    /// \brief Callback in Qt thread when the keyboard is enabled or disabled.
-    /// \param[in] _checked variable to indicate the state of the switch.
-    public slots: void OnKeySwitch(bool _checked);
+  /// \brief Sets the movement scale when the keyboard is used.
+  public: void SetKeyScale();
 
-    /// \brief Sets the movement scale when the keyboard is used.
-    public: void SetKeyScale();
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<TeleopPrivate> dataPtr;
 
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<TeleopPrivate> dataPtr;
-
-  };
-}
-}
-}
-
-#endif
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TELEOP_HH_

--- a/src/plugins/topic_echo/TopicEcho.cc
+++ b/src/plugins/topic_echo/TopicEcho.cc
@@ -23,40 +23,29 @@
 #include "gz/gui/Application.hh"
 #include "TopicEcho.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TopicEchoPrivate
 {
-namespace plugins
-{
-  class TopicEchoPrivate
-  {
-    /// \brief Topic
-    public: QString topic{"/echo"};
+  /// \brief Topic
+  public: QString topic{"/echo"};
 
-    /// \brief A list of text data.
-    public: QStringListModel msgList;
+  /// \brief A list of text data.
+  public: QStringListModel msgList;
 
-    /// \brief Size of the text buffer. The size is the number of
-    /// messages.
-    public: unsigned int buffer{10u};
+  /// \brief Size of the text buffer. The size is the number of
+  /// messages.
+  public: unsigned int buffer{10u};
 
-    /// \brief Flag used to pause message parsing.
-    public: bool paused{false};
+  /// \brief Flag used to pause message parsing.
+  public: bool paused{false};
 
-    /// \brief Mutex to protect message buffer.
-    public: std::mutex mutex;
+  /// \brief Mutex to protect message buffer.
+  public: std::mutex mutex;
 
-    /// \brief Node for communication
-    public: gz::transport::Node node;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Node for communication
+  public: gz::transport::Node node;
+};
 
 /////////////////////////////////////////////////
 TopicEcho::TopicEcho()
@@ -176,8 +165,8 @@ void TopicEcho::SetPaused(const bool &_paused)
   this->dataPtr->paused = _paused;
   this->PausedChanged();
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(TopicEcho,
-              gui::Plugin)
-
+GZ_ADD_PLUGIN(gz::gui::plugins::TopicEcho,
+              gz::gui::Plugin)

--- a/src/plugins/topic_echo/TopicEcho.hh
+++ b/src/plugins/topic_echo/TopicEcho.hh
@@ -41,97 +41,90 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TopicEchoPrivate;
+
+/// \brief Echo messages coming through a Gazebo Transport topic.
+///
+/// ## Configuration
+/// This plugin doesn't accept any custom configuration.
+class TopicEcho_EXPORTS_API TopicEcho : public Plugin
 {
-namespace plugins
-{
-  class TopicEchoPrivate;
+  Q_OBJECT
 
-  /// \brief Echo messages coming through a Gazebo Transport topic.
-  ///
-  /// ## Configuration
-  /// This plugin doesn't accept any custom configuration.
-  class TopicEcho_EXPORTS_API TopicEcho : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Topic
+  Q_PROPERTY(
+    QString topic
+    READ Topic
+    WRITE SetTopic
+    NOTIFY TopicChanged
+  )
 
-    /// \brief Topic
-    Q_PROPERTY(
-      QString topic
-      READ Topic
-      WRITE SetTopic
-      NOTIFY TopicChanged
-    )
+  /// \brief Paused
+  Q_PROPERTY(
+    bool paused
+    READ Paused
+    WRITE SetPaused
+    NOTIFY PausedChanged
+  )
 
-    /// \brief Paused
-    Q_PROPERTY(
-      bool paused
-      READ Paused
-      WRITE SetPaused
-      NOTIFY PausedChanged
-    )
+  /// \brief Constructor
+  public: TopicEcho();
 
-    /// \brief Constructor
-    public: TopicEcho();
+  /// \brief Destructor
+  public: virtual ~TopicEcho();
 
-    /// \brief Destructor
-    public: virtual ~TopicEcho();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Get the topic as a string, for example
+  /// '/echo'
+  /// \return Topic
+  public: Q_INVOKABLE QString Topic() const;
 
-    /// \brief Get the topic as a string, for example
-    /// '/echo'
-    /// \return Topic
-    public: Q_INVOKABLE QString Topic() const;
+  /// \brief Set the topic from a string, for example
+  /// '/echo'
+  /// \param[in] _topic Topic
+  public: Q_INVOKABLE void SetTopic(const QString &_topic);
 
-    /// \brief Set the topic from a string, for example
-    /// '/echo'
-    /// \param[in] _topic Topic
-    public: Q_INVOKABLE void SetTopic(const QString &_topic);
+  /// \brief Notify that topic has changed
+  signals: void TopicChanged();
 
-    /// \brief Notify that topic has changed
-    signals: void TopicChanged();
+  public slots: void OnBuffer(const unsigned int _steps);
 
-    public slots: void OnBuffer(const unsigned int _steps);
+  /// \brief Get whether it is paused
+  /// \return True if paused
+  public: Q_INVOKABLE bool Paused() const;
 
-    /// \brief Get whether it is paused
-    /// \return True if paused
-    public: Q_INVOKABLE bool Paused() const;
+  /// \brief Set whether to be paused
+  /// \param[in] _paused True if paused
+  public: Q_INVOKABLE void SetPaused(const bool &_paused);
 
-    /// \brief Set whether to be paused
-    /// \param[in] _paused True if paused
-    public: Q_INVOKABLE void SetPaused(const bool &_paused);
+  /// \brief Notify that paused has changed
+  signals: void PausedChanged();
 
-    /// \brief Notify that paused has changed
-    signals: void PausedChanged();
+  /// \brief Signal to add a message to the GUI list.
+  /// \param[in] _msg Text message to add.
+  signals: void AddMsg(QString _msg);
 
-    /// \brief Signal to add a message to the GUI list.
-    /// \param[in] _msg Text message to add.
-    signals: void AddMsg(QString _msg);
+  /// \brief Receives incoming text messages.
+  /// \param[in] _msg New text message.
+  private: void OnMessage(const google::protobuf::Message &_msg);
 
-    /// \brief Receives incoming text messages.
-    /// \param[in] _msg New text message.
-    private: void OnMessage(const google::protobuf::Message &_msg);
+  /// \brief Clear list and unsubscribe.
+  private: void Stop();
 
-    /// \brief Clear list and unsubscribe.
-    private: void Stop();
+  /// \brief Callback when echo button is pressed
+  public slots: void OnEcho(const bool _checked);
 
-    /// \brief Callback when echo button is pressed
-    public slots: void OnEcho(const bool _checked);
+  /// \brief Callback from the ::AddMsg signal.
+  /// \param[in] _msg Message to add to the list.
+  private slots: void OnAddMsg(QString _msg);
 
-    /// \brief Callback from the ::AddMsg signal.
-    /// \param[in] _msg Message to add to the list.
-    private slots: void OnAddMsg(QString _msg);
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<TopicEchoPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<TopicEchoPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TOPICECHO_HH_

--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -46,109 +46,95 @@
 #define PATH_ROLE 54
 #define PLOT_ROLE 55
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TopicsModel : public QStandardItemModel
 {
-namespace plugins
-{
-  /// \brief Model for the Topics and their Msgs and Fields
-  /// a tree model that represents the topics tree with its Msgs
-  /// Childeren and each msg node has its own fileds/msgs childeren
-  class TopicsModel : public QStandardItemModel
+  /// \brief roles and names of the model
+  public: QHash<int, QByteArray> roleNames() const override
   {
-    /// \brief roles and names of the model
-    public: QHash<int, QByteArray> roleNames() const override
-    {
-      QHash<int, QByteArray> roles;
-      roles[NAME_ROLE] = NAME_KEY;
-      roles[TYPE_ROLE] = TYPE_KEY;
-      roles[TOPIC_ROLE] = TOPIC_KEY;
-      roles[PATH_ROLE] = PATH_KEY;
-      roles[PLOT_ROLE] = PLOT_KEY;
-      return roles;
-    }
-  };
+    QHash<int, QByteArray> roles;
+    roles[NAME_ROLE] = NAME_KEY;
+    roles[TYPE_ROLE] = TYPE_KEY;
+    roles[TOPIC_ROLE] = TOPIC_KEY;
+    roles[PATH_ROLE] = PATH_KEY;
+    roles[PLOT_ROLE] = PLOT_KEY;
+    return roles;
+  }
+};
 
-  class TopicViewerPrivate
-  {
-    /// \brief Node for Commincation
-    public: gz::transport::Node node;
+class TopicViewerPrivate
+{
+  /// \brief Node for Commincation
+  public: gz::transport::Node node;
 
-    /// \brief Model to create it from the available topics and messages
-    public: TopicsModel *model;
+  /// \brief Model to create it from the available topics and messages
+  public: TopicsModel *model;
 
-    /// \brief Timer to update the model and keep track of its changes
-    public: QTimer *timer;
+  /// \brief Timer to update the model and keep track of its changes
+  public: QTimer *timer;
 
-    /// \brief topic: msgType map to keep track of the model current topics
-    public: std::map<std::string, std::string> currentTopics;
+  /// \brief topic: msgType map to keep track of the model current topics
+  public: std::map<std::string, std::string> currentTopics;
 
-    /// \brief Create the fields model
-    public: void CreateModel();
+  /// \brief Create the fields model
+  public: void CreateModel();
 
-    /// \brief add a topic to the model
-    /// \param[in] _topic topic name to be displayed
-    /// \param[in] _msg topic's msg type
-    public: void AddTopic(const std::string &_topic,
-                         const std::string &_msg);
+  /// \brief add a topic to the model
+  /// \param[in] _topic topic name to be displayed
+  /// \param[in] _msg topic's msg type
+  public: void AddTopic(const std::string &_topic,
+                       const std::string &_msg);
 
-    /// \brief add a field/msg child to that parent item
-    /// \param[in] _parentItem a parent for the added field/msg
-    /// \param[in] _msgName the displayed name of the field/msg
-    /// \param[in] _msgType field/msg type
-    public: void AddField(QStandardItem *_parentItem,
-                       const std::string &_msgName,
-                       const std::string &_msgType);
+  /// \brief add a field/msg child to that parent item
+  /// \param[in] _parentItem a parent for the added field/msg
+  /// \param[in] _msgName the displayed name of the field/msg
+  /// \param[in] _msgType field/msg type
+  public: void AddField(QStandardItem *_parentItem,
+                     const std::string &_msgName,
+                     const std::string &_msgType);
 
-    /// \brief factory method for creating an item
-    /// \param[in] _name the display name
-    /// \param[in] _type type of the field of the item
-    /// \param[in] _path a set of concatenate strings of parent msgs
-    /// names that lead to that field, starting from the most parent
-    /// ex : if we have [Collision]msg contains [pose]msg contains [position]
-    /// msg contains [x,y,z] fields, so the path of x = "pose-position-x"
-    /// \param[in] _topic the name of the most parent item
-    /// \return the created Item
-    public: QStandardItem *FactoryItem(const std::string &_name,
-                                      const std::string &_type,
-                                      const std::string &_path = "",
-                                      const std::string &_topic = "");
+  /// \brief factory method for creating an item
+  /// \param[in] _name the display name
+  /// \param[in] _type type of the field of the item
+  /// \param[in] _path a set of concatenate strings of parent msgs
+  /// names that lead to that field, starting from the most parent
+  /// ex : if we have [Collision]msg contains [pose]msg contains [position]
+  /// msg contains [x,y,z] fields, so the path of x = "pose-position-x"
+  /// \param[in] _topic the name of the most parent item
+  /// \return the created Item
+  public: QStandardItem *FactoryItem(const std::string &_name,
+                                    const std::string &_type,
+                                    const std::string &_path = "",
+                                    const std::string &_topic = "");
 
-    /// \brief set the topic role name of the item with the most
-    /// topic parent of that field item
-    /// \param[in] _item item ref to set its topic
-    public: void SetItemTopic(QStandardItem *_item);
+  /// \brief set the topic role name of the item with the most
+  /// topic parent of that field item
+  /// \param[in] _item item ref to set its topic
+  public: void SetItemTopic(QStandardItem *_item);
 
-    /// \brief set the path/ID of the givin item starting from
-    /// the most topic parent to the field itself
-    /// \param[in] _item item ref to set its path
-    public: void SetItemPath(QStandardItem *_item);
+  /// \brief set the path/ID of the givin item starting from
+  /// the most topic parent to the field itself
+  /// \param[in] _item item ref to set its path
+  public: void SetItemPath(QStandardItem *_item);
 
-    /// \brief get the topic name of selected item
-    /// \param[in] _item ref to the item to get its parent topic
-    public: std::string TopicName(const QStandardItem *_item) const;
+  /// \brief get the topic name of selected item
+  /// \param[in] _item ref to the item to get its parent topic
+  public: std::string TopicName(const QStandardItem *_item) const;
 
-    /// \brief full path starting from topic name till the msg name
-    /// \param[in] _index index of the QStanadardItem
-    /// \return string with all elements separated by '/'
-    public: std::string ItemPath(const QStandardItem *_item) const;
+  /// \brief full path starting from topic name till the msg name
+  /// \param[in] _index index of the QStanadardItem
+  /// \return string with all elements separated by '/'
+  public: std::string ItemPath(const QStandardItem *_item) const;
 
-    /// \brief check if the type is supported in the plotting types
-    /// \param[in] _type the msg type to check if it is supported
-    public: bool IsPlotable(
-            const google::protobuf::FieldDescriptor::Type &_type);
+  /// \brief check if the type is supported in the plotting types
+  /// \param[in] _type the msg type to check if it is supported
+  public: bool IsPlotable(
+          const google::protobuf::FieldDescriptor::Type &_type);
 
-    /// \brief supported types for plotting
-    public: std::vector<google::protobuf::FieldDescriptor::Type> plotableTypes;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief supported types for plotting
+  public: std::vector<google::protobuf::FieldDescriptor::Type> plotableTypes;
+};
 
 TopicViewer::TopicViewer() : Plugin(), dataPtr(new TopicViewerPrivate)
 {
@@ -432,8 +418,7 @@ void TopicViewer::UpdateModel()
     }
   }
 }
-
-
+}  // namespace gz::gui::plugins
 // Register this plugin
-GZ_ADD_PLUGIN(TopicViewer,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::TopicViewer,
+              gz::gui::Plugin)

--- a/src/plugins/topic_viewer/TopicViewer.hh
+++ b/src/plugins/topic_viewer/TopicViewer.hh
@@ -14,6 +14,10 @@
  * limitations under the License.
  *
 */
+
+#ifndef GZ_GUI_PLUGINS_TOPICVIEWER_HH_
+#define GZ_GUI_PLUGINS_TOPICVIEWER_HH_
+
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
@@ -28,41 +32,35 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TopicsModel;
+class TopicViewerPrivate;
+
+/// \brief a Plugin to view the topics and their msgs & fields
+/// Field's informations can be passed by dragging them via the UI
+class TopicViewer_EXPORTS_API TopicViewer : public Plugin
 {
-namespace plugins
-{
-  class TopicsModel;
-  class TopicViewerPrivate;
+  Q_OBJECT
 
-  /// \brief a Plugin to view the topics and their msgs & fields
-  /// Field's informations can be passed by dragging them via the UI
-  class TopicViewer_EXPORTS_API TopicViewer : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: TopicViewer();
 
-    /// \brief Constructor
-    public: TopicViewer();
+  /// \brief Destructor
+  public: ~TopicViewer();
 
-    /// \brief Destructor
-    public: ~TopicViewer();
+  /// \brief Documentaation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *) override;
 
-    /// \brief Documentaation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *) override;
+  /// \brief Get the model of msgs & fields
+  /// \return Pointer to the model of msgs & fields
+  public: QStandardItemModel *Model();
 
-    /// \brief Get the model of msgs & fields
-    /// \return Pointer to the model of msgs & fields
-    public: QStandardItemModel *Model();
+  /// \brief update the model according to the changes of the topics
+  public slots: void UpdateModel();
 
-    /// \brief update the model according to the changes of the topics
-    public slots: void UpdateModel();
-
-    /// \brief Pointer to private data.
-    private: std:: unique_ptr<TopicViewerPrivate> dataPtr;
-  };
-
-}
-}
-}
+  /// \brief Pointer to private data.
+  private: std:: unique_ptr<TopicViewerPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TOPICVIEWER_HH_

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -54,8 +54,10 @@
 
 #include "TransportSceneManager.hh"
 
+namespace gz::gui::plugins
+{
 /// \brief Private data class for TransportSceneManager
-class gz::gui::plugins::TransportSceneManagerPrivate
+class TransportSceneManagerPrivate
 {
   /// \brief Make the scene service request and populate the scene
   public: void Request();
@@ -171,10 +173,6 @@ class gz::gui::plugins::TransportSceneManagerPrivate
   /// \brief Thread to wait for transport initialization
   public: std::thread initializeTransport;
 };
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
 
 /////////////////////////////////////////////////
 TransportSceneManager::TransportSceneManager()
@@ -871,6 +869,7 @@ void TransportSceneManagerPrivate::DeleteEntity(const unsigned int _entity)
     this->lights.erase(_entity);
   }
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::TransportSceneManager,

--- a/src/plugins/transport_scene_manager/TransportSceneManager.hh
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.hh
@@ -22,50 +22,43 @@
 
 #include "gz/gui/Plugin.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class TransportSceneManagerPrivate;
+
+/// \brief Provides a Gazebo Transport interface to
+/// `gz::gui::plugins::MinimalScene`.
+///
+/// ## Configuration
+///
+/// * \<service\> : Name of service where this system will request a scene
+///                 message. Optional, defaults to "/scene".
+/// * \<pose_topic\> : Name of topic to subscribe to receive pose updates.
+///                    Optional, defaults to "/pose".
+/// * \<deletion_topic\> : Name of topic to request entity deletions.
+///                        Optional, defaults to "/delete".
+/// * \<scene_topic\> : Name of topic to receive scene updates. Optional,
+///                     defaults to "/scene".
+class TransportSceneManager : public Plugin
 {
-namespace plugins
-{
-  class TransportSceneManagerPrivate;
+  Q_OBJECT
 
-  /// \brief Provides a Gazebo Transport interface to
-  /// `gz::gui::plugins::MinimalScene`.
-  ///
-  /// ## Configuration
-  ///
-  /// * \<service\> : Name of service where this system will request a scene
-  ///                 message. Optional, defaults to "/scene".
-  /// * \<pose_topic\> : Name of topic to subscribe to receive pose updates.
-  ///                    Optional, defaults to "/pose".
-  /// * \<deletion_topic\> : Name of topic to request entity deletions.
-  ///                        Optional, defaults to "/delete".
-  /// * \<scene_topic\> : Name of topic to receive scene updates. Optional,
-  ///                     defaults to "/scene".
-  class TransportSceneManager : public Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: TransportSceneManager();
 
-    /// \brief Constructor
-    public: TransportSceneManager();
+  /// \brief Destructor
+  public: virtual ~TransportSceneManager();
 
-    /// \brief Destructor
-    public: virtual ~TransportSceneManager();
+  // Documentation inherited
+  public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+      override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  // Documentation inherited
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-    // Documentation inherited
-    private: bool eventFilter(QObject *_obj, QEvent *_event) override;
-
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<TransportSceneManagerPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<TransportSceneManagerPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TRANSPORTSCENEMANAGER_HH_

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -33,52 +33,41 @@
 #include "gz/gui/GuiEvents.hh"
 #include "gz/gui/MainWindow.hh"
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class WorldControlPrivate
 {
-namespace plugins
-{
-  class WorldControlPrivate
-  {
-    /// \brief Send the world control event or call the control service.
-    /// \param[in] _msg Message to send.
-    public: void SendEventMsg(const gz::msgs::WorldControl &_msg);
+  /// \brief Send the world control event or call the control service.
+  /// \param[in] _msg Message to send.
+  public: void SendEventMsg(const gz::msgs::WorldControl &_msg);
 
-    /// \brief Message holding latest world statistics
-    public: gz::msgs::WorldStatistics msg;
+  /// \brief Message holding latest world statistics
+  public: gz::msgs::WorldStatistics msg;
 
-    /// \brief Service to send world control requests
-    public: std::string controlService;
+  /// \brief Service to send world control requests
+  public: std::string controlService;
 
-    /// \brief Mutex to protect msg
-    public: std::recursive_mutex mutex;
+  /// \brief Mutex to protect msg
+  public: std::recursive_mutex mutex;
 
-    /// \brief Communication node
-    public: gz::transport::Node node;
+  /// \brief Communication node
+  public: gz::transport::Node node;
 
-    /// \brief The multi step value
-    public: unsigned int multiStep = 1u;
+  /// \brief The multi step value
+  public: unsigned int multiStep = 1u;
 
-    /// \brief True for paused
-    public: bool pause{true};
+  /// \brief True for paused
+  public: bool pause{true};
 
-    /// \brief The paused state of the most recently received world stats msg
-    /// (true for paused)
-    public: bool lastStatsMsgPaused{true};
+  /// \brief The paused state of the most recently received world stats msg
+  /// (true for paused)
+  public: bool lastStatsMsgPaused{true};
 
-    /// \brief Whether server communication should occur through an event (true)
-    /// or service (false). The service option was used by default for
-    /// gz-gui7 and earlier, and now uses the event by default in gz-gui8.
-    public: bool useEvent{true};
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+  /// \brief Whether server communication should occur through an event (true)
+  /// or service (false). The service option was used by default for
+  /// gz-gui7 and earlier, and now uses the event by default in gz-gui8.
+  public: bool useEvent{true};
+};
 
 /////////////////////////////////////////////////
 WorldControl::WorldControl()
@@ -358,7 +347,8 @@ void WorldControlPrivate::SendEventMsg(const msgs::WorldControl &_msg)
     this->node.Request(this->controlService, _msg, cb);
   }
 }
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(WorldControl,
-              gui::Plugin)
+GZ_ADD_PLUGIN(gz::gui::plugins::WorldControl,
+              gz::gui::Plugin)

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -34,81 +34,74 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class WorldControlPrivate;
+
+/// \brief This plugin provides a world control panel which may have a
+/// play / pause and step buttons.
+///
+/// ## Configuration
+///
+/// * \<play_pause\> : Set to true to see a play/pause button,
+///                    false by default.
+/// * \<step\> : Set to true to see a step button, false by default.
+/// * \<start_paused\> : Set to false to start playing, false by default.
+/// * \<service\> : Service for world control, optional. If not presnt,
+///               the plugin will attempt to create a topic with the main
+///               window's `worldName` property.
+/// * \<stats_topic\> : Topic to receive world statistics, optional. If not
+///               present, the plugin will attempt to create a topic with the
+///               main window's `worldName` property.
+///
+/// If no elements are filled for the plugin, both the play/pause and the
+/// step buttons will be displayed.
+class WorldControl_EXPORTS_API WorldControl: public gz::gui::Plugin
 {
-namespace plugins
-{
-  class WorldControlPrivate;
+  Q_OBJECT
 
-  /// \brief This plugin provides a world control panel which may have a
-  /// play / pause and step buttons.
-  ///
-  /// ## Configuration
-  ///
-  /// * \<play_pause\> : Set to true to see a play/pause button,
-  ///                    false by default.
-  /// * \<step\> : Set to true to see a step button, false by default.
-  /// * \<start_paused\> : Set to false to start playing, false by default.
-  /// * \<service\> : Service for world control, optional. If not presnt,
-  ///               the plugin will attempt to create a topic with the main
-  ///               window's `worldName` property.
-  /// * \<stats_topic\> : Topic to receive world statistics, optional. If not
-  ///               present, the plugin will attempt to create a topic with the
-  ///               main window's `worldName` property.
-  ///
-  /// If no elements are filled for the plugin, both the play/pause and the
-  /// step buttons will be displayed.
-  class WorldControl_EXPORTS_API WorldControl: public gz::gui::Plugin
-  {
-    Q_OBJECT
+  /// \brief Constructor
+  public: WorldControl();
 
-    /// \brief Constructor
-    public: WorldControl();
+  /// \brief Destructor
+  public: virtual ~WorldControl();
 
-    /// \brief Destructor
-    public: virtual ~WorldControl();
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Callback in main thread when diagnostics come in
+  public slots: void ProcessMsg();
 
-    /// \brief Callback in main thread when diagnostics come in
-    public slots: void ProcessMsg();
+  /// \brief Callback in Qt thread when play button is clicked.
+  public slots: void OnPlay();
 
-    /// \brief Callback in Qt thread when play button is clicked.
-    public slots: void OnPlay();
+  /// \brief Callback in Qt thread when pause button is clicked.
+  public slots: void OnPause();
 
-    /// \brief Callback in Qt thread when pause button is clicked.
-    public slots: void OnPause();
+  /// \brief Callback in Qt thread when reset button is clicked.
+  public slots: void OnReset();
 
-    /// \brief Callback in Qt thread when reset button is clicked.
-    public slots: void OnReset();
+  /// \brief Callback in Qt thread when step button is clicked.
+  public slots: void OnStep();
 
-    /// \brief Callback in Qt thread when step button is clicked.
-    public slots: void OnStep();
+  /// \brief Callback in Qt thread when step count is changed.
+  /// \param[in] _steps New number of steps.
+  public slots: void OnStepCount(const unsigned int _steps);
 
-    /// \brief Callback in Qt thread when step count is changed.
-    /// \param[in] _steps New number of steps.
-    public slots: void OnStepCount(const unsigned int _steps);
+  /// \brief Notify that it's now playing.
+  signals: void playing();
 
-    /// \brief Notify that it's now playing.
-    signals: void playing();
+  /// \brief Notify that it's now paused.
+  signals: void paused();
 
-    /// \brief Notify that it's now paused.
-    signals: void paused();
+  /// \brief Notify that it's now resetted.
+  signals: void reset();
 
-    /// \brief Notify that it's now resetted.
-    signals: void reset();
+  /// \brief Subscriber callback when new world statistics are received
+  private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
 
-    /// \brief Subscriber callback when new world statistics are received
-    private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
-
-    // Private data
-    private: std::unique_ptr<WorldControlPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  // Private data
+  private: std::unique_ptr<WorldControlPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_WORLDCONTROL_HH_

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -35,134 +35,127 @@
 #  endif
 #endif
 
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class WorldStatsPrivate;
+
+/// \brief This plugin provides a time panel which may display:
+/// * Simulation time
+/// * Real time
+/// * Real time factor
+/// * Iterations
+///
+/// ## Configuration
+///
+/// * \<sim_time\> : Set to true to display a sim time widget, false by
+///                  default.
+/// * \<real_time\> : True to display a real time widget, false by default.
+/// * \<real_time_factor\> : True to display a real time factor widget,
+///                          false by default.
+/// * \<iterations\> : True to display an iterations widget, false by default.
+/// * \<topic\> : Topic to receive world statistics, optional. If not present,
+///               the plugin will attempt to create a topic with the main
+///               window's `worldName` property.
+///
+/// If no elements are filled for the plugin, all properties will be
+/// displayed.
+class WorldStats_EXPORTS_API WorldStats: public gz::gui::Plugin
 {
-namespace plugins
-{
-  class WorldStatsPrivate;
+  Q_OBJECT
 
-  /// \brief This plugin provides a time panel which may display:
-  /// * Simulation time
-  /// * Real time
-  /// * Real time factor
-  /// * Iterations
-  ///
-  /// ## Configuration
-  ///
-  /// * \<sim_time\> : Set to true to display a sim time widget, false by
-  ///                  default.
-  /// * \<real_time\> : True to display a real time widget, false by default.
-  /// * \<real_time_factor\> : True to display a real time factor widget,
-  ///                          false by default.
-  /// * \<iterations\> : True to display an iterations widget, false by default.
-  /// * \<topic\> : Topic to receive world statistics, optional. If not present,
-  ///               the plugin will attempt to create a topic with the main
-  ///               window's `worldName` property.
-  ///
-  /// If no elements are filled for the plugin, all properties will be
-  /// displayed.
-  class WorldStats_EXPORTS_API WorldStats: public gz::gui::Plugin
-  {
-    Q_OBJECT
+  /// \brief Real time factor
+  Q_PROPERTY(
+    QString realTimeFactor
+    READ RealTimeFactor
+    WRITE SetRealTimeFactor
+    NOTIFY RealTimeFactorChanged
+  )
 
-    /// \brief Real time factor
-    Q_PROPERTY(
-      QString realTimeFactor
-      READ RealTimeFactor
-      WRITE SetRealTimeFactor
-      NOTIFY RealTimeFactorChanged
-    )
+  /// \brief Sim time
+  Q_PROPERTY(
+    QString simTime
+    READ SimTime
+    WRITE SetSimTime
+    NOTIFY SimTimeChanged
+  )
 
-    /// \brief Sim time
-    Q_PROPERTY(
-      QString simTime
-      READ SimTime
-      WRITE SetSimTime
-      NOTIFY SimTimeChanged
-    )
+  /// \brief Real time
+  Q_PROPERTY(
+    QString realTime
+    READ RealTime
+    WRITE SetRealTime
+    NOTIFY RealTimeChanged
+  )
 
-    /// \brief Real time
-    Q_PROPERTY(
-      QString realTime
-      READ RealTime
-      WRITE SetRealTime
-      NOTIFY RealTimeChanged
-    )
+  /// \brief Iterations
+  Q_PROPERTY(
+    QString iterations
+    READ Iterations
+    WRITE SetIterations
+    NOTIFY IterationsChanged
+  )
 
-    /// \brief Iterations
-    Q_PROPERTY(
-      QString iterations
-      READ Iterations
-      WRITE SetIterations
-      NOTIFY IterationsChanged
-    )
+  /// \brief Constructor
+  public: WorldStats();
 
-    /// \brief Constructor
-    public: WorldStats();
+  /// \brief Destructor
+  public: virtual ~WorldStats();
 
-    /// \brief Destructor
-    public: virtual ~WorldStats();
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  /// \brief Callback in main thread when diagnostics come in
+  public slots: void ProcessMsg();
 
-    /// \brief Callback in main thread when diagnostics come in
-    public slots: void ProcessMsg();
+  /// \brief Get the message type as a string, for example
+  /// \return Message type
+  public: Q_INVOKABLE QString RealTimeFactor() const;
 
-    /// \brief Get the message type as a string, for example
-    /// \return Message type
-    public: Q_INVOKABLE QString RealTimeFactor() const;
+  /// \brief Set the message type from a string, for example
+  /// \param[in] _realTimeFactor Message type
+  public: Q_INVOKABLE void SetRealTimeFactor(const QString &_realTimeFactor);
 
-    /// \brief Set the message type from a string, for example
-    /// \param[in] _realTimeFactor Message type
-    public: Q_INVOKABLE void SetRealTimeFactor(const QString &_realTimeFactor);
+  /// \brief Notify that message type has changed
+  signals: void RealTimeFactorChanged();
 
-    /// \brief Notify that message type has changed
-    signals: void RealTimeFactorChanged();
+  /// \brief Get the message type as a string, for example
+  /// \return Message type
+  public: Q_INVOKABLE QString SimTime() const;
 
-    /// \brief Get the message type as a string, for example
-    /// \return Message type
-    public: Q_INVOKABLE QString SimTime() const;
+  /// \brief Set the message type from a string, for example
+  /// \param[in] _simTime Message type
+  public: Q_INVOKABLE void SetSimTime(const QString &_simTime);
 
-    /// \brief Set the message type from a string, for example
-    /// \param[in] _simTime Message type
-    public: Q_INVOKABLE void SetSimTime(const QString &_simTime);
+  /// \brief Notify that message type has changed
+  signals: void SimTimeChanged();
 
-    /// \brief Notify that message type has changed
-    signals: void SimTimeChanged();
+  /// \brief Get the message type as a string, for example
+  /// \return Message type
+  public: Q_INVOKABLE QString RealTime() const;
 
-    /// \brief Get the message type as a string, for example
-    /// \return Message type
-    public: Q_INVOKABLE QString RealTime() const;
+  /// \brief Set the message type from a string, for example
+  /// \param[in] _realTime Message type
+  public: Q_INVOKABLE void SetRealTime(const QString &_realTime);
 
-    /// \brief Set the message type from a string, for example
-    /// \param[in] _realTime Message type
-    public: Q_INVOKABLE void SetRealTime(const QString &_realTime);
+  /// \brief Notify that message type has changed
+  signals: void RealTimeChanged();
 
-    /// \brief Notify that message type has changed
-    signals: void RealTimeChanged();
+  /// \brief Get the message type as a string, for example
+  /// \return Message type
+  public: Q_INVOKABLE QString Iterations() const;
 
-    /// \brief Get the message type as a string, for example
-    /// \return Message type
-    public: Q_INVOKABLE QString Iterations() const;
+  /// \brief Set the message type from a string, for example
+  /// \param[in] _iterations Message type
+  public: Q_INVOKABLE void SetIterations(const QString &_iterations);
 
-    /// \brief Set the message type from a string, for example
-    /// \param[in] _iterations Message type
-    public: Q_INVOKABLE void SetIterations(const QString &_iterations);
+  /// \brief Notify that message type has changed
+  signals: void IterationsChanged();
 
-    /// \brief Notify that message type has changed
-    signals: void IterationsChanged();
+  /// \brief Subscriber callback when new world statistics are received
+  private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
 
-    /// \brief Subscriber callback when new world statistics are received
-    private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
-
-    // Private data
-    private: std::unique_ptr<WorldStatsPrivate> dataPtr;
-  };
-}
-}
-}
-
-#endif
+  // Private data
+  private: std::unique_ptr<WorldStatsPrivate> dataPtr;
+};
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_WORLDSTATS_HH_


### PR DESCRIPTION
Housekeeping to clean up namespaces.

Remove `using namespace gz` and use nested namespace declarations where possible.