### PR TITLE
Use gz::utils::ImplPtr as much as possible

### DIFF
--- a/include/gz/gui/Application.hh
+++ b/include/gz/gui/Application.hh
@@ -25,12 +25,7 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Export.hh"
 
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
+#include <gz/utils/ImplPtr.hh>
 
 namespace tinyxml2
 {
@@ -39,7 +34,6 @@ namespace tinyxml2
 
 namespace gz::gui
 {
-    class ApplicationPrivate;
     class Dialog;
     class MainWindow;
     class Plugin;
@@ -208,7 +202,7 @@ namespace gz::gui
 
       /// \internal
       /// \brief Private data pointer
-      private: std::unique_ptr<ApplicationPrivate> dataPtr;
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
 
     /// \brief Get current running application, this is a cast of qGuiApp.
@@ -216,9 +210,4 @@ namespace gz::gui
     GZ_GUI_VISIBLE
     Application *App();
 }  // namespace gz::gui
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #endif  // GZ_GUI_APPLICATION_HH_

--- a/include/gz/gui/Dialog.hh
+++ b/include/gz/gui/Dialog.hh
@@ -85,6 +85,5 @@ namespace gz::gui
       /// \brief Private data pointer
       GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
-};
 }  // namespace gz::gui
 #endif  // GZ_GUI_DIALOG_HH_

--- a/include/gz/gui/Dialog.hh
+++ b/include/gz/gui/Dialog.hh
@@ -24,17 +24,10 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Export.hh"
 
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
+#include <gz/utils/ImplPtr.hh>
 
 namespace gz::gui
 {
-    class DialogPrivate;
-
     /// \brief Gui plugin
     class GZ_GUI_VISIBLE Dialog : public QObject
     {
@@ -90,12 +83,8 @@ namespace gz::gui
 
       /// \internal
       /// \brief Private data pointer
-      private: std::unique_ptr<DialogPrivate> dataPtr;
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
+};
 }  // namespace gz::gui
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #endif  // GZ_GUI_DIALOG_HH_

--- a/include/gz/gui/MainWindow.hh
+++ b/include/gz/gui/MainWindow.hh
@@ -575,8 +575,9 @@ namespace gz::gui
 
       /// \internal
       /// \brief Private data pointer
+      /// Private is necessary here for the Qt MOC
       private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
-};
+    };
 
     /// \brief Holds configurations related to a MainWindow.
     struct GZ_GUI_VISIBLE WindowConfig
@@ -667,9 +668,4 @@ namespace gz::gui
       std::string plugins{""};
     };
 }  // namespace gz::gui
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #endif  // GZ_GUI_MAINWINDOW_HH_

--- a/include/gz/gui/MainWindow.hh
+++ b/include/gz/gui/MainWindow.hh
@@ -28,17 +28,9 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Export.hh"
 
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
-
 namespace gz::gui
 {
     Q_NAMESPACE
-    class MainWindowPrivate;
     struct WindowConfig;
 
     /// \brief The action executed when GUI is closed without prompt.
@@ -583,8 +575,8 @@ namespace gz::gui
 
       /// \internal
       /// \brief Private data pointer
-      private: std::unique_ptr<MainWindowPrivate> dataPtr;
-    };
+      private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
 
     /// \brief Holds configurations related to a MainWindow.
     struct GZ_GUI_VISIBLE WindowConfig

--- a/include/gz/gui/PlottingInterface.hh
+++ b/include/gz/gui/PlottingInterface.hh
@@ -38,10 +38,10 @@
 
 #include "gz/gui/Export.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui
 {
-class PlotDataPrivate;
-
 /// \brief Plot Data containter to hold value and registered charts
 /// Can be a Field or a PlotComponent
 /// Used by PlottingInterface and Gazebo Plotting
@@ -85,10 +85,8 @@ class GZ_GUI_VISIBLE PlotData
   public: std::set<int> &Charts();
 
   /// \brief Private data member.
-  private: std::unique_ptr<PlotDataPrivate> dataPtr;
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
-
-class TopicPrivate;
 
 /// \brief Plotting Topic to handle published topics & their registered fields
 class GZ_GUI_VISIBLE Topic : public QObject
@@ -149,10 +147,8 @@ class GZ_GUI_VISIBLE Topic : public QObject
   public: void SetPlottingTimeRef(const std::shared_ptr<double> &_time);
 
   /// \brief Private data member.
-  private: std::unique_ptr<TopicPrivate> dataPtr;
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
-
-class TransportPrivate;
 
 /// \brief Handle transport topics subscribing for one object (Chart)
 class GZ_GUI_VISIBLE Transport : public QObject
@@ -203,11 +199,10 @@ class GZ_GUI_VISIBLE Transport : public QObject
   /// \param[in] _y y coordinates of the plot point
   signals: void plot(int _chart, QString _fieldID, double _x, double _y);
 
+  private:
   /// \brief Private data member.
-  private: std::unique_ptr<TransportPrivate> dataPtr;
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
-
-class PlottingIfacePrivate;
 
 /// \brief Plotting Interface
 /// Responsible for plotting transport msgs-fields
@@ -328,7 +323,7 @@ class GZ_GUI_VISIBLE PlottingInterface : public QObject
   public slots: void UpdateTime();
 
   /// \brief Private data member.
-  private: std::unique_ptr<PlottingIfacePrivate> dataPtr;
+  private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
 }  // namespace gz::gui
 #endif  // GZ_GUI_PLOTTINGINTERFACE_HH_

--- a/include/gz/gui/PlottingInterface.hh
+++ b/include/gz/gui/PlottingInterface.hh
@@ -323,6 +323,7 @@ class GZ_GUI_VISIBLE PlottingInterface : public QObject
   public slots: void UpdateTime();
 
   /// \brief Private data member.
+  /// Private is necessary here for the Qt MOC
   private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
 }  // namespace gz::gui

--- a/include/gz/gui/Plugin.hh
+++ b/include/gz/gui/Plugin.hh
@@ -94,7 +94,8 @@ namespace gz::gui
       ///
       /// \sa Load
       /// \param[in] _pluginElem Element containing configuration
-      protected: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+      protected: virtual void LoadConfig(
+                    const tinyxml2::XMLElement *_pluginElem);
 
       /// \brief Get title
       /// \return Plugin title.

--- a/include/gz/gui/Plugin.hh
+++ b/include/gz/gui/Plugin.hh
@@ -18,25 +18,17 @@
 #define GZ_GUI_PLUGIN_HH_
 
 #include <tinyxml2.h>
+#include <gz/utils/ImplPtr.hh>
 #include <memory>
 #include <string>
 
 #include "gz/gui/qt.h"
 #include "gz/gui/Export.hh"
 
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
-
 namespace gz::gui
 {
     /// \brief Namespace for all plugins
     namespace plugins {}
-
-    class PluginPrivate;
 
     /// \brief Base class for Gazebo GUI plugins.
     ///
@@ -102,15 +94,11 @@ namespace gz::gui
       ///
       /// \sa Load
       /// \param[in] _pluginElem Element containing configuration
-      protected: virtual void LoadConfig(
-          const tinyxml2::XMLElement *_pluginElem)
-          {
-            (void)_pluginElem;
-          }
+      protected: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
 
       /// \brief Get title
       /// \return Plugin title.
-      public: virtual std::string Title() const {return this->title;}
+      public: virtual std::string Title() const;
 
       /// \brief Get the value of the the `delete_later` element from the
       /// configuration file, which defaults to false.
@@ -142,12 +130,7 @@ namespace gz::gui
 
       /// \internal
       /// \brief Pointer to private data
-      private: std::unique_ptr<PluginPrivate> dataPtr;
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
 }  // namespace gz::gui
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #endif  // GZ_GUI_PLUGIN_HH_

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -39,7 +39,7 @@
 
 namespace gz::gui
 {
-class ApplicationPrivate
+class Application::Implementation
 {
   /// \brief QML engine
   public: QQmlApplicationEngine *engine{nullptr};
@@ -91,7 +91,7 @@ enum class GZ_COMMON_HIDDEN AvailableAPIs
 Application::Application(int &_argc, char **_argv, const WindowType _type,
                          const char *_renderEngineGuiApiBackend) :
   QApplication(_argc, _argv),
-  dataPtr(new ApplicationPrivate)
+  dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   gzdbg << "Initializing application." << std::endl;
 
@@ -880,7 +880,7 @@ void Application::RemovePlugin(std::shared_ptr<Plugin> _plugin)
 }
 
 //////////////////////////////////////////////////
-void ApplicationPrivate::MessageHandler(QtMsgType _type,
+void Application::Implementation::MessageHandler(QtMsgType _type,
     const QMessageLogContext &_context, const QString &_msg)
 {
   std::string msg = "[QT] " + _msg.toStdString();

--- a/src/Dialog.cc
+++ b/src/Dialog.cc
@@ -18,12 +18,13 @@
 #include <tinyxml2.h>
 
 #include <gz/common/Console.hh>
+#include <gz/utils/ImplPtr.hh>
 #include "gz/gui/Application.hh"
 #include "gz/gui/Dialog.hh"
 
 namespace gz::gui
 {
-class DialogPrivate
+class Dialog::Implementation
 {
   /// \brief Pointer to quick window
   public: QQuickWindow *quickWindow{nullptr};
@@ -31,7 +32,7 @@ class DialogPrivate
 
 /////////////////////////////////////////////////
 Dialog::Dialog()
-  : dataPtr(new DialogPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   // Load QML and keep pointer to generated QQuickWindow
   std::string qmlFile("qrc:qml/StandaloneDialog.qml");

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -85,7 +85,7 @@ class MainWindow::Implementation
   public: std::string controlService{"/server_control"};
 
   /// \brief Communication node
-  public: gz::transport::Node node;
+  public: gz::transport::Node node {gz::transport::NodeOptions()};
 };
 
 /////////////////////////////////////////////////

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -16,6 +16,7 @@
  */
 
 #include <tinyxml2.h>
+#include <gz/utils/ImplPtr.hh>
 #include <regex>
 #include <string>
 
@@ -29,11 +30,21 @@
 #include "gz/msgs/server_control.pb.h"
 #include "gz/transport/Node.hh"
 
+namespace {
+/// \brief Strip last component from a path.
+/// \return Original path without its last component.
+/// \ToDo: Move this function to common::Filesystem
+std::string dirName(const std::string &_path)
+{
+  std::size_t found = _path.find_last_of("/\\");
+  return _path.substr(0, found);
+}
+}  // namespace
+
 namespace gz::gui
 {
-class MainWindowPrivate
+class MainWindow::Implementation
 {
-  /// \brief Number of plugins on the window
   public: int pluginCount{0};
 
   /// \brief Pointer to quick window
@@ -77,18 +88,9 @@ class MainWindowPrivate
   public: gz::transport::Node node;
 };
 
-/// \brief Strip last component from a path.
-/// \return Original path without its last component.
-/// \ToDo: Move this function to common::Filesystem
-std::string dirName(const std::string &_path)
-{
-  std::size_t found = _path.find_last_of("/\\");
-  return _path.substr(0, found);
-}
-
 /////////////////////////////////////////////////
 MainWindow::MainWindow()
-  : dataPtr(new MainWindowPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   // Expose the ExitAction enum to QML via ExitAction 1.0 module
   qRegisterMetaType<ExitAction>("ExitAction");

--- a/src/PlottingInterface.cc
+++ b/src/PlottingInterface.cc
@@ -70,7 +70,7 @@ class Topic::Implementation
 class Transport::Implementation
 {
   /// \brief Node for Commincation
-  public: gz::transport::Node node;
+  public: gz::transport::Node node {gz::transport::NodeOptions()};
 
   /// \brief subscribed topics
   public: std::map<std::string, gz::gui::Topic*> topics;

--- a/src/PlottingInterface.cc
+++ b/src/PlottingInterface.cc
@@ -25,13 +25,15 @@
 #include "gz/gui/PlottingInterface.hh"
 #include "gz/gui/Application.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 #define DEFAULT_TIME (INT_MIN)
 // 1/60 Period like the GuiSystem frequency (60Hz)
 #define MAX_PERIOD_DIFF (0.0166666667)
 
 namespace gz::gui
 {
-class PlotDataPrivate
+class PlotData::Implementation
 {
   /// \brief Value of that field
   public: double value;
@@ -43,7 +45,7 @@ class PlotDataPrivate
   public: std::set<int> charts;
 };
 
-class TopicPrivate
+class Topic::Implementation
 {
   /// \brief Check the plotable types and get data from reflection
   /// \param[in] _msg Message to get data from
@@ -65,7 +67,7 @@ class TopicPrivate
   public: std::map<std::string, gz::gui::PlotData*> fields;
 };
 
-class TransportPrivate
+class Transport::Implementation
 {
   /// \brief Node for Commincation
   public: gz::transport::Node node;
@@ -74,7 +76,7 @@ class TransportPrivate
   public: std::map<std::string, gz::gui::Topic*> topics;
 };
 
-class PlottingIfacePrivate
+class PlottingInterface::Implementation
 {
   /// \brief Responsible for transport messages and topics
   public: gui::Transport transport;
@@ -86,12 +88,12 @@ class PlottingIfacePrivate
   public: int timeout;
 
   /// \brief timer to update the plotting each time step
-  public: QTimer timer;
+  public: QTimer timer {nullptr};
 };
 
 //////////////////////////////////////////////////////
 PlotData::PlotData() :
-    dataPtr(std::make_unique<PlotDataPrivate>())
+    dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   this->dataPtr->value = 0;
 }
@@ -150,8 +152,8 @@ std::set<int> &PlotData::Charts()
 }
 
 //////////////////////////////////////////////////////
-Topic::Topic(const std::string &_name) : QObject(),
-    dataPtr(std::make_unique<TopicPrivate>())
+Topic::Topic(const std::string &_name):
+    dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   this->dataPtr->name = _name;
 }
@@ -361,7 +363,7 @@ void Topic::SetPlottingTimeRef(const std::shared_ptr<double> &_timeRef)
 }
 
 //////////////////////////////////////////////////////
-double TopicPrivate::FieldData(const google::protobuf::Message &_msg,
+double Topic::Implementation::FieldData(const google::protobuf::Message &_msg,
                                const google::protobuf::FieldDescriptor *_field)
 {
   using namespace google::protobuf;
@@ -390,7 +392,8 @@ double TopicPrivate::FieldData(const google::protobuf::Message &_msg,
 }
 
 ////////////////////////////////////////////
-Transport::Transport() : dataPtr(std::make_unique<TransportPrivate>())
+Transport::Transport():
+  dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -481,7 +484,7 @@ void Transport::UnsubscribeOutdatedTopics()
 
 //////////////////////////////////////////////////////
 PlottingInterface::PlottingInterface() : QObject(),
-    dataPtr(std::make_unique<PlottingIfacePrivate>())
+    dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   connect(&this->dataPtr->transport,
           SIGNAL(plot(int, QString, double, double)), this,

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -15,6 +15,7 @@
  *
  */
 
+#include <gz/utils/ImplPtr.hh>
 #include <unordered_set>
 
 #include <gz/common/Console.hh>
@@ -56,7 +57,7 @@ const std::unordered_set<std::string> kIgnoredProps{
 
 namespace gz::gui
 {
-class PluginPrivate
+class Plugin::Implementation
 {
   /// \brief Set this to true if the plugin should be deleted as soon as it has
   ///  a parent.
@@ -86,7 +87,7 @@ class PluginPrivate
 };
 
 /////////////////////////////////////////////////
-Plugin::Plugin() : dataPtr(new PluginPrivate)
+Plugin::Plugin() : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -515,6 +516,17 @@ void Plugin::PostParentChanges()
 
     this->CardItem()->setProperty(prop.first.c_str(), prop.second);
   }
+}
+
+/////////////////////////////////////////////////
+void Plugin::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
+{
+  (void) _pluginElem;
+}
+
+/////////////////////////////////////////////////
+std::string Plugin::Title() const {
+  return this->title;
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/camera_fps/CameraFps.cc
+++ b/src/plugins/camera_fps/CameraFps.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gz/utils/ImplPtr.hh>
 #include <list>
 #include <string>
 
@@ -32,7 +33,7 @@
 namespace gz::gui::plugins
 {
 /// \brief Private data class for CameraFps
-class CameraFpsPrivate
+class CameraFps::Implementation
 {
   /// \brief Previous camera update time
   public: std::optional<std::chrono::steady_clock::time_point>
@@ -82,7 +83,7 @@ void CameraFps::OnRender()
 
 /////////////////////////////////////////////////
 CameraFps::CameraFps()
-  : dataPtr(new CameraFpsPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 

--- a/src/plugins/camera_fps/CameraFps.hh
+++ b/src/plugins/camera_fps/CameraFps.hh
@@ -18,14 +18,13 @@
 #ifndef GZ_GUI_PLUGINS_CAMERAFPS_HH_
 #define GZ_GUI_PLUGINS_CAMERAFPS_HH_
 
+#include <gz/utils/ImplPtr.hh>
 #include <memory>
 
 #include "gz/gui/Plugin.hh"
 
 namespace gz::gui::plugins
 {
-  class CameraFpsPrivate;
-
   /// \brief This plugin displays the GUI camera's Framerate Per Second (FPS)
   class CameraFps : public Plugin
   {
@@ -68,7 +67,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<CameraFpsPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/camera_tracking/CameraTracking.hh
+++ b/src/plugins/camera_tracking/CameraTracking.hh
@@ -18,14 +18,13 @@
 #ifndef GZ_GUI_PLUGINS_CAMERATRACKING_HH_
 #define GZ_GUI_PLUGINS_CAMERATRACKING_HH_
 
+#include <gz/utils/ImplPtr.hh>
 #include <memory>
 
 #include "gz/gui/Plugin.hh"
 
 namespace gz::gui::plugins
 {
-  class CameraTrackingPrivate;
-
   /// \brief This plugin provides camera tracking capabilities such as "move to"
   /// and "follow".
   ///
@@ -58,7 +57,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<CameraTrackingPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -32,7 +32,7 @@
 
 #include "GridConfig.hh"
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
   struct GridParam
   {
@@ -52,7 +52,7 @@ namespace gz::gui
     math::Color color{math::Color(0.7f, 0.7f, 0.7f, 1.0f)};
   };
 
-  class GridConfigPrivate
+  class GridConfig::Implementation
   {
     /// \brief List of grid names.
     public: QStringList nameList;
@@ -84,7 +84,7 @@ namespace gz::gui
 
 /////////////////////////////////////////////////
 GridConfig::GridConfig()
-  : dataPtr(std::make_unique<GridConfigPrivate>())
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -408,5 +408,5 @@ void GridConfig::RefreshList()
 }  // namespace gz::gui
 
 // Register this plugin
-GZ_ADD_PLUGIN(gz::gui::GridConfig,
+GZ_ADD_PLUGIN(gz::gui::plugins::GridConfig,
               gz::gui::Plugin)

--- a/src/plugins/grid_config/GridConfig.hh
+++ b/src/plugins/grid_config/GridConfig.hh
@@ -22,7 +22,9 @@
 
 #include <gz/gui/Plugin.hh>
 
-namespace gz::gui
+#include <gz/utils/ImplPtr.hh>
+
+namespace gz::gui::plugins
 {
   class GridConfigPrivate;
 
@@ -139,8 +141,7 @@ namespace gz::gui
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<GridConfigPrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
-}  // namespace gz::gui
-
-#endif  // GZ_GUI_GRIDCONFIG_HH_
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_GRIDCONFIG_HH_

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -35,7 +35,7 @@
 
 namespace gz::gui::plugins
 {
-class ImageDisplayPrivate
+class ImageDisplay::Implementation
 {
   /// \brief List of topics publishing image messages.
   public: QStringList topicList;
@@ -55,7 +55,7 @@ class ImageDisplayPrivate
 
 /////////////////////////////////////////////////
 ImageDisplay::ImageDisplay()
-  : dataPtr(new ImageDisplayPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -36,10 +36,10 @@
 
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui::plugins
 {
-  class ImageDisplayPrivate;
-
   class ImageProvider : public QQuickImageProvider
   {
     public: ImageProvider()
@@ -121,7 +121,6 @@ namespace gz::gui::plugins
     /// \brief Notify that a new image has been received.
     signals: void newImage();
 
-    /// \brief Callback in main thread when image changes
     private slots: void ProcessImage();
 
     /// \brief Subscriber callback when new image is received
@@ -130,7 +129,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<ImageDisplayPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/interactive_view_control/InteractiveViewControl.hh
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.hh
@@ -22,6 +22,8 @@
 
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui::plugins
 {
   class InteractiveViewControlPrivate;
@@ -64,7 +66,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<InteractiveViewControlPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/key_publisher/KeyPublisher.cc
+++ b/src/plugins/key_publisher/KeyPublisher.cc
@@ -17,6 +17,7 @@
 
 #include <gz/msgs/int32.pb.h>
 
+#include <gz/utils/ImplPtr.hh>
 #include <string>
 
 #include <gz/gui/Application.hh>
@@ -25,9 +26,9 @@
 
 #include "KeyPublisher.hh"
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-class KeyPublisherPrivate
+class KeyPublisher::Implementation
 {
   /// \brief Node for communication
   public: gz::transport::Node node;
@@ -49,7 +50,8 @@ class KeyPublisherPrivate
 };
 
 /////////////////////////////////////////////////
-KeyPublisher::KeyPublisher(): dataPtr(new KeyPublisherPrivate)
+KeyPublisher::KeyPublisher():
+  dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   // Advertise publisher node
   this->dataPtr->pub = this->dataPtr->node.Advertise<msgs::Int32>
@@ -79,8 +81,8 @@ bool KeyPublisher::eventFilter(QObject *_obj, QEvent *_event)
   }
   return QObject::eventFilter(_obj, _event);
 }
-}  // namespace gz::gui
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(gz::gui::KeyPublisher,
+GZ_ADD_PLUGIN(gz::gui::plugins::KeyPublisher,
               gz::gui::Plugin)

--- a/src/plugins/key_publisher/KeyPublisher.hh
+++ b/src/plugins/key_publisher/KeyPublisher.hh
@@ -33,12 +33,11 @@
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
+#include <gz/utils/ImplPtr.hh>
 #include <gz/transport/Node.hh>
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-  class KeyPublisherPrivate;
-
   /// \brief Publish keyboard stokes to "keyboard/keypress" topic.
   ///
   /// ## Configuration
@@ -64,8 +63,8 @@ namespace gz::gui
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<KeyPublisherPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
-}  // namespace gz::gui
+}  // namespace gz::gui::plugins
 
 #endif  // GZ_GUI_PLUGINS_KEYPUBLISHER_HH_

--- a/src/plugins/key_publisher/KeyPublisher_TEST.cc
+++ b/src/plugins/key_publisher/KeyPublisher_TEST.cc
@@ -30,24 +30,25 @@
 
 #include "KeyPublisher.hh"
 
+using Application = gz::gui::Application;
+using KeyPublisher = gz::gui::plugins::KeyPublisher;
+using MainWindow = gz::gui::MainWindow;
+
 int g_argc = 1;
 char* g_argv[] =
 {
   reinterpret_cast<char*>(const_cast<char*>("./KeyPublisher_TEST")),
 };
 
-using namespace gz;
-using namespace gui;
-
 class KeyPublisherTest : public ::testing::Test
 {
   // Set up function.
   protected: void SetUp() override
     {
-      common::Console::SetVerbosity(4);
+      gz::common::Console::SetVerbosity(4);
 
       this->app.AddPluginPath(
-        common::joinPaths(std::string(PROJECT_BINARY_PATH), "lib"));
+        gz::common::joinPaths(std::string(PROJECT_BINARY_PATH), "lib"));
 
       // Load plugin
       EXPECT_TRUE(this->app.LoadPlugin("KeyPublisher"));
@@ -75,7 +76,7 @@ class KeyPublisherTest : public ::testing::Test
     }
 
   // Callback function to verify key message was sent correctly
-  protected: void VerifyKeypressCb(const msgs::Int32 &_msg)
+  protected: void VerifyKeypressCb(const gz::msgs::Int32 &_msg)
     {
       this->received = true;
       EXPECT_EQ(_msg.data(), this->currentKey);
@@ -113,7 +114,7 @@ class KeyPublisherTest : public ::testing::Test
 
   // Checks if a new key has been received.
   protected: bool received = false;
-  protected: transport::Node node;
+  protected: gz::transport::Node node;
 
   // Current key
   protected: int currentKey = 0;

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -284,7 +284,8 @@ bool MarkerManager::Implementation::OnMarkerMsgArray(
 }
 
 //////////////////////////////////////////////////
-bool MarkerManager::Implementation::ProcessMarkerMsg(const gz::msgs::Marker &_msg)
+bool MarkerManager::Implementation::ProcessMarkerMsg(
+  const gz::msgs::Marker &_msg)
 {
   // Get the namespace, if it exists. Otherwise, use the global namespace
   std::string ns;

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -52,7 +52,7 @@
 namespace gz::gui::plugins
 {
 /// \brief Private data class for MarkerManager
-class MarkerManagerPrivate
+class MarkerManager::Implementation
 {
   /// \brief Update markers based on msgs received
   public: void OnRender();
@@ -123,7 +123,7 @@ class MarkerManagerPrivate
       std::map<uint64_t, gz::rendering::VisualPtr>> visuals;
 
   /// \brief Gazebo node
-  public: gz::transport::Node node;
+  public: gz::transport::Node node {gz::transport::NodeOptions()};
 
   /// \brief Topic name for the marker service
   public: std::string topicName = "/marker";
@@ -143,7 +143,7 @@ class MarkerManagerPrivate
 };
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::Initialize()
+void MarkerManager::Implementation::Initialize()
 {
   if (!this->scene)
   {
@@ -160,7 +160,7 @@ void MarkerManagerPrivate::Initialize()
 
   // Advertise the list service
   if (!this->node.Advertise(this->topicName + "/list",
-      &MarkerManagerPrivate::OnList, this))
+      &Implementation::OnList, this))
   {
     gzerr << "Unable to advertise to the " << this->topicName
            << "/list service.\n";
@@ -170,7 +170,7 @@ void MarkerManagerPrivate::Initialize()
 
   // Advertise to the marker service
   if (!this->node.Advertise(this->topicName,
-        &MarkerManagerPrivate::OnMarkerMsg, this))
+        &Implementation::OnMarkerMsg, this))
   {
     gzerr << "Unable to advertise to the " << this->topicName
            << " service.\n";
@@ -180,7 +180,7 @@ void MarkerManagerPrivate::Initialize()
 
   // Advertise to the marker_array service
   if (!this->node.Advertise(this->topicName + "_array",
-        &MarkerManagerPrivate::OnMarkerMsgArray, this))
+        &Implementation::OnMarkerMsgArray, this))
   {
     gzerr << "Unable to advertise to the " << this->topicName
            << "_array service.\n";
@@ -190,7 +190,7 @@ void MarkerManagerPrivate::Initialize()
 }
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::OnRender()
+void MarkerManager::Implementation::OnRender()
 {
   if (!this->scene)
   {
@@ -246,7 +246,7 @@ void MarkerManagerPrivate::OnRender()
 }
 
 /////////////////////////////////////////////////
-bool MarkerManagerPrivate::OnList(gz::msgs::Marker_V &_rep)
+bool MarkerManager::Implementation::OnList(gz::msgs::Marker_V &_rep)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
   _rep.clear_marker();
@@ -266,14 +266,14 @@ bool MarkerManagerPrivate::OnList(gz::msgs::Marker_V &_rep)
 }
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::OnMarkerMsg(const gz::msgs::Marker &_req)
+void MarkerManager::Implementation::OnMarkerMsg(const gz::msgs::Marker &_req)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
   this->markerMsgs.push_back(_req);
 }
 
 /////////////////////////////////////////////////
-bool MarkerManagerPrivate::OnMarkerMsgArray(
+bool MarkerManager::Implementation::OnMarkerMsgArray(
     const gz::msgs::Marker_V&_req, gz::msgs::Boolean &_res)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
@@ -284,7 +284,7 @@ bool MarkerManagerPrivate::OnMarkerMsgArray(
 }
 
 //////////////////////////////////////////////////
-bool MarkerManagerPrivate::ProcessMarkerMsg(const gz::msgs::Marker &_msg)
+bool MarkerManager::Implementation::ProcessMarkerMsg(const gz::msgs::Marker &_msg)
 {
   // Get the namespace, if it exists. Otherwise, use the global namespace
   std::string ns;
@@ -450,7 +450,7 @@ bool MarkerManagerPrivate::ProcessMarkerMsg(const gz::msgs::Marker &_msg)
 }
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::SetVisual(const gz::msgs::Marker &_msg,
+void MarkerManager::Implementation::SetVisual(const gz::msgs::Marker &_msg,
                            const rendering::VisualPtr &_visualPtr)
 {
   // Set Visual Scale
@@ -500,7 +500,7 @@ void MarkerManagerPrivate::SetVisual(const gz::msgs::Marker &_msg,
 }
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::SetMarker(const gz::msgs::Marker &_msg,
+void MarkerManager::Implementation::SetMarker(const gz::msgs::Marker &_msg,
                            const rendering::MarkerPtr &_markerPtr)
 {
   _markerPtr->SetLayer(_msg.layer());
@@ -560,8 +560,8 @@ void MarkerManagerPrivate::SetMarker(const gz::msgs::Marker &_msg,
 }
 
 /////////////////////////////////////////////////
-rendering::MaterialPtr MarkerManagerPrivate::MsgToMaterial(
-                              const gz::msgs::Marker &_msg)
+rendering::MaterialPtr
+MarkerManager::Implementation::MsgToMaterial(const gz::msgs::Marker &_msg)
 {
   rendering::MaterialPtr material = this->scene->CreateMaterial();
 
@@ -595,8 +595,8 @@ rendering::MaterialPtr MarkerManagerPrivate::MsgToMaterial(
 }
 
 /////////////////////////////////////////////////
-gz::rendering::MarkerType MarkerManagerPrivate::MsgToType(
-                          const gz::msgs::Marker &_msg)
+gz::rendering::MarkerType
+MarkerManager::Implementation::MsgToType(const gz::msgs::Marker &_msg)
 {
   gz::msgs::Marker_Type marker = this->msg.type();
   if (marker != _msg.type() && _msg.type() != gz::msgs::Marker::NONE)
@@ -636,7 +636,7 @@ gz::rendering::MarkerType MarkerManagerPrivate::MsgToType(
 }
 
 /////////////////////////////////////////////////
-void MarkerManagerPrivate::OnWorldStatsMsg(
+void MarkerManager::Implementation::OnWorldStatsMsg(
   const gz::msgs::WorldStatistics &_msg)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
@@ -659,7 +659,7 @@ void MarkerManagerPrivate::OnWorldStatsMsg(
 
 /////////////////////////////////////////////////
 MarkerManager::MarkerManager()
-  : dataPtr(new MarkerManagerPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -740,7 +740,7 @@ void MarkerManager::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
   {
     // Subscribe to world_stats
     if (!this->dataPtr->node.Subscribe(statsTopic,
-        &MarkerManagerPrivate::OnWorldStatsMsg, this->dataPtr.get()))
+        &Implementation::OnWorldStatsMsg, this->dataPtr.get()))
     {
       gzerr << "Failed to subscribe to [" << statsTopic << "]" << std::endl;
     }

--- a/src/plugins/marker_manager/MarkerManager.hh
+++ b/src/plugins/marker_manager/MarkerManager.hh
@@ -18,14 +18,13 @@
 #ifndef GZ_GUI_PLUGINS_MARKERMANAGER_HH_
 #define GZ_GUI_PLUGINS_MARKERMANAGER_HH_
 
+#include <gz/utils/ImplPtr.hh>
 #include <memory>
 
 #include "gz/gui/Plugin.hh"
 
 namespace gz::gui::plugins
 {
-  class MarkerManagerPrivate;
-
   /// \brief This plugin will be in charge of handling the markers in the
   /// scene. It will allow to add, modify or remove markers.
   ///
@@ -56,7 +55,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<MarkerManagerPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.cc
@@ -36,42 +36,31 @@
 #include <string>
 
 /////////////////////////////////////////////////
-namespace gz
+namespace gz::gui::plugins
 {
-namespace gui
+class GzCameraTextureRhiVulkanPrivate
 {
-namespace plugins
+  public: VkImage textureId = 0;
+};
+
+class RenderThreadRhiVulkanPrivate
 {
-  class GzCameraTextureRhiVulkanPrivate
-  {
-    public: VkImage textureId = 0;
-  };
+  public: GzRenderer *renderer = nullptr;
+  public: void *texturePtr = nullptr;
+  public: QOffscreenSurface *surface = nullptr;
+};
 
-  class RenderThreadRhiVulkanPrivate
-  {
-    public: GzRenderer *renderer = nullptr;
-    public: void *texturePtr = nullptr;
-    public: QOffscreenSurface *surface = nullptr;
-  };
-
-  class TextureNodeRhiVulkanPrivate
-  {
-    public: VkImage textureId = 0;
-    public: VkImage newTextureId = 0;
-    public: std::weak_ptr<rendering::Camera> lastCamera;
-    public: QSize size {0, 0};
-    public: QSize newSize {0, 0};
-    public: QMutex mutex;
-    public: QSGTexture *texture = nullptr;
-    public: QQuickWindow *window = nullptr;
-  };
-}
-}
-}
-
-using namespace gz;
-using namespace gui;
-using namespace plugins;
+class TextureNodeRhiVulkanPrivate
+{
+  public: VkImage textureId = 0;
+  public: VkImage newTextureId = 0;
+  public: std::weak_ptr<rendering::Camera> lastCamera;
+  public: QSize size {0, 0};
+  public: QSize newSize {0, 0};
+  public: QMutex mutex;
+  public: QSGTexture *texture = nullptr;
+  public: QQuickWindow *window = nullptr;
+};
 
 /////////////////////////////////////////////////
 GzCameraTextureRhiVulkan::~GzCameraTextureRhiVulkan() = default;
@@ -121,7 +110,7 @@ std::string RenderThreadRhiVulkan::Initialize()
     return loadingError;
   }
 
-  return std::string();
+  return {};
 }
 
 /////////////////////////////////////////////////
@@ -169,7 +158,7 @@ void RenderThreadRhiVulkan::ShutDown()
   this->dataPtr->texturePtr = nullptr;
 
   // Schedule this to be deleted only after we're done cleaning up
-  if (this->dataPtr->surface)
+  if (this->dataPtr->surface != nullptr)
   {
     this->dataPtr->surface->deleteLater();
   }
@@ -184,16 +173,11 @@ TextureNodeRhiVulkan::~TextureNodeRhiVulkan()
 
 /////////////////////////////////////////////////
 TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
-                                           rendering::CameraPtr &
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
-                                             _camera
-#endif
-                                           ) :
+                                           rendering::CameraPtr &_camera):
   dataPtr(std::make_unique<TextureNodeRhiVulkanPrivate>())
 {
   this->dataPtr->window = _window;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
   // It says Metal but it also works for Vulkan in the exact same way
   _camera->RenderTextureMetalId(&this->dataPtr->textureId);
   this->dataPtr->lastCamera = _camera;
@@ -204,7 +188,6 @@ TextureNodeRhiVulkan::TextureNodeRhiVulkan(QQuickWindow *_window,
     0,                                               //
     QSize(static_cast<int>(_camera->ImageWidth()),
           static_cast<int>(_camera->ImageHeight())));
-#endif
 }
 
 /////////////////////////////////////////////////
@@ -216,7 +199,7 @@ QSGTexture *TextureNodeRhiVulkan::Texture() const
 /////////////////////////////////////////////////
 bool TextureNodeRhiVulkan::HasNewTexture() const
 {
-  return (this->dataPtr->newTextureId != 0);
+  return (this->dataPtr->newTextureId != nullptr);
 }
 
 /////////////////////////////////////////////////
@@ -235,7 +218,7 @@ void TextureNodeRhiVulkan::PrepareNode()
   this->dataPtr->mutex.lock();
   this->dataPtr->newTextureId = this->dataPtr->textureId;
   this->dataPtr->newSize = this->dataPtr->size;
-  this->dataPtr->textureId = 0;
+  this->dataPtr->textureId = nullptr;
   this->dataPtr->mutex.unlock();
 
   // Required: PrepareForExternalSampling ensures the texture is ready to
@@ -244,19 +227,18 @@ void TextureNodeRhiVulkan::PrepareNode()
   auto lastCamera = this->dataPtr->lastCamera.lock();
   lastCamera->PrepareForExternalSampling();
 
-  if (this->dataPtr->newTextureId)
+  if (this->dataPtr->newTextureId != nullptr)
   {
     delete this->dataPtr->texture;
     this->dataPtr->texture = nullptr;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
     this->dataPtr->texture =
         this->dataPtr->window->createTextureFromNativeObject(
             QQuickWindow::NativeObjectTexture,
             static_cast<void*>(&this->dataPtr->newTextureId),
             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
             this->dataPtr->newSize);
-#endif
   }
 }
-#endif
+}  // namespace gz::gui::plugins
+#endif  // HAVE_QT_VULKAN

--- a/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhiVulkan.hh
@@ -28,12 +28,7 @@
 #include <memory>
 #include <string>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
-namespace gz
-{
-namespace gui
-{
-namespace plugins
+namespace gz::gui::plugins
 {
   /// \brief Private data for GzCameraTextureRhiVulkan
   class GzCameraTextureRhiVulkanPrivate;
@@ -138,10 +133,6 @@ namespace plugins
     /// \internal Pointer to private data
     private: std::unique_ptr<TextureNodeRhiVulkanPrivate> dataPtr;
    };
-}
-}
-}
-
-#endif
+}  // namespace gz::gui::plugins
 
 #endif

--- a/src/plugins/navsat_map/NavSatMap.cc
+++ b/src/plugins/navsat_map/NavSatMap.cc
@@ -31,7 +31,7 @@
 
 namespace gz::gui::plugins
 {
-class NavSatMapPrivate
+class NavSatMap::Implementation
 {
   /// \brief List of topics publishing navSat messages.
   public: QStringList topicList;
@@ -48,7 +48,7 @@ class NavSatMapPrivate
 
 /////////////////////////////////////////////////
 NavSatMap::NavSatMap()
-  : dataPtr(new NavSatMapPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -78,7 +78,7 @@ void NavSatMap::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   if (topic.empty() && !topicPicker)
   {
     gzwarn << "Can't hide topic picker without a default topic." << std::endl;
-    topicPicker = true;
+   topicPicker = true;
   }
 
   this->PluginItem()->setProperty("showPicker", topicPicker);

--- a/src/plugins/navsat_map/NavSatMap.hh
+++ b/src/plugins/navsat_map/NavSatMap.hh
@@ -88,8 +88,8 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<NavSatMapPrivate> dataPtr;
-  };
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
 }  // namespace gz::gui::plugins
 
 #endif  // GZ_GUI_PLUGINS_NAVSAT_MAP_HH_

--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -15,10 +15,14 @@
  *
 */
 #include <gz/plugin/Register.hh>
+#include <gz/utils/ImplPtr.hh>
 #include "TransportPlotting.hh"
 
 namespace gz::gui::plugins
 {
+//////////////////////////////////////////
+TransportPlotting::TransportPlotting() = default;
+
 //////////////////////////////////////////
 TransportPlotting::~TransportPlotting() = default;
 
@@ -28,14 +32,8 @@ void TransportPlotting::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Transport plotting";
 }
-
-//////////////////////////////////////////
-TransportPlotting::TransportPlotting() :
-    dataPtr(new PlottingInterface)
-{
-}
 }  // namespace gz::gui::plugins
-
+//
 // Register this plugin
 GZ_ADD_PLUGIN(gz::gui::plugins::TransportPlotting,
               gz::gui::Plugin)

--- a/src/plugins/plotting/TransportPlotting.hh
+++ b/src/plugins/plotting/TransportPlotting.hh
@@ -20,6 +20,7 @@
 
 #include <gz/gui/Plugin.hh>
 #include <gz/gui/PlottingInterface.hh>
+#include <gz/utils/ImplPtr.hh>
 #include <gz/utils/SuppressWarning.hh>
 
 #include <memory>
@@ -36,15 +37,10 @@ class TransportPlotting : public gz::gui::Plugin
   public: TransportPlotting();
 
   /// \brief Destructor
-  public: ~TransportPlotting();
+  public: ~TransportPlotting() override;
 
   // Documentation inherited
   public: void LoadConfig(const tinyxml2::XMLElement *) override;
-
-  /// \brief Interface with the UI to Handle Transport Plotting
-  GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
-  private: std::unique_ptr<PlottingInterface> dataPtr;
-  GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
 };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -21,6 +21,7 @@
 #include "gz/msgs/pointcloud_packed.pb.h"
 
 #include <algorithm>
+#include <gz/utils/ImplPtr.hh>
 #include <limits>
 #include <string>
 #include <utility>
@@ -46,7 +47,7 @@
 namespace gz::gui::plugins
 {
 /// \brief Private data class for PointCloud
-class PointCloudPrivate
+class PointCloud::Implementation
 {
   /// \brief Makes a request to populate the scene with markers
   public: void PublishMarkers();
@@ -55,7 +56,7 @@ class PointCloudPrivate
   public: void ClearMarkers();
 
   /// \brief Transport node
-  public: gz::transport::Node node;
+  public: gz::transport::Node node {gz::transport::NodeOptions()};
 
   /// \brief Name of topic for PointCloudPacked
   public: std::string pointCloudTopic{""};
@@ -99,7 +100,7 @@ class PointCloudPrivate
 
 /////////////////////////////////////////////////
 PointCloud::PointCloud()
-  : dataPtr(std::make_unique<PointCloudPrivate>())
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -353,7 +354,7 @@ void PointCloud::OnFloatVService(
 }
 
 //////////////////////////////////////////////////
-void PointCloudPrivate::PublishMarkers()
+void PointCloud::Implementation::PublishMarkers()
 {
   GZ_PROFILE("PointCloud::PublishMarkers");
 
@@ -432,7 +433,7 @@ void PointCloudPrivate::PublishMarkers()
 }
 
 //////////////////////////////////////////////////
-void PointCloudPrivate::ClearMarkers()
+void PointCloud::Implementation::ClearMarkers()
 {
   if (this->pointCloudTopic.empty())
     return;

--- a/src/plugins/point_cloud/PointCloud.hh
+++ b/src/plugins/point_cloud/PointCloud.hh
@@ -25,10 +25,10 @@
 
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui::plugins
 {
-  class PointCloudPrivate;
-
   /// \brief Visualize `gz::msgs::PointCloudPacked` messages in a 3D
   /// scene.
   ///
@@ -232,7 +232,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data
-    private: std::unique_ptr<PointCloudPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gz/utils/ImplPtr.hh>
 #include <iostream>
 #include <gz/common/Console.hh>
 #include <gz/msgs/Utility.hh>
@@ -25,7 +26,7 @@
 
 namespace gz::gui::plugins
 {
-class PublisherPrivate
+class Publisher::Implementation
 {
   /// \brief Message type
   public: QString msgType = "gz.msgs.StringMsg";
@@ -51,7 +52,7 @@ class PublisherPrivate
 
 /////////////////////////////////////////////////
 Publisher::Publisher()
-  : dataPtr(new PublisherPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 

--- a/src/plugins/publisher/Publisher.hh
+++ b/src/plugins/publisher/Publisher.hh
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "gz/gui/Plugin.hh"
+#include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
 #  define Publisher_EXPORTS_API
@@ -34,8 +35,6 @@
 
 namespace gz::gui::plugins
 {
-  class PublisherPrivate;
-
   /// \brief Widget which publishes a custom Gazebo Transport message.
   ///
   /// ## Configuration
@@ -141,7 +140,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<PublisherPrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/screenshot/Screenshot.cc
+++ b/src/plugins/screenshot/Screenshot.cc
@@ -16,6 +16,7 @@
 */
 #include "Screenshot.hh"
 
+#include <gz/utils/ImplPtr.hh>
 #include <string>
 
 #include <gz/common/Console.hh>
@@ -34,7 +35,7 @@
 
 namespace gz::gui::plugins
 {
-class ScreenshotPrivate
+class Screenshot::Implementation
 {
   /// \brief Node for communication
   public: gz::transport::Node node;
@@ -57,7 +58,7 @@ class ScreenshotPrivate
 
 /////////////////////////////////////////////////
 Screenshot::Screenshot()
-  : dataPtr(std::make_unique<ScreenshotPrivate>())
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   std::string home;
   common::env(GZ_HOMEDIR, home);

--- a/src/plugins/screenshot/Screenshot.hh
+++ b/src/plugins/screenshot/Screenshot.hh
@@ -26,10 +26,10 @@
 #include "gz/gui/qt.h"
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui::plugins
 {
-  class ScreenshotPrivate;
-
   /// \brief Provides a button and a transport service for taking a screenshot
   /// of current 3D scene.
   ///
@@ -118,7 +118,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<ScreenshotPrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/shutdown_button/ShutdownButton.hh
+++ b/src/plugins/shutdown_button/ShutdownButton.hh
@@ -41,7 +41,7 @@ namespace gz::gui::plugins
     public: ShutdownButton();
 
     /// \brief Destructor
-    public: virtual ~ShutdownButton();
+    public: virtual ~ShutdownButton() override;
 
     // Documentation inherited
     public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;

--- a/src/plugins/tape_measure/TapeMeasure.cc
+++ b/src/plugins/tape_measure/TapeMeasure.cc
@@ -17,6 +17,7 @@
 
 #include <gz/msgs/marker.pb.h>
 
+#include <gz/utils/ImplPtr.hh>
 #include <iostream>
 #include <unordered_set>
 #include <string>
@@ -33,9 +34,9 @@
 
 #include "TapeMeasure.hh"
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-class TapeMeasurePrivate
+class TapeMeasure::Implementation
 {
   /// \brief Gazebo communication node.
   public: transport::Node node;
@@ -90,7 +91,7 @@ class TapeMeasurePrivate
 
 /////////////////////////////////////////////////
 TapeMeasure::TapeMeasure()
-  : dataPtr(std::make_unique<TapeMeasurePrivate>())
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -321,8 +322,8 @@ bool TapeMeasure::eventFilter(QObject *_obj, QEvent *_event)
 
   return QObject::eventFilter(_obj, _event);
 }
-}  // namespace gz::gui
+}  // namespace gz::gui::plugins
 
 // Register this plugin
-GZ_ADD_PLUGIN(gz::gui::TapeMeasure,
+GZ_ADD_PLUGIN(gz::gui::plugins::TapeMeasure,
               gz::gui::Plugin)

--- a/src/plugins/tape_measure/TapeMeasure.hh
+++ b/src/plugins/tape_measure/TapeMeasure.hh
@@ -18,16 +18,15 @@
 #ifndef GZ_GUI_TAPEMEASURE_HH_
 #define GZ_GUI_TAPEMEASURE_HH_
 
+#include <gz/utils/ImplPtr.hh>
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/math/Color.hh>
 
-namespace gz::gui
+namespace gz::gui::plugins
 {
-  class TapeMeasurePrivate;
-
   /// \brief Provides buttons for the tape measure tool.
   class TapeMeasure : public gz::gui::Plugin
   {
@@ -96,8 +95,7 @@ namespace gz::gui
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<TapeMeasurePrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
-}  // namespace gz::gui
-
-#endif  // GZ_GUI_TAPEMEASURE_HH_
+}  // namespace gz::gui::plugins
+#endif  // GZ_GUI_PLUGINS_TAPEMEASURE_HH_

--- a/src/plugins/teleop/Teleop.cc
+++ b/src/plugins/teleop/Teleop.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gz/utils/ImplPtr.hh>
 #include <iostream>
 #include <string>
 
@@ -50,7 +51,7 @@ enum class KeyYaw{
 
 namespace gz::gui::plugins
 {
-class TeleopPrivate
+class Teleop::Implementation
 {
   /// \brief Node for communication.
   public: gz::transport::Node node;
@@ -102,7 +103,7 @@ class TeleopPrivate
 };
 
 /////////////////////////////////////////////////
-Teleop::Teleop(): dataPtr(std::make_unique<TeleopPrivate>())
+Teleop::Teleop(): dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   // Initialize publisher using default topic.
   this->dataPtr->cmdVelPub = transport::Node::Publisher();

--- a/src/plugins/teleop/Teleop.hh
+++ b/src/plugins/teleop/Teleop.hh
@@ -20,10 +20,10 @@
 
 #include <memory>
 
-#include <gz/transport/Node.hh>
-
 #include <gz/gui/Plugin.hh>
 #include <gz/gui/qt.h>
+#include <gz/transport/Node.hh>
+#include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
 #  define Teleop_EXPORTS_API
@@ -37,8 +37,6 @@
 
 namespace gz::gui::plugins
 {
-  class TeleopPrivate;
-
   /// \brief Publish teleop stokes to a user selected topic,
   /// or to '/cmd_vel' if no topic is selected.
   /// Buttons, the keyboard or sliders can be used to move a
@@ -85,10 +83,10 @@ namespace gz::gui::plugins
     public: Teleop();
 
     /// \brief Destructor
-    public: virtual ~Teleop();
+    public: ~Teleop() override;
 
     // Documentation inherited.
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *) override;
+    public: void LoadConfig(const tinyxml2::XMLElement *) override;
 
     /// \brief Filters events of type 'keypress' and 'keyrelease'.
     protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
@@ -155,8 +153,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<TeleopPrivate> dataPtr;
-
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/topic_echo/TopicEcho.cc
+++ b/src/plugins/topic_echo/TopicEcho.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gz/utils/ImplPtr.hh>
 #include <iostream>
 #include <gz/common/Console.hh>
 #include <gz/plugin/Register.hh>
@@ -25,13 +26,13 @@
 
 namespace gz::gui::plugins
 {
-class TopicEchoPrivate
+class TopicEcho::Implementation
 {
   /// \brief Topic
   public: QString topic{"/echo"};
 
   /// \brief A list of text data.
-  public: QStringListModel msgList;
+  public: QStringListModel msgList {nullptr};
 
   /// \brief Size of the text buffer. The size is the number of
   /// messages.
@@ -49,7 +50,7 @@ class TopicEchoPrivate
 
 /////////////////////////////////////////////////
 TopicEcho::TopicEcho()
-  : dataPtr(new TopicEchoPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   // Connect model
   App()->Engine()->rootContext()->setContextProperty("TopicEchoMsgList",

--- a/src/plugins/topic_echo/TopicEcho.hh
+++ b/src/plugins/topic_echo/TopicEcho.hh
@@ -40,11 +40,10 @@
 #include <memory>
 
 #include "gz/gui/Plugin.hh"
+#include <gz/utils/ImplPtr.hh>
 
 namespace gz::gui::plugins
 {
-  class TopicEchoPrivate;
-
   /// \brief Echo messages coming through a Gazebo Transport topic.
   ///
   /// ## Configuration
@@ -73,10 +72,10 @@ namespace gz::gui::plugins
     public: TopicEcho();
 
     /// \brief Destructor
-    public: virtual ~TopicEcho();
+    public: ~TopicEcho() override;
 
     // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
     /// \brief Get the topic as a string, for example
     /// '/echo'
@@ -124,7 +123,7 @@ namespace gz::gui::plugins
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<TopicEchoPrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/topic_viewer/TopicViewer.cc
+++ b/src/plugins/topic_viewer/TopicViewer.cc
@@ -281,10 +281,11 @@ void TopicViewer::Implementation::AddField(QStandardItem *_parentItem,
 }
 
 //////////////////////////////////////////////////
-QStandardItem *TopicViewer::Implementation::FactoryItem(const std::string &_name,
-                                               const std::string &_type,
-                                               const std::string &_path,
-                                               const std::string &_topic)
+QStandardItem *TopicViewer::Implementation::FactoryItem(
+  const std::string &_name,
+  const std::string &_type,
+  const std::string &_path,
+  const std::string &_topic)
 {
   QString name = QString::fromStdString(_name);
   QString type = QString::fromStdString(_type);

--- a/src/plugins/topic_viewer/TopicViewer.hh
+++ b/src/plugins/topic_viewer/TopicViewer.hh
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include <gz/gui/Plugin.hh>
+#include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
 #  define TopicViewer_EXPORTS_API
@@ -35,7 +36,6 @@
 namespace gz::gui::plugins
 {
   class TopicsModel;
-  class TopicViewerPrivate;
 
   /// \brief a Plugin to view the topics and their msgs & fields
   /// Field's informations can be passed by dragging them via the UI
@@ -60,7 +60,7 @@ namespace gz::gui::plugins
     public slots: void UpdateModel();
 
     /// \brief Pointer to private data.
-    private: std:: unique_ptr<TopicViewerPrivate> dataPtr;
+    private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <gz/utils/ImplPtr.hh>
 #include <map>
 #include <sstream>
 #include <string>
@@ -57,7 +58,7 @@
 namespace gz::gui::plugins
 {
 /// \brief Private data class for TransportSceneManager
-class TransportSceneManagerPrivate
+class TransportSceneManager::Implementation
 {
   /// \brief Make the scene service request and populate the scene
   public: void Request();
@@ -176,7 +177,7 @@ class TransportSceneManagerPrivate
 
 /////////////////////////////////////////////////
 TransportSceneManager::TransportSceneManager()
-  : dataPtr(new TransportSceneManagerPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -252,12 +253,12 @@ void TransportSceneManager::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::InitializeTransport()
+void TransportSceneManager::Implementation::InitializeTransport()
 {
   this->Request();
 
   if (!this->node.Subscribe(this->poseTopic,
-      &TransportSceneManagerPrivate::OnPoseVMsg, this))
+      &Implementation::OnPoseVMsg, this))
   {
     gzerr << "Error subscribing to pose topic: " << this->poseTopic
       << std::endl;
@@ -269,7 +270,7 @@ void TransportSceneManagerPrivate::InitializeTransport()
   }
 
   if (!this->node.Subscribe(this->deletionTopic,
-      &TransportSceneManagerPrivate::OnDeletionMsg, this))
+      &Implementation::OnDeletionMsg, this))
   {
     gzerr << "Error subscribing to deletion topic: " << this->deletionTopic
       << std::endl;
@@ -281,7 +282,7 @@ void TransportSceneManagerPrivate::InitializeTransport()
   }
 
   if (!this->node.Subscribe(this->sceneTopic,
-      &TransportSceneManagerPrivate::OnSceneMsg, this))
+      &Implementation::OnSceneMsg, this))
   {
     gzerr << "Error subscribing to scene topic: " << this->sceneTopic
            << std::endl;
@@ -308,7 +309,7 @@ bool TransportSceneManager::eventFilter(QObject *_obj, QEvent *_event)
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::Request()
+void TransportSceneManager::Implementation::Request()
 {
   // wait for the service to be advertized
   std::vector<transport::ServicePublisher> publishers;
@@ -324,7 +325,7 @@ void TransportSceneManagerPrivate::Request()
   }
 
   if (publishers.empty() || !this->node.Request(this->service,
-      &TransportSceneManagerPrivate::OnSceneSrvMsg, this))
+      &Implementation::OnSceneSrvMsg, this))
   {
     gzerr << "Error making service request to [" << this->service << "]"
            << std::endl;
@@ -332,7 +333,7 @@ void TransportSceneManagerPrivate::Request()
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::OnPoseVMsg(const msgs::Pose_V &_msg)
+void TransportSceneManager::Implementation::OnPoseVMsg(const msgs::Pose_V &_msg)
 {
   std::lock_guard<std::mutex> lock(this->msgMutex);
   for (int i = 0; i < _msg.pose_size(); ++i)
@@ -351,7 +352,8 @@ void TransportSceneManagerPrivate::OnPoseVMsg(const msgs::Pose_V &_msg)
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::OnDeletionMsg(const msgs::UInt32_V &_msg)
+void TransportSceneManager::Implementation::OnDeletionMsg(
+  const msgs::UInt32_V &_msg)
 {
   std::lock_guard<std::mutex> lock(this->msgMutex);
   std::copy(_msg.data().begin(), _msg.data().end(),
@@ -359,7 +361,7 @@ void TransportSceneManagerPrivate::OnDeletionMsg(const msgs::UInt32_V &_msg)
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::OnRender()
+void TransportSceneManager::Implementation::OnRender()
 {
   if (nullptr == this->scene)
   {
@@ -368,7 +370,7 @@ void TransportSceneManagerPrivate::OnRender()
       return;
 
     this->initializeTransport = std::thread(
-        &TransportSceneManagerPrivate::InitializeTransport, this);
+        &Implementation::InitializeTransport, this);
   }
 
   std::lock_guard<std::mutex> lock(this->msgMutex);
@@ -430,15 +432,15 @@ void TransportSceneManagerPrivate::OnRender()
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::OnSceneMsg(const msgs::Scene &_msg)
+void TransportSceneManager::Implementation::OnSceneMsg(const msgs::Scene &_msg)
 {
   std::lock_guard<std::mutex> lock(this->msgMutex);
   this->sceneMsgs.push_back(_msg);
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::OnSceneSrvMsg(const msgs::Scene &_msg,
-    const bool result)
+void TransportSceneManager::Implementation::OnSceneSrvMsg(
+  const msgs::Scene &_msg, const bool result)
 {
   if (!result)
   {
@@ -454,7 +456,7 @@ void TransportSceneManagerPrivate::OnSceneSrvMsg(const msgs::Scene &_msg,
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::LoadScene(const msgs::Scene &_msg)
+void TransportSceneManager::Implementation::LoadScene(const msgs::Scene &_msg)
 {
   rendering::VisualPtr rootVis = this->scene->RootVisual();
 
@@ -487,7 +489,7 @@ void TransportSceneManagerPrivate::LoadScene(const msgs::Scene &_msg)
 }
 
 /////////////////////////////////////////////////
-rendering::VisualPtr TransportSceneManagerPrivate::LoadModel(
+rendering::VisualPtr TransportSceneManager::Implementation::LoadModel(
     const msgs::Model &_msg)
 {
   rendering::VisualPtr modelVis;
@@ -529,7 +531,7 @@ rendering::VisualPtr TransportSceneManagerPrivate::LoadModel(
 }
 
 /////////////////////////////////////////////////
-rendering::VisualPtr TransportSceneManagerPrivate::LoadLink(
+rendering::VisualPtr TransportSceneManager::Implementation::LoadLink(
     const msgs::Link &_msg)
 {
   rendering::VisualPtr linkVis;
@@ -570,7 +572,7 @@ rendering::VisualPtr TransportSceneManagerPrivate::LoadLink(
 }
 
 /////////////////////////////////////////////////
-rendering::VisualPtr TransportSceneManagerPrivate::LoadVisual(
+rendering::VisualPtr TransportSceneManager::Implementation::LoadVisual(
     const msgs::Visual &_msg)
 {
   if (!_msg.has_geometry())
@@ -674,7 +676,7 @@ rendering::VisualPtr TransportSceneManagerPrivate::LoadVisual(
 }
 
 /////////////////////////////////////////////////
-rendering::GeometryPtr TransportSceneManagerPrivate::LoadGeometry(
+rendering::GeometryPtr TransportSceneManager::Implementation::LoadGeometry(
     const msgs::Geometry &_msg, math::Vector3d &_scale,
     math::Pose3d &_localPose)
 {
@@ -767,7 +769,7 @@ rendering::GeometryPtr TransportSceneManagerPrivate::LoadGeometry(
 }
 
 /////////////////////////////////////////////////
-rendering::MaterialPtr TransportSceneManagerPrivate::LoadMaterial(
+rendering::MaterialPtr TransportSceneManager::Implementation::LoadMaterial(
     const msgs::Material &_msg)
 {
   rendering::MaterialPtr material = this->scene->CreateMaterial();
@@ -792,7 +794,7 @@ rendering::MaterialPtr TransportSceneManagerPrivate::LoadMaterial(
 }
 
 /////////////////////////////////////////////////
-rendering::LightPtr TransportSceneManagerPrivate::LoadLight(
+rendering::LightPtr TransportSceneManager::Implementation::LoadLight(
     const msgs::Light &_msg)
 {
   rendering::LightPtr light;
@@ -848,7 +850,8 @@ rendering::LightPtr TransportSceneManagerPrivate::LoadLight(
 }
 
 /////////////////////////////////////////////////
-void TransportSceneManagerPrivate::DeleteEntity(const unsigned int _entity)
+void TransportSceneManager::Implementation::DeleteEntity(
+  const unsigned int _entity)
 {
   if (this->visuals.find(_entity) != this->visuals.end())
   {

--- a/src/plugins/transport_scene_manager/TransportSceneManager.hh
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.hh
@@ -22,10 +22,10 @@
 
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz::gui::plugins
 {
-  class TransportSceneManagerPrivate;
-
   /// \brief Provides a Gazebo Transport interface to
   /// `gz::gui::plugins::MinimalScene`.
   ///
@@ -46,19 +46,18 @@ namespace gz::gui::plugins
     /// \brief Constructor
     public: TransportSceneManager();
 
-    /// \brief Destructor
-    public: virtual ~TransportSceneManager();
+  /// \brief Destructor
+  public: ~TransportSceneManager() override;
 
-    // Documentation inherited
-    public: virtual void LoadConfig(const tinyxml2::XMLElement *_pluginElem)
-        override;
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
     // Documentation inherited
     private: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
     /// \internal
     /// \brief Pointer to private data.
-    private: std::unique_ptr<TransportSceneManagerPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/world_control/WorldControl.cc
+++ b/src/plugins/world_control/WorldControl.cc
@@ -35,7 +35,7 @@
 
 namespace gz::gui::plugins
 {
-class WorldControlPrivate
+class WorldControl::Implementation
 {
   /// \brief Send the world control event or call the control service.
   /// \param[in] _msg Message to send.
@@ -71,7 +71,7 @@ class WorldControlPrivate
 
 /////////////////////////////////////////////////
 WorldControl::WorldControl()
-  : dataPtr(new WorldControlPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -327,7 +327,7 @@ void WorldControl::OnStep()
 }
 
 /////////////////////////////////////////////////
-void WorldControlPrivate::SendEventMsg(const msgs::WorldControl &_msg)
+void WorldControl::Implementation::SendEventMsg(const msgs::WorldControl &_msg)
 {
   if (this->useEvent)
   {

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -24,6 +24,8 @@
 
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 #ifndef _WIN32
 #  define WorldControl_EXPORTS_API
 #else
@@ -36,8 +38,6 @@
 
 namespace gz::gui::plugins
 {
-  class WorldControlPrivate;
-
   /// \brief This plugin provides a world control panel which may have a
   /// play / pause and step buttons.
   ///
@@ -63,11 +63,11 @@ namespace gz::gui::plugins
     /// \brief Constructor
     public: WorldControl();
 
-    /// \brief Destructor
-    public: virtual ~WorldControl();
+  /// \brief Destructor
+  public: ~WorldControl() override;
 
-    // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+  // Documentation inherited
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
     /// \brief Callback in main thread when diagnostics come in
     public slots: void ProcessMsg();
@@ -101,7 +101,7 @@ namespace gz::gui::plugins
     private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
 
     // Private data
-    private: std::unique_ptr<WorldControlPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 

--- a/src/plugins/world_stats/WorldStats.cc
+++ b/src/plugins/world_stats/WorldStats.cc
@@ -26,12 +26,13 @@
 #include <gz/math/Helpers.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
+#include <gz/utils/ImplPtr.hh>
 
 #include "gz/gui/Helpers.hh"
 
 namespace gz::gui::plugins
 {
-class WorldStatsPrivate
+class WorldStats::Implementation
 {
   /// \brief Message holding latest world statistics
   public: gz::msgs::WorldStatistics msg;
@@ -65,7 +66,7 @@ class WorldStatsPrivate
 
 /////////////////////////////////////////////////
 WorldStats::WorldStats()
-  : dataPtr(new WorldStatsPrivate)
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -25,6 +25,8 @@
 #include "gz/gui/Export.hh"
 #include "gz/gui/Plugin.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 #ifndef _WIN32
 #  define WorldStats_EXPORTS_API
 #else
@@ -37,8 +39,6 @@
 
 namespace gz::gui::plugins
 {
-  class WorldStatsPrivate;
-
   /// \brief This plugin provides a time panel which may display:
   /// * Simulation time
   /// * Real time
@@ -99,10 +99,10 @@ namespace gz::gui::plugins
     public: WorldStats();
 
     /// \brief Destructor
-    public: virtual ~WorldStats();
+    public: ~WorldStats() override;
 
     // Documentation inherited
-    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem);
+    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
     /// \brief Callback in main thread when diagnostics come in
     public slots: void ProcessMsg();
@@ -155,7 +155,7 @@ namespace gz::gui::plugins
     private: void OnWorldStatsMsg(const gz::msgs::WorldStatistics &_msg);
 
     // Private data
-    private: std::unique_ptr<WorldStatsPrivate> dataPtr;
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }  // namespace gz::gui::plugins
 


### PR DESCRIPTION
This changes the rest of our `std::unique_ptr` implementations over to `gz::utils::ImplPtr`.