### PR TITLE
Add check for vulkan support in rendering

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -37,6 +37,7 @@
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
+#include <gz/rendering/config.hh>
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RayQuery.hh>
 #include <gz/rendering/RenderEngine.hh>

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -40,7 +40,6 @@
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RayQuery.hh>
 #include <gz/rendering/RenderEngine.hh>
-#include <gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 #include <gz/rendering/Utils.hh>
@@ -52,8 +51,10 @@
 #include "gz/gui/Helpers.hh"
 #include "gz/gui/MainWindow.hh"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
 #  include <QVulkanInstance>
+#  include <gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh>
 #endif
 
 Q_DECLARE_METATYPE(gz::gui::plugins::RenderSync*)
@@ -584,7 +585,8 @@ rendering::CameraPtr GzRenderer::Camera()
   return this->dataPtr->camera;
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
 /////////////////////////////////////////////////
 /// \brief fillQtInstanceExtensionsToOgre
 /// Extract Vulkan Instance extension information to be sent to OgreNext
@@ -677,7 +679,8 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
 
     this->dataPtr->rhiParams["winID"] = std::to_string(quickWindow->winId());
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
     // externalInstance & externalDevice MUST be declared at this scope
     // because we save their stack addresses into this->dataPtr->rhiParams
     // and must be alive until rendering::engine() returns.
@@ -805,7 +808,8 @@ void GzRenderer::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
   {
     gzdbg << "Creating gz-rendering interface for Vulkan" << std::endl;
     this->dataPtr->rhiParams["vulkan"] = "1";
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
     this->dataPtr->rhi = std::make_unique<GzCameraTextureRhiVulkan>();
 #else
     this->dataPtr->rhi = std::make_unique<GzCameraTextureRhiOpenGL>();
@@ -973,7 +977,8 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
 
   // Create the render interface
   if (_graphicsAPI == rendering::GraphicsAPI::OPENGL
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
       // Use fallback (GPU -> CPU -> GPU)
       || _graphicsAPI == rendering::GraphicsAPI::VULKAN
 #endif
@@ -982,7 +987,8 @@ void RenderThread::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
     gzdbg << "Creating render thread interface for OpenGL" << std::endl;
     this->rhi = std::make_unique<RenderThreadRhiOpenGL>(&this->gzRenderer);
   }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
   else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
   {
     gzdbg << "Creating render thread interface for Vulkan" << std::endl;
@@ -1013,7 +1019,8 @@ std::string RenderThread::Initialize()
 TextureNode::TextureNode(QQuickWindow *_window, RenderSync &_renderSync,
                          const rendering::GraphicsAPI &_graphicsAPI,
                          rendering::CameraPtr &
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
                            _camera
 #endif
                          ) :
@@ -1021,7 +1028,8 @@ TextureNode::TextureNode(QQuickWindow *_window, RenderSync &_renderSync,
   window(_window)
 {
   if (_graphicsAPI == rendering::GraphicsAPI::OPENGL
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
       // Use fallback (GPU -> CPU -> GPU)
       || _graphicsAPI == rendering::GraphicsAPI::VULKAN
 #endif
@@ -1030,7 +1038,8 @@ TextureNode::TextureNode(QQuickWindow *_window, RenderSync &_renderSync,
     gzdbg << "Creating texture node render interface for OpenGL" << std::endl;
     this->rhi = std::make_unique<TextureNodeRhiOpenGL>(_window);
   }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
   else if (_graphicsAPI == rendering::GraphicsAPI::VULKAN)
   {
     gzdbg << "Creating texture node render interface for Vulkan" << std::endl;
@@ -1137,7 +1146,8 @@ void RenderWindowItem::StopRendering()
 void RenderWindowItem::Ready()
 {
   if (this->dataPtr->graphicsAPI == rendering::GraphicsAPI::OPENGL
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
       // Use fallback (GPU -> CPU -> GPU)
       || this->dataPtr->graphicsAPI == rendering::GraphicsAPI::VULKAN
 #endif
@@ -1156,7 +1166,8 @@ void RenderWindowItem::Ready()
   }
 
   if (this->dataPtr->graphicsAPI == rendering::GraphicsAPI::OPENGL
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
       // Use fallback (GPU -> CPU -> GPU)
       || this->dataPtr->graphicsAPI == rendering::GraphicsAPI::VULKAN
 #endif
@@ -1204,7 +1215,8 @@ QSGNode *RenderWindowItem::updatePaintNode(QSGNode *_node,
         this->dataPtr->graphicsAPI);
 
     if (this->dataPtr->graphicsAPI == rendering::GraphicsAPI::OPENGL
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan)
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 2) && QT_CONFIG(vulkan) && \
+    defined(GZ_RENDERING_HAVE_VULKAN)
         // Use fallback (GPU -> CPU -> GPU)
         || this->dataPtr->graphicsAPI == rendering::GraphicsAPI::VULKAN
 #endif


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-gui/issues/585

## Summary

Add check to make sure we only enable vulkan only if gz-rendering is built with vulkan support.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

