### PR TITLE
Enable HIDE_SYMBOLS_BY_DEFAULT + patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,8 @@ set(GZ_GUI_PLUGIN_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS)
+gz_configure_build(QUIT_IF_BUILD_ERRORS
+  HIDE_SYMBOLS_BY_DEFAULT)
 
 #============================================================================
 # gz command line support

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -82,7 +82,7 @@ namespace plugins
   /// \<topic\> : Set the topic to receive image messages.
   /// \<topic_picker\> : Whether to show the topic picker, true by default. If
   ///                    this is false, a \<topic\> must be specified.
-  class ImageDisplay_EXPORTS_API ImageDisplay : public Plugin
+  class GZ_GUI_VISIBLE ImageDisplay : public Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/key_publisher/KeyPublisher.hh
+++ b/src/plugins/key_publisher/KeyPublisher.hh
@@ -45,7 +45,7 @@ namespace gui
   ///
   /// ## Configuration
   /// This plugin doesn't accept any custom configuration.
-  class KeyPublisher_EXPORTS_API KeyPublisher : public gz::gui::Plugin
+  class GZ_GUI_VISIBLE KeyPublisher : public gz::gui::Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/publisher/Publisher.hh
+++ b/src/plugins/publisher/Publisher.hh
@@ -44,7 +44,7 @@ namespace plugins
   ///
   /// ## Configuration
   /// This plugin doesn't accept any custom configuration.
-  class Publisher_EXPORTS_API Publisher : public Plugin
+  class GZ_GUI_VISIBLE Publisher : public Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/shutdown_button/ShutdownButton.hh
+++ b/src/plugins/shutdown_button/ShutdownButton.hh
@@ -37,7 +37,7 @@ namespace gui
 namespace plugins
 {
   /// \brief This plugin provides a shutdown button.
-  class ShutdownButton_EXPORTS_API ShutdownButton: public gz::gui::Plugin
+  class GZ_GUI_VISIBLE ShutdownButton: public gz::gui::Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/teleop/Teleop.hh
+++ b/src/plugins/teleop/Teleop.hh
@@ -49,7 +49,7 @@ namespace plugins
   /// vehicle in the world.
   /// ## Configuration
   /// * `<topic>`: Topic to publish twist messages to.
-  class Teleop_EXPORTS_API Teleop : public Plugin
+  class GZ_GUI_VISIBLE Teleop : public Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/topic_echo/TopicEcho.hh
+++ b/src/plugins/topic_echo/TopicEcho.hh
@@ -53,7 +53,7 @@ namespace plugins
   ///
   /// ## Configuration
   /// This plugin doesn't accept any custom configuration.
-  class TopicEcho_EXPORTS_API TopicEcho : public Plugin
+  class GZ_GUI_VISIBLE TopicEcho : public Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/topic_viewer/TopicViewer.hh
+++ b/src/plugins/topic_viewer/TopicViewer.hh
@@ -39,7 +39,7 @@ namespace plugins
 
   /// \brief a Plugin to view the topics and their msgs & fields
   /// Field's informations can be passed by dragging them via the UI
-  class TopicViewer_EXPORTS_API TopicViewer : public Plugin
+  class GZ_GUI_VISIBLE TopicViewer : public Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -60,7 +60,7 @@ namespace plugins
   ///
   /// If no elements are filled for the plugin, both the play/pause and the
   /// step buttons will be displayed.
-  class WorldControl_EXPORTS_API WorldControl: public gz::gui::Plugin
+  class GZ_GUI_VISIBLE WorldControl: public gz::gui::Plugin
   {
     Q_OBJECT
 

--- a/src/plugins/world_control/WorldControlEventListener.hh
+++ b/src/plugins/world_control/WorldControlEventListener.hh
@@ -30,7 +30,7 @@ namespace gui
   /// \brief Helper class for testing listening to events emitted by the
   /// WorldControl plugin. This is used for testing the event behavior of
   /// the WorldControl plugin.
-  class WorldControlEventListener : public QObject
+  class GZ_GUI_VISIBLE WorldControlEventListener : public QObject
   {
     Q_OBJECT
 

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -63,7 +63,7 @@ namespace plugins
   ///
   /// If no elements are filled for the plugin, all properties will be
   /// displayed.
-  class WorldStats_EXPORTS_API WorldStats: public gz::gui::Plugin
+  class GZ_GUI_VISIBLE WorldStats: public gz::gui::Plugin
   {
     Q_OBJECT
 

--- a/test/helpers/TestHelper.hh
+++ b/test/helpers/TestHelper.hh
@@ -36,7 +36,7 @@ namespace gz
 namespace gui
 {
 /// \brief
-class TestHelper_EXPORTS_API TestHelper : public QObject
+class GZ_GUI_VISIBLE TestHelper : public QObject
 {
   Q_OBJECT
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/pull/392 and https://github.com/gazebosim/gz-cmake/issues/166.

## Summary
The PR enables the `HIDE_SYMBOLS_BY_DEFAULT` option and patch the failures found during the build on Linux.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.