### PR TITLE
Enable HIDE_SYMBOLS_BY_DEFAULT + patches (take II)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,8 @@ set(GZ_GUI_PLUGIN_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS)
+gz_configure_build(QUIT_IF_BUILD_ERRORS
+  HIDE_SYMBOLS_BY_DEFAULT)
 
 #============================================================================
 # gz command line support

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -25,7 +25,7 @@
 #include <gz/msgs/image.pb.h>
 
 #ifndef _WIN32
-#  define ImageDisplay_EXPORTS_API
+#  define ImageDisplay_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(ImageDisplay_EXPORTS))
 #    define ImageDisplay_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/key_publisher/KeyPublisher.hh
+++ b/src/plugins/key_publisher/KeyPublisher.hh
@@ -19,7 +19,7 @@
 #define GZ_GUI_PLUGINS_KEYPUBLISHER_HH_
 
 #ifndef _WIN32
-#  define KeyPublisher_EXPORTS_API
+#  define KeyPublisher_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(KeyPublisher_EXPORTS))
 #    define KeyPublisher_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/publisher/Publisher.hh
+++ b/src/plugins/publisher/Publisher.hh
@@ -24,7 +24,7 @@
 #include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
-#  define Publisher_EXPORTS_API
+#  define Publisher_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(Publisher_EXPORTS))
 #    define Publisher_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/shutdown_button/ShutdownButton.hh
+++ b/src/plugins/shutdown_button/ShutdownButton.hh
@@ -21,7 +21,7 @@
 #include "gz/gui/Plugin.hh"
 
 #ifndef _WIN32
-#  define ShutdownButton_EXPORTS_API
+#  define ShutdownButton_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(ShutdownButton_EXPORTS))
 #    define ShutdownButton_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/teleop/Teleop.hh
+++ b/src/plugins/teleop/Teleop.hh
@@ -26,7 +26,7 @@
 #include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
-#  define Teleop_EXPORTS_API
+#  define Teleop_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(Teleop_EXPORTS))
 #    define Teleop_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/topic_echo/TopicEcho.hh
+++ b/src/plugins/topic_echo/TopicEcho.hh
@@ -28,7 +28,7 @@
 #endif
 
 #ifndef _WIN32
-#  define TopicEcho_EXPORTS_API
+#  define TopicEcho_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(TopicEcho_EXPORTS))
 #    define TopicEcho_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/topic_viewer/TopicViewer.hh
+++ b/src/plugins/topic_viewer/TopicViewer.hh
@@ -24,7 +24,7 @@
 #include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
-#  define TopicViewer_EXPORTS_API
+#  define TopicViewer_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(TopicViewer_EXPORTS))
 #    define TopicViewer_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/world_control/WorldControl.hh
+++ b/src/plugins/world_control/WorldControl.hh
@@ -27,7 +27,7 @@
 #include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
-#  define WorldControl_EXPORTS_API
+#  define WorldControl_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(WorldControl_EXPORTS))
 #    define WorldControl_EXPORTS_API __declspec(dllexport)

--- a/src/plugins/world_control/WorldControlEventListener.hh
+++ b/src/plugins/world_control/WorldControlEventListener.hh
@@ -18,17 +18,27 @@
 #define GZ_GUI_WORLDCONTROLEVENTLISTENER_HH_
 
 #include "gz/gui/Application.hh"
-#include "gz/gui/Export.hh"
 #include "gz/gui/GuiEvents.hh"
 #include "gz/gui/MainWindow.hh"
 #include "gz/gui/qt.h"
+
+#ifndef _WIN32
+#  define WorldControl_EXPORTS_API __attribute__ ((visibility ("default")))
+#else
+#  if (defined(WorldControl_EXPORTS))
+#    define WorldControl_EXPORTS_API __declspec(dllexport)
+#  else
+#    define WorldControl_EXPORTS_API __declspec(dllimport)
+#  endif
+#endif
+
 
 namespace gz::gui
 {
   /// \brief Helper class for testing listening to events emitted by the
   /// WorldControl plugin. This is used for testing the event behavior of
   /// the WorldControl plugin.
-  class WorldControlEventListener : public QObject
+  class WorldControl_EXPORTS_API WorldControlEventListener : public QObject
   {
     Q_OBJECT
 

--- a/src/plugins/world_stats/WorldStats.hh
+++ b/src/plugins/world_stats/WorldStats.hh
@@ -22,13 +22,12 @@
 
 #include <gz/msgs/world_stats.pb.h>
 
-#include "gz/gui/Export.hh"
 #include "gz/gui/Plugin.hh"
 
 #include <gz/utils/ImplPtr.hh>
 
 #ifndef _WIN32
-#  define WorldStats_EXPORTS_API
+#  define WorldStats_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(WorldStats_EXPORTS))
 #    define WorldStats_EXPORTS_API __declspec(dllexport)

--- a/test/helpers/TestHelper.hh
+++ b/test/helpers/TestHelper.hh
@@ -18,11 +18,10 @@
 #define GZ_GUI_TESTHELPER_HH_
 
 #include <gz/gui/Application.hh>
-#include <gz/gui/Export.hh>
 #include <gz/gui/MainWindow.hh>
 
 #ifndef _WIN32
-#  define TestHelper_EXPORTS_API
+#  define TestHelper_EXPORTS_API __attribute__ ((visibility ("default")))
 #else
 #  if (defined(TestHelper_EXPORTS))
 #    define TestHelper_EXPORTS_API __declspec(dllexport)


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/pull/392 and https://github.com/gazebosim/gz-cmake/issues/166.

Replaces #600.

## Summary
The PR enables the `HIDE_SYMBOLS_BY_DEFAULT` option and patch the failures found during the build on Linux. Mainly by adding the default visibility behaviour for the custom define on each plugin.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.