### PR TITLE
Fix QImage's step size in ImageDisplay plugin

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -129,7 +129,8 @@ void ImageDisplay::ProcessImage()
     case msgs::PixelFormatType::RGB_INT8:
       // copy image data buffer directly to QImage
       image = QImage(reinterpret_cast<const uchar *>(
-          this->dataPtr->imageMsg.data().c_str()), width, height, qFormat);
+          this->dataPtr->imageMsg.data().c_str()), width, height,
+          3 * width, qFormat);
       break;
     // for other cases, convert to RGB common::Image
     case msgs::PixelFormatType::R_FLOAT32:


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/945

## Summary
The `QImage` constructor that was used expects the images are 32 bit aligned. This is not true for our `RGB_INT8` formats. (24 bits) The PR fixes the issue by explicitly specifying the `bytesPerLine` field in the constructor.

Tested with `camera_sensor.sdf` world by changing the image width to be `321` (from `320`)

Before
<img width="403" alt="image_display_before" src="https://github.com/gazebosim/gz-gui/assets/4000684/181a7d37-255f-47f2-9f57-076815f530dc">


After
<img width="404" alt="Image_display_after" src="https://github.com/gazebosim/gz-gui/assets/4000684/c12685fa-4b46-4a44-aaef-904c4c2c5bf6">



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
