### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,7 @@ set(GZ_GUI_PLUGIN_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT)
+gz_configure_build(QUIT_IF_BUILD_ERRORS)
 
 #============================================================================
 # gz command line support


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166