### PR TITLE
Support `<gz-gui>` tag in plugin config

### DIFF
--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -167,7 +167,12 @@ void Plugin::Load(const tinyxml2::XMLElement *_pluginElem)
   }
 
   // Load common configuration
-  this->LoadCommonConfig(_pluginElem->FirstChildElement("ignition-gui"));
+  auto guiElem = _pluginElem->FirstChildElement("ignition-gui");
+  if (!guiElem)
+  {
+    guiElem = _pluginElem->FirstChildElement("gz-gui");
+  }
+  this->LoadCommonConfig(guiElem);
 
   // Load custom configuration
   this->LoadConfig(_pluginElem);

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -321,3 +321,33 @@ TEST(PluginTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ConfigStrInputNoPlugin))
   }
 }
 
+/////////////////////////////////////////////////
+TEST(PluginTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(GzSimCompatibility))
+{
+  common::Console::SetVerbosity(4);
+
+  Application app(g_argc, g_argv);
+  app.AddPluginPath(
+      common::joinPaths(std::string(PROJECT_BINARY_PATH), "lib"));
+
+  // Load plugin config that returns null GetText
+  const char *pluginStr = R"(
+    <plugin filename="TestPlugin">
+      <gz-gui>
+        <title>GzSimCompatibility</title>
+      </gz-gui>
+    </plugin>)";
+
+  tinyxml2::XMLDocument pluginDoc;
+  pluginDoc.Parse(pluginStr);
+  EXPECT_TRUE(app.LoadPlugin("TestPlugin",
+      pluginDoc.FirstChildElement("plugin")));
+
+  auto win = app.findChild<MainWindow *>();
+  ASSERT_NE(nullptr, win);
+
+  // Check plugin was loaded and `gz-gui` was processed.
+  auto plugins = win->findChildren<Plugin *>();
+  ASSERT_EQ(1, plugins.size());
+  EXPECT_EQ(plugins[0]->Title(), "GzSimCompatibility");
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
This allows users to specify `<gz-gui>` instead of `<ignition-gui>` in their GUI plugins so that SDF files can work on Fortress and Garden/Harmonic without modification.

## Test it
Run `PluginTest.GzSimCompatibility` test

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.