### PR TITLE
Fix pkg-config version comparator for Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ gz_find_package (Qt${QT_MAJOR_VERSION}
     Widgets
     Test
   REQUIRED
+  PKGCONFIG_VER_COMPARISON >=
   PKGCONFIG "Qt${QT_MAJOR_VERSION}Core Qt${QT_MAJOR_VERSION}Quick Qt${QT_MAJOR_VERSION}QuickControls2 Qt${QT_MAJOR_VERSION}Widgets")
 add_compile_definitions(QT_DISABLE_DEPRECATED_UP_TO=0x050F00)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes pkg-config test in gz-gui9 bottle test: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui9-install_bottle-homebrew-amd64&build=62)](https://build.osrfoundation.org/view/gz-ionic/job/gz_gui9-install_bottle-homebrew-amd64/62/)

## Summary

The `pkg-config` test for `gz-gui9` bottle fails with:

~~~
pkg-config
gz-gui9
--cflags

Package 'gz-gui9' requires 'Qt5Widgets = 5.15' but version of Qt5Widgets is 5.15.12
~~~

The fix is to use the `>=` comparator when finding Qt.

Tested with this branch in [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui9-install_bottle-homebrew-amd64&build=63)](https://build.osrfoundation.org/view/gz-ionic/job/gz_gui9-install_bottle-homebrew-amd64/63/) using `ci_matching_branch/`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
