### PR TITLE
Define GZ_GUI_VERSION_NAMESPACE in config.hh

### DIFF
--- a/include/gz/gui/config.hh.in
+++ b/include/gz/gui/config.hh.in
@@ -27,6 +27,7 @@
 
 #define GZ_GUI_VERSION "${PROJECT_VERSION}"
 #define GZ_GUI_VERSION_FULL "${PROJECT_VERSION_FULL}"
+#define GZ_GUI_VERSION_NAMESPACE v${PROJECT_VERSION_MAJOR}
 
 #define GZ_GUI_VERSION_HEADER "Gazebo GUI, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2017 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-cmake#412.

## Summary

Ensure that the `GZ_GUI_VERSION_NAMESPACE` macro is defined in config.hh.in.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
