### PR TITLE
Add Cone as a primitive parametric shape.

### DIFF
--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -610,6 +610,8 @@ gz::rendering::MarkerType MarkerManagerPrivate::MsgToType(
       return gz::rendering::MarkerType::MT_BOX;
     case gz::msgs::Marker::CAPSULE:
       return gz::rendering::MarkerType::MT_CAPSULE;
+    case gz::msgs::Marker::CONE:
+      return gz::rendering::MarkerType::MT_CONE;
     case gz::msgs::Marker::CYLINDER:
       return gz::rendering::MarkerType::MT_CYLINDER;
     case gz::msgs::Marker::LINE_STRIP:

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -687,6 +687,13 @@ rendering::GeometryPtr TransportSceneManagerPrivate::LoadGeometry(
     if (_msg.box().has_size())
       scale = msgs::Convert(_msg.box().size());
   }
+  else if (_msg.has_cone())
+  {
+    geom = this->scene->CreateCone();
+    scale.X() = _msg.cone().radius() * 2;
+    scale.Y() = scale.X();
+    scale.Z() = _msg.cone().length();
+  }
   else if (_msg.has_cylinder())
   {
     geom = this->scene->CreateCylinder();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This helps add the missing cone geometry for primitive/basic parametric shapes:

![conetopple](https://github.com/gazebosim/gz-math/assets/10233412/5fd8f1a1-3a77-4e61-95d5-f053389cd908)
![cone](https://github.com/gazebosim/gz-math/assets/10233412/1c516775-7adb-4318-9c6a-0c09a746a3b0)

And is also valuable for visualizations of emitters/source that typically have conic-based spread as seen in this acoustic attack on an IMU by showing the affected area:

![drone_attack](https://github.com/gazebosim/gz-rendering/assets/10233412/7a6b0dfa-8ad6-42c1-83bc-8385ccc4c81a)

Associated PRs:

- https://github.com/gazebosim/gz-gui/pull/620
- https://github.com/gazebosim/gz-math/pull/593
- https://github.com/gazebosim/gz-msgs/pull/441
- https://github.com/gazebosim/gz-physics/pull/638
- https://github.com/gazebosim/gz-rendering/pull/1001
- https://github.com/gazebosim/gz-sim/pull/2404
- https://github.com/gazebosim/sdformat/pull/1415

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
