### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/plugins/image_display/ImageDisplay_TEST.cc
+++ b/src/plugins/image_display/ImageDisplay_TEST.cc
@@ -269,7 +269,7 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImage))
 
     // red image
     int bufferSize = msg.width() * msg.height() * bpp;
-    std::shared_ptr<unsigned char> buffer(new unsigned char[bufferSize]);
+    std::shared_ptr<unsigned char[]> buffer(new unsigned char[bufferSize]);
     for (int i = 0; i < bufferSize; i += bpp)
     {
       buffer.get()[i] = 255u;
@@ -371,7 +371,7 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImageFloat32))
 
     // first half is gray, second half is black
     int bufferSize = msg.width() * msg.height() * bpp;
-    std::shared_ptr<float> buffer(new float[bufferSize]);
+    std::shared_ptr<float[]> buffer(new float[bufferSize]);
     for (unsigned int y = 0; y < msg.width(); ++y)
     {
       float v = 0.5f * static_cast<int>(y / (msg.height() / 2.0) + 1);
@@ -485,7 +485,7 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImageInt16))
 
     // first half is black, second half is white
     int bufferSize = msg.width() * msg.height() * bpp;
-    std::shared_ptr<uint16_t> buffer(new uint16_t[bufferSize]);
+    std::shared_ptr<uint16_t[]> buffer(new uint16_t[bufferSize]);
     for (unsigned int y = 0; y < msg.width(); ++y)
     {
       uint16_t v = 100 * static_cast<int>(y / (msg.height() / 2.0) + 1);

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1014,6 +1014,7 @@ TextureNode::TextureNode(QQuickWindow *_window, RenderSync &_renderSync,
   renderSync(_renderSync),
   window(_window)
 {
+  (void) _camera;
   if (_graphicsAPI == rendering::GraphicsAPI::OPENGL)
   {
     gzdbg << "Creating texture node render interface for OpenGL" << std::endl;


### PR DESCRIPTION
## Summary
Fixes the warnings present in main jobs of he buildfarm.

Reference build: 
https://build.osrfoundation.org/job/gz_gui-ci-main-noble-amd64/5/

There are two warnings being fixed:

1. In MinimalScene plugin, if `GZ_GUI_HAVE_VULKAN` is not defined, the parameter `_camera` of the `TextureNode` constructor is not used. I added a void statement to suppress that warning.

2. In ImageDisplay plugin tests, there are shared_pointers declared with an incompatible new/delete match.
   `std::shared_ptr<unsigned char> buffer(new unsigned char[bufferSize]);`
Given that the shared pointer is not declared as an array, the tests leak memory as they are right now. I added a fix for all of those tests.

cc: @Crola1702 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
