### PR TITLE
Fix color distortion in low light conditions

### DIFF
--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -140,7 +140,8 @@ GLuint EngineToQtInterface::TextureId(gz::rendering::CameraPtr &_camera)
 
     QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
     glFuncs->glBindTexture(GL_TEXTURE_2D, textureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT,
+                    GL_SKIP_DECODE_EXT);
     return textureId;
   }
   else

--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -136,7 +136,12 @@ GLuint EngineToQtInterface::TextureId(gz::rendering::CameraPtr &_camera)
 {
   if (!this->NeedsFallback(_camera))
   {
-    return _camera->RenderTextureGLId();
+    auto textureId = _camera->RenderTextureGLId();
+
+    QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
+    glFuncs->glBindTexture(GL_TEXTURE_2D, textureId);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT, GL_SKIP_DECODE_EXT);
+    return textureId;
   }
   else
   {

--- a/src/plugins/minimal_scene/EngineToQtInterface.cc
+++ b/src/plugins/minimal_scene/EngineToQtInterface.cc
@@ -140,8 +140,8 @@ GLuint EngineToQtInterface::TextureId(gz::rendering::CameraPtr &_camera)
 
     QOpenGLFunctions *glFuncs = this->dataPtr->glContext->functions();
     glFuncs->glBindTexture(GL_TEXTURE_2D, textureId);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT,
-                    GL_SKIP_DECODE_EXT);
+    glFuncs->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SRGB_DECODE_EXT,
+                             GL_SKIP_DECODE_EXT);
     return textureId;
   }
   else

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1545,12 +1545,6 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   }
 
   renderWindow->SetEngineName(cmdRenderEngine);
-  // there is a problem with displaying ogre2 render textures that are in
-  // sRGB format. Workaround for now is to apply gamma correction
-  // manually.
-  // There maybe a better way to solve the problem by making OpenGL calls.
-  if (cmdRenderEngine == std::string("ogre2"))
-    this->PluginItem()->setProperty("gammaCorrect", true);
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalScene.qml
+++ b/src/plugins/minimal_scene/MinimalScene.qml
@@ -26,11 +26,6 @@ Rectangle {
   anchors.fill: parent
 
   /**
-   * True to enable gamma correction
-   */
-  property bool gammaCorrect: false
-
-  /**
    * Get mouse position on 3D widget
    */
   MouseArea {
@@ -54,16 +49,6 @@ Rectangle {
     visible: MinimalScene.loadingError.length == 0
   }
 
-  /*
-   * Gamma correction for sRGB output. Enabled when engine is set to ogre2
-   */
-  GammaAdjust {
-      anchors.fill: renderWindow
-      source: renderWindow
-      gamma: 2.4
-      enabled: gammaCorrect
-      visible: gammaCorrect
-  }
 
   onParentChanged: {
     if (undefined === parent)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This replaces the gamma correction QML  element and instead tells Qt to copy the texture as is without decoding from srgb->rgb. This is an alternative to #629 

Using Renderdoc, I found that no matter what the target render texture is (RGBA8_UNORM_SRGB or RGBA8_UNORM), the back color buffer (what Qt displays on the screen) always converts it to RGB8_UNORM. I also found that there's a parameter that can be set on a texture to tell OpenGL to not do any srgb->linear conversion https://docs.imgtec.com/reference-manuals/open-gl-es-extensions/html/topics/GL_EXT/texture-sRGB-decode.html

This fixes various distortion issues. Here are some examples:

## Banding in specular highlights
**Before**
![image](https://github.com/user-attachments/assets/87e33c5e-36d9-42fc-8365-705dc4c1a715)
**After**
![image](https://github.com/user-attachments/assets/de80a9c6-c2f3-4a95-8af8-75c6921d02ed)


## Color distortion in low light conditions
**Before**
![image](https://github.com/user-attachments/assets/f5fc797d-7604-427c-978c-4db3a4dcedf2)

**After**
![image](https://github.com/user-attachments/assets/facf2c2b-cc9e-4cbc-ab1e-fbd2f0f28af7)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
