### PR TITLE
Expose shadow texture size for directional lighting in SDF

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -762,7 +762,7 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     scene->SetSkyEnabled(true);
   }
 
-  scene->SetShadowTextureSize(this->directionalLightTextureSize);
+  scene->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL, this->directionalLightTextureSize);
 
   auto root = scene->RootVisual();
 
@@ -1323,9 +1323,13 @@ void RenderWindowItem::SetSkyEnabled(const bool &_sky)
   this->dataPtr->renderThread->gzRenderer.skyEnable = _sky;
 }
 
-void RenderWindowItem::SetShadowTextureSize(unsigned int _textureSize)
+/////////////////////////////////////////////////
+void RenderWindowItem::SetShadowTextureSize(rendering::LightType _lightType, unsigned int _textureSize)
 {
-  this->dataPtr->renderThread->gzRenderer.directionalLightTextureSize = _textureSize;
+  if (_lightType == rendering::LightType::LT_DIRECTIONAL)
+  {
+    this->dataPtr->renderThread->gzRenderer.directionalLightTextureSize = _textureSize;
+  }
 }
 
 /////////////////////////////////////////////////
@@ -1493,12 +1497,12 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
           else
           {
             printf("setting texsize now\n");
-            renderWindow->SetShadowTextureSize(texSize);
+            renderWindow->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL, texSize);
           }
         }
         else
         {
-          gzwarn << "Light type [" << lightType << "] is not supported."
+          gzerr << "Light type [" << lightType << "] is not supported."
                   << std::endl;
         }
       }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1491,8 +1491,7 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         if (texSizeStr.fail())
         {
           gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
-                << "' using default directional light texture size"
-                << std::endl;
+                << "' using default texture size" << std::endl;
         }
         else
         {

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -762,7 +762,8 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     scene->SetSkyEnabled(true);
   }
 
-  scene->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL, this->directionalLightTextureSize);
+  scene->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL,
+      this->directionalLightTextureSize);
 
   auto root = scene->RootVisual();
 
@@ -1324,11 +1325,13 @@ void RenderWindowItem::SetSkyEnabled(const bool &_sky)
 }
 
 /////////////////////////////////////////////////
-void RenderWindowItem::SetShadowTextureSize(rendering::LightType _lightType, unsigned int _textureSize)
+void RenderWindowItem::SetShadowTextureSize(rendering::LightType _lightType,
+    unsigned int _textureSize)
 {
   if (_lightType == rendering::LightType::LT_DIRECTIONAL)
   {
-    this->dataPtr->renderThread->gzRenderer.directionalLightTextureSize = _textureSize;
+    this->dataPtr->renderThread->gzRenderer.directionalLightTextureSize =
+        _textureSize;
   }
 }
 
@@ -1491,11 +1494,13 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
           if (texSizeStr.fail())
           {
             gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
-                  << "' using default directional light texture size" << std::endl;
+                  << "' using default directional light texture size"
+                  << std::endl;
           }
           else
           {
-            renderWindow->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL, texSize);
+            renderWindow->SetShadowTextureSize(
+                rendering::LightType::LT_DIRECTIONAL, texSize);
           }
         }
         else

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -765,9 +765,11 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   if (!scene->SetShadowTextureSize(rendering::LightType::DIRECTIONAL,
       this->directionalLightTextureSize))
   {
-    gzerr << "Unable to set <texture_size> to '"
+    gzerr << "Unable to set directional light shadow <texture_size> to '"
           << this->directionalLightTextureSize
-          << "' using default texture size" << std::endl;
+          << "'. Using default texture size of "
+          << scene->ShadowTextureSize(rendering::LightType::DIRECTIONAL)
+          << std::endl;
   }
 
   auto root = scene->RootVisual();
@@ -1498,7 +1500,7 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         texSizeStr >> texSize;
         if (texSizeStr.fail())
         {
-          gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
+          gzerr << "Unable to set shadow <texture_size> to '" << texSizeStr.str()
                 << "' using default texture size" << std::endl;
         }
         else
@@ -1509,14 +1511,14 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
             if (!renderWindow->SetShadowTextureSize(
                 rendering::LightType::DIRECTIONAL, texSize))
             {
-              gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
+              gzerr << "Unable to set shadow <texture_size> to '" << texSizeStr.str()
                     << "' using default texture size" << std::endl;
             }
           }
           else
           {
-            gzerr << "Light type [" << lightType << "] is not supported."
-                  << std::endl;
+            gzerr << "Setting shadow <texture_size> for light type [" 
+                  << lightType << "] is not supported." << std::endl;
           }
         }
       }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -762,8 +762,12 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     scene->SetSkyEnabled(true);
   }
 
-  scene->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL,
-      this->directionalLightTextureSize);
+  if (!scene->SetShadowTextureSize(rendering::LightType::DIRECTIONAL,
+      this->directionalLightTextureSize))
+  {
+    gzerr << "Unable to set <texture_size> to '" << this->directionalLightTextureSize
+          << "' using default texture size" << std::endl;
+  }
 
   auto root = scene->RootVisual();
 
@@ -1325,14 +1329,17 @@ void RenderWindowItem::SetSkyEnabled(const bool &_sky)
 }
 
 /////////////////////////////////////////////////
-void RenderWindowItem::SetShadowTextureSize(rendering::LightType _lightType,
+bool RenderWindowItem::SetShadowTextureSize(rendering::LightType _lightType,
     unsigned int _textureSize)
 {
-  if (_lightType == rendering::LightType::LT_DIRECTIONAL)
+  if (_lightType == rendering::LightType::DIRECTIONAL)
   {
     this->dataPtr->renderThread->gzRenderer.directionalLightTextureSize =
         _textureSize;
+    return true;
   }
+
+  return false;
 }
 
 /////////////////////////////////////////////////
@@ -1498,8 +1505,12 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
           std::string lightType = textureSizeElem->Attribute("light_type");
           if (lightType == "directional")
           {
-            renderWindow->SetShadowTextureSize(
-                rendering::LightType::LT_DIRECTIONAL, texSize);
+            if (!renderWindow->SetShadowTextureSize(
+                rendering::LightType::DIRECTIONAL, texSize))
+            {
+              gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
+                    << "' using default texture size" << std::endl;
+            }
           }
           else
           {

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1488,7 +1488,6 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
           std::stringstream texSizeStr;
           texSizeStr << std::string(textureSizeElem->GetText());
           texSizeStr >> texSize;
-          printf("texSize: %d\n", texSize);
           if (texSizeStr.fail())
           {
             gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
@@ -1496,7 +1495,6 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
           }
           else
           {
-            printf("setting texsize now\n");
             renderWindow->SetShadowTextureSize(rendering::LightType::LT_DIRECTIONAL, texSize);
           }
         }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1500,7 +1500,8 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         texSizeStr >> texSize;
         if (texSizeStr.fail())
         {
-          gzerr << "Unable to set shadow <texture_size> to '" << texSizeStr.str()
+          gzerr << "Unable to set shadow <texture_size> to '"
+                << texSizeStr.str()
                 << "' using default texture size" << std::endl;
         }
         else
@@ -1511,13 +1512,14 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
             if (!renderWindow->SetShadowTextureSize(
                 rendering::LightType::DIRECTIONAL, texSize))
             {
-              gzerr << "Unable to set shadow <texture_size> to '" << texSizeStr.str()
+              gzerr << "Unable to set shadow <texture_size> to '"
+                    << texSizeStr.str()
                     << "' using default texture size" << std::endl;
             }
           }
           else
           {
-            gzerr << "Setting shadow <texture_size> for light type [" 
+            gzerr << "Setting shadow <texture_size> for light type ["
                   << lightType << "] is not supported." << std::endl;
           }
         }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -765,7 +765,8 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   if (!scene->SetShadowTextureSize(rendering::LightType::DIRECTIONAL,
       this->directionalLightTextureSize))
   {
-    gzerr << "Unable to set <texture_size> to '" << this->directionalLightTextureSize
+    gzerr << "Unable to set <texture_size> to '"
+          << this->directionalLightTextureSize
           << "' using default texture size" << std::endl;
   }
 

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -1484,29 +1484,29 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       auto textureSizeElem = elem->FirstChildElement("texture_size");
       if (nullptr != elem && nullptr != textureSizeElem->GetText())
       {
-        std::string lightType = textureSizeElem->Attribute("light_type");
-        if (lightType == "directional")
+        unsigned int texSize;
+        std::stringstream texSizeStr;
+        texSizeStr << std::string(textureSizeElem->GetText());
+        texSizeStr >> texSize;
+        if (texSizeStr.fail())
         {
-          unsigned int texSize;
-          std::stringstream texSizeStr;
-          texSizeStr << std::string(textureSizeElem->GetText());
-          texSizeStr >> texSize;
-          if (texSizeStr.fail())
-          {
-            gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
-                  << "' using default directional light texture size"
-                  << std::endl;
-          }
-          else
+          gzerr << "Unable to set <texture_size> to '" << texSizeStr.str()
+                << "' using default directional light texture size"
+                << std::endl;
+        }
+        else
+        {
+          std::string lightType = textureSizeElem->Attribute("light_type");
+          if (lightType == "directional")
           {
             renderWindow->SetShadowTextureSize(
                 rendering::LightType::LT_DIRECTIONAL, texSize);
           }
-        }
-        else
-        {
-          gzerr << "Light type [" << lightType << "] is not supported."
+          else
+          {
+            gzerr << "Light type [" << lightType << "] is not supported."
                   << std::endl;
+          }
         }
       }
     }

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -762,6 +762,8 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     scene->SetSkyEnabled(true);
   }
 
+  scene->SetTexSize(this->texSize);
+
   auto root = scene->RootVisual();
 
   // Camera
@@ -1321,6 +1323,11 @@ void RenderWindowItem::SetSkyEnabled(const bool &_sky)
   this->dataPtr->renderThread->gzRenderer.skyEnable = _sky;
 }
 
+void RenderWindowItem::SetTexSize(unsigned int _texSize)
+{
+  this->dataPtr->renderThread->gzRenderer.texSize = _texSize;
+}
+
 /////////////////////////////////////////////////
 void RenderWindowItem::SetGraphicsAPI(
     const rendering::GraphicsAPI &_graphicsAPI)
@@ -1462,6 +1469,16 @@ void MinimalScene::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       if (!elem->NoChildren())
         gzwarn << "Child elements of <sky> are not supported yet"
                 << std::endl;
+    }
+
+    elem = _pluginElem->FirstChildElement("tex_size");
+    if (nullptr != elem && nullptr != elem->GetText())
+    {
+      unsigned int texSize;
+      std::stringstream texSizeStr;
+      texSizeStr << std::string(elem->GetText());
+      texSizeStr >> texSize;
+      renderWindow->SetTexSize(texSize);
     }
 
     const std::string backendApiName = gz::gui::renderEngineBackendApiName();

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -371,7 +371,7 @@ namespace gz::gui::plugins
     /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
 
-    /// @brief  \brief Set the shadow texture size for the given light type.
+    /// \brief Set the shadow texture size for the given light type.
     /// @param _lightType Light type that creates the shadow
     /// @param _textureSize Shadow texture size
     public: bool SetShadowTextureSize(rendering::LightType _lightType,

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -374,7 +374,7 @@ namespace gz::gui::plugins
     /// @brief  \brief Set the shadow texture size for the given light type.
     /// @param _lightType Light type that creates the shadow
     /// @param _textureSize Shadow texture size
-    public: void SetShadowTextureSize(rendering::LightType _lightType,
+    public: bool SetShadowTextureSize(rendering::LightType _lightType,
         unsigned int _textureSize);
 
     /// \brief Set the Horizontal FOV of the camera

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -239,6 +239,7 @@ namespace gz::gui::plugins
     /// \brief True if sky is enabled;
     public: bool skyEnable = false;
 
+    /// \brief Shadow texture size for directional light
     public: unsigned int directionalLightTextureSize = 2048u;
 
     /// \brief Horizontal FOV of the camera;
@@ -372,8 +373,8 @@ namespace gz::gui::plugins
     public: void SetSkyEnabled(const bool &_sky);
 
     /// \brief Set the shadow texture size for the given light type.
-    /// @param _lightType Light type that creates the shadow
-    /// @param _textureSize Shadow texture size
+    /// \param _lightType Light type that creates the shadow
+    /// \param _textureSize Shadow texture size
     public: bool SetShadowTextureSize(rendering::LightType _lightType,
         unsigned int _textureSize);
 

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -28,6 +28,7 @@
 #include <gz/math/Vector2.hh>
 #include <gz/utils/ImplPtr.hh>
 #include <gz/rendering/GraphicsAPI.hh>
+#include <gz/rendering/Light.hh>
 
 #include "gz/gui/Plugin.hh"
 
@@ -370,7 +371,10 @@ namespace gz::gui::plugins
     /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
 
-    public: void SetShadowTextureSize(unsigned int _textureSize);
+    /// @brief  \brief Set the shadow texture size for the given light type.
+    /// @param _lightType Light type that creates the shadow
+    /// @param _textureSize Shadow texture size 
+    public: void SetShadowTextureSize(rendering::LightType _lightType, unsigned int _textureSize);
 
     /// \brief Set the Horizontal FOV of the camera
     /// \param[in] _fov FOV of the camera in degree

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -238,7 +238,7 @@ namespace gz::gui::plugins
     /// \brief True if sky is enabled;
     public: bool skyEnable = false;
 
-    public: unsigned int texSize = 2048u;
+    public: unsigned int directionalLightTextureSize = 2048u;
 
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
@@ -370,7 +370,7 @@ namespace gz::gui::plugins
     /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
 
-    public: void SetTexSize(unsigned int _texSize);
+    public: void SetShadowTextureSize(unsigned int _textureSize);
 
     /// \brief Set the Horizontal FOV of the camera
     /// \param[in] _fov FOV of the camera in degree

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -373,8 +373,9 @@ namespace gz::gui::plugins
 
     /// @brief  \brief Set the shadow texture size for the given light type.
     /// @param _lightType Light type that creates the shadow
-    /// @param _textureSize Shadow texture size 
-    public: void SetShadowTextureSize(rendering::LightType _lightType, unsigned int _textureSize);
+    /// @param _textureSize Shadow texture size
+    public: void SetShadowTextureSize(rendering::LightType _lightType,
+        unsigned int _textureSize);
 
     /// \brief Set the Horizontal FOV of the camera
     /// \param[in] _fov FOV of the camera in degree

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -238,6 +238,8 @@ namespace gz::gui::plugins
     /// \brief True if sky is enabled;
     public: bool skyEnable = false;
 
+    public: unsigned int texSize = 2048u;
+
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);
 
@@ -367,6 +369,8 @@ namespace gz::gui::plugins
     /// \brief Set if sky is enabled
     /// \param[in] _sky True to enable the sky, false otherwise.
     public: void SetSkyEnabled(const bool &_sky);
+
+    public: void SetTexSize(unsigned int _texSize);
 
     /// \brief Set the Horizontal FOV of the camera
     /// \param[in] _fov FOV of the camera in degree

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -90,6 +90,9 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
       "  <near>0.1</near>"
       "  <far>5000</far>"
       "</camera_clip>"
+      "<shadows>"
+      "  <texture_size light_type=\"directional\">8192</texture_size>"
+      "</shadows>"
       "<horizontal_fov>60</horizontal_fov>"
       "<view_controller>ortho</view_controller>"
     "</plugin>";
@@ -130,6 +133,11 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 1.57), camera->WorldPose());
   EXPECT_DOUBLE_EQ(0.1, camera->NearClipPlane());
   EXPECT_DOUBLE_EQ(5000.0, camera->FarClipPlane());
+
+  EXPECT_EQ(8192u, scene->ShadowTextureSize(
+      rendering::LightType::LT_DIRECTIONAL));
+  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::LT_SPOT));
+  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::LT_POINT));
 
   EXPECT_NEAR(60, camera->HFOV().Degree(), 1e-4);
 

--- a/test/integration/minimal_scene.cc
+++ b/test/integration/minimal_scene.cc
@@ -135,9 +135,9 @@ TEST(MinimalSceneTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Config))
   EXPECT_DOUBLE_EQ(5000.0, camera->FarClipPlane());
 
   EXPECT_EQ(8192u, scene->ShadowTextureSize(
-      rendering::LightType::LT_DIRECTIONAL));
-  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::LT_SPOT));
-  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::LT_POINT));
+      rendering::LightType::DIRECTIONAL));
+  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::SPOT));
+  EXPECT_EQ(2048u, scene->ShadowTextureSize(rendering::LightType::POINT));
 
   EXPECT_NEAR(60, camera->HFOV().Degree(), 1e-4);
 


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-rendering/pull/1034, view that for details.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
