### PR TITLE
Prepare for 9.0.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake4 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,57 @@
 ## Gazebo GUI 9
 
-### Gazebo GUI 9.0.0 (2023-XX-XX)
+### Gazebo GUI 9.0.0 (2024-09-XX)
+
+1. **Baseline:** this includes all changes from 8.3.0 and earlier.
+
+1. Update badges for ionic gz-gui9
+    * [Pull request #636](https://github.com/gazebosim/gz-gui/pull/636)
+
+1. Expose shadow texture size for directional lighting in SDF
+    * [Pull request #633](https://github.com/gazebosim/gz-gui/pull/633)
+
+1. Enable ubuntu noble github actions, require 3.22.1
+    * [Pull request #634](https://github.com/gazebosim/gz-gui/pull/634)
+
+1. Fix color distortion in low light conditions
+    * [Pull request #630](https://github.com/gazebosim/gz-gui/pull/630)
+
+1. Added dark mode for drawer and menu buttons
+    * [Pull request #626](https://github.com/gazebosim/gz-gui/pull/626)
+
+1. Adding cone primitives.
+    * [Pull request #621](https://github.com/gazebosim/gz-gui/pull/621)
+
+1. Fix compiler warnings
+    * [Pull request #623](https://github.com/gazebosim/gz-gui/pull/623)
+
+1. Define GZ_GUI_VERSION_NAMESPACE in config.hh
+    * [Pull request #611](https://github.com/gazebosim/gz-gui/pull/611)
+
+1. Use >= for Qt PKGCONFIG_VER_COMPARISON
+    * [Pull request #610](https://github.com/gazebosim/gz-gui/pull/610)
+
+1. Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.
+    * [Pull request #605](https://github.com/gazebosim/gz-gui/pull/605)
+
+1. Enable HIDE_SYMBOLS_BY_DEFAULT + patches (take II)
+    * [Pull request #601](https://github.com/gazebosim/gz-gui/pull/601)
+
+1. Qt6 migrations that are compatible with Qt5
+    * [Pull request #598](https://github.com/gazebosim/gz-gui/pull/598)
+
+1. Added motion duration to the 'move to pose' service of the camera tracking plugin.
+    * [Pull request #594](https://github.com/gazebosim/gz-gui/pull/594)
+
+1. First pass at level1 clazy checks for qt
+    * [Pull request #584](https://github.com/gazebosim/gz-gui/pull/584)
+
+1. Use gz::utils::ImplPtr as much as possible
+    * [Pull request #583](https://github.com/gazebosim/gz-gui/pull/583)
+
+1. Bumps in Ionic: gz-gui9
+    * [Pull request #587](https://github.com/gazebosim/gz-gui/pull/587)
+    * [Pull request #588](https://github.com/gazebosim/gz-gui/pull/588)
 
 ## Gazebo GUI 8
 
@@ -399,7 +450,7 @@
     * [Pull request #343](https://github.com/gazebosim/gz-gui/pull/343)
     * [Pull request #327](https://github.com/gazebosim/gz-gui/pull/327)
     * [Pull request #313](https://github.com/gazebosim/gz-gui/pull/313)
-    * [Pull request #301](https://github.com/gazebosim/gz-gui/pull/301)    
+    * [Pull request #301](https://github.com/gazebosim/gz-gui/pull/301)
 
 1. Added macOS source code installation
     * [Pull request #297](https://github.com/gazebosim/gz-gui/pull/297)


### PR DESCRIPTION


# 🎈 Release

Preparation for 9.0.0 release.

Comparison to 8.3.0: https://github.com/gazebosim/gz-gui/compare/gz-gui8_8.30...prep9.0.0pre1


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
