### PR TITLE
Only set shadow texture size if configured by the user in the SDFormat file

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -762,11 +762,12 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     scene->SetSkyEnabled(true);
   }
 
-  if (!scene->SetShadowTextureSize(rendering::LightType::DIRECTIONAL,
-      this->directionalLightTextureSize))
+  if (this->directionalLightTextureSize.has_value() &&
+    !scene->SetShadowTextureSize(rendering::LightType::DIRECTIONAL,
+      *this->directionalLightTextureSize))
   {
     gzerr << "Unable to set directional light shadow <texture_size> to '"
-          << this->directionalLightTextureSize
+          << *this->directionalLightTextureSize
           << "'. Using default texture size of "
           << scene->ShadowTextureSize(rendering::LightType::DIRECTIONAL)
           << std::endl;

--- a/src/plugins/minimal_scene/MinimalScene.hh
+++ b/src/plugins/minimal_scene/MinimalScene.hh
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <memory>
+#include <optional>
 
 #include <gz/common/KeyEvent.hh>
 #include <gz/common/MouseEvent.hh>
@@ -240,7 +241,7 @@ namespace gz::gui::plugins
     public: bool skyEnable = false;
 
     /// \brief Shadow texture size for directional light
-    public: unsigned int directionalLightTextureSize = 2048u;
+    public: std::optional<unsigned int> directionalLightTextureSize;
 
     /// \brief Horizontal FOV of the camera;
     public: math::Angle cameraHFOV = math::Angle(M_PI * 0.5);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1604

## Summary
The default shadow texture size being set even in Ogre1, for which we don't have that capability implemented. This changes the texture size to an optional so that only if the shadow texture parameter is specified in the SDFormat file will it try to call `SetShadowTextureSize`.

## Test It
https://github.com/gazebosim/gz-sim/pull/2586 has changed the `dem_monterey_bay.sdf` file to use `ogre2`, so you'll need to change it back to `ogre` to test this. With this PR, it should not have an error message.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.