### PR TITLE
Prepare for 3.12.1 Release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,20 @@
 ## Gazebo GUI 3
 
+### Gazebo GUI 3.12.1 (2024-12-12)
+
+1. Find any major version of Protobuf
+    * [Pull request #544](https://github.com/gazebosim/gz-gui/pull/544)
+
+1. Infrastructure
+    * [Pull request #526](https://github.com/gazebosim/gz-gui/pull/526)
+    * [Pull request #597](https://github.com/gazebosim/gz-gui/pull/597)
+
+1. Rename COPYING to LICENSE
+    * [Pull request #525](https://github.com/gazebosim/gz-gui/pull/525)
+
+1. Update maintainer email
+    * [Pull request #521](https://github.com/gazebosim/gz-gui/pull/521)
+
 ### Gazebo GUI 3.12.0 (2022-11-30)
 
 1. Add degree as an optional unit for rotation in GzPose.


### PR DESCRIPTION
# 🎈 Release

Part of https://github.com/gazebo-tooling/release-tools/issues/1223

This will be the **final** released of ign-gui3 as Citadel has reached EOL.

Preparation for 3.12.1 release.

Comparison to 3.12.0: https://github.com/gazebosim/gz-gui/compare/ignition-gui3_3.12.0...ign-gui3


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.