### PR TITLE
Prepare for 3.12.1 Release (Redo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gui3 VERSION 3.12.0)
+project(ignition-gui3 VERSION 3.12.1)
 
 #============================================================================
 # Find ignition-cmake


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.12.1 release.

#649 did not update the version in the CMakeLists file

Comparison to 3.12.0: https://github.com/gazebosim/gz-gui/compare/ignition-gui3_3.12.0...ign-gui3


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.