### PR TITLE
Use SplitView from QtQuick.Controls 2 for GzSplit

### DIFF
--- a/include/gz/gui/qml/GzCard.qml
+++ b/include/gz/gui/qml/GzCard.qml
@@ -114,7 +114,7 @@ Pane {
   /**
    * Minimum height of the card pane
    */
-  property int cardMinimumHeight: content.minimumHeight;
+  property double cardMinimumHeight: content.minimumHeight;
 
 
   property double cardMaximumHeight: Infinity

--- a/include/gz/gui/qml/GzCard.qml
+++ b/include/gz/gui/qml/GzCard.qml
@@ -114,7 +114,7 @@ Pane {
   /**
    * Minimum height of the card pane
    */
-  property double cardMinimumHeight: content.minimumHeight;
+  property int cardMinimumHeight: content.minimumHeight;
 
 
   property double cardMaximumHeight: Infinity

--- a/include/gz/gui/qml/GzHelpers.qml
+++ b/include/gz/gui/qml/GzHelpers.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.9
 
 Item {
+  visible: false
   /**
    * Helper function to get an item's ancestor by name.
    * @param _item Item whose parent we're looking for.
@@ -56,4 +57,16 @@ Item {
 
     return 4
   }
+  function dump(object, indent, depth) {
+    console.log(indent + object)
+    if (depth > 0) {
+      for (const i in object.children)
+        dump(object.children[i], indent + "    ", depth - 1)
+    }
+  }
+
+  function clamp(val, min, max) {
+    return Math.max(min, Math.min(val, max))
+  }
+
 }

--- a/include/gz/gui/qml/GzSplit.qml
+++ b/include/gz/gui/qml/GzSplit.qml
@@ -122,7 +122,7 @@ Item
         anchors.fill: parent
         anchors.rightMargin: scrollView.scrollBarWidth
 
-        readonly property double handleHeight: handle.createObject().implicitHeight
+        readonly property double handleHeight: 6 //handle.createObject().implicitHeight
 
         // Establish a binding for contentHeight on the children's minimumHeight and maximumHeight,
         // but not their height as doing so causes a subtle binding loop.

--- a/include/gz/gui/qml/GzSplit.qml
+++ b/include/gz/gui/qml/GzSplit.qml
@@ -122,7 +122,9 @@ Item
         anchors.fill: parent
         anchors.rightMargin: scrollView.scrollBarWidth
 
-        readonly property double handleHeight: 6 //handle.createObject().implicitHeight
+        // Temporarily create the handle object to get its height. Use `helpers` as the parent
+        // to avoid warnings.
+        readonly property double handleHeight: handle.createObject(helpers).implicitHeight
 
         // Establish a binding for contentHeight on the children's minimumHeight and maximumHeight,
         // but not their height as doing so causes a subtle binding loop.

--- a/include/gz/gui/qml/GzSplit.qml
+++ b/include/gz/gui/qml/GzSplit.qml
@@ -13,45 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
-import QtQuick 2.9
-import QtQuick.Controls 1.1
-import QtQuick.Controls 2.2
+ */
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts 1.3
 
 /**
- * Main split view, which provides functions to add and remove child items
- * and splits.
+ * Main item, which provides functions to add and remove child items.
  */
-SplitView {
+Item
+{
+  id: root
 
-  id: background
-  objectName: "background"
-
-  GzHelpers {
-    id: helpers
-  }
-
-  /**
-   * Dictionary of all split items contained in this split.
-   */
-  property variant childItems: new Object()
-
-  /**
-   * Dictionary of all splits nested into this split.
-   */
-  property variant childSplits: new Object()
-
-  /**
-   * Callback when the height changed.
-   */
-  onHeightChanged:
+  Item
   {
-    background.recalculateMinimumSizes();
+    id: floatingArea;
+    visible: children.length > 0
+    anchors.fill: parent
+    z: 1
+
+    function dockingArea() {
+      return background
+    }
+
+    function removeFromParent()
+    {
+      removeItem(this);
+    }
   }
 
-  Rectangle {
+  Rectangle
+  {
     id: startLabel;
     visible: MainWindow.pluginCount === 0
     anchors.fill: parent
@@ -67,319 +60,167 @@ SplitView {
   }
 
   /**
-   * Recalculate minimum size for all splits
+   * Calculate the minimum width needed for each split by taking the max
+   * of the minimum widths of all the cards in a split
    */
-  function recalculateMinimumSizes()
-  {
-    for (var name in childSplits)
-    {
-      childSplits[name].split.recalculateMinimumSize()
-    }
-  }
-
-  /**
-   * This function will appropriately create new items and splits according to
-   * the current main window state.
-   * @return Name of added item, which is prefixed by `split_item_`. The item
-   * is empty, so the caller can add content to it.
-   * TODO(louise) Accept configuration, so we know how to add the item
-   * (orientation, size)
-   * TODO(louise) Make this more flexible so we can have different window
-   * arrangements
-   */
-  function addSplitItem()
-  {
-    var itemName = "";
-
-    // First section goes in the top level SplitView, which is Qt.Horizontal
-    // 2 for helpers and startLabel
-    if (background.__items.length <= 2)
-    {
-      itemName = _addNewItem(background);
-    }
-    // The next one adds a Qt.Vertical split to the right
-    else if (Object.keys(childSplits).length === 0)
-    {
-      // Add the split
-      var split = _addNewSplit(background);
-      split.split.orientation = Qt.Vertical;
-
-      // Then add a new item to the newly created split
-      itemName = _addNewItem(split);
-    }
-    // All subsequent ones are added to the vertical child split on the right
-    else
-    {
-      // Get desired split (for now we have only one)
-      var firstChildSplit = childSplits[Object.keys(childSplits)[0]];
-
-      // Then add a new item to it
-      itemName = _addNewItem(firstChildSplit);
-    }
-
-    return itemName
-  }
-
-  /**
-   * Remove a split item according to its name.
-   * @param Name of item, which must start with `split_item_`.
-   */
-  function removeSplitItem(_name)
-  {
-    // Remove from split
-    _removeFromSplits(childItems[_name]);
-
-    // Remove from dictionary and destroy
-    delete childItems[_name];
-  }
-
-  /**
-   * Create a new item and add it to a split.
-   * Meant for internal use.
-   * @param _split Split to add item to
-   * @return Unique name of newly created item; starts with `split_item_`.
-   */
-  function _addNewItem(_split)
-  {
-    // Create item
-    var item = newItem.createObject(_split);
-
-    // Unique name
-    var itemName = "split_item_" + Math.floor(Math.random() * 100000)
-    item.objectName = itemName;
-
-    // Add to dictionary
-    childItems[itemName] = item;
-
-    // Add to parent
-    if (_split === background)
-    {
-      _split.addItem(item);
-    }
-    else
-    {
-      _split.split.addItem(item);
-
-      // Make sure that changes to the item's minimum size get propagated to the
-      // split.
-      item.minimumSizeChanged.connect(function(){
-        _split.split.recalculateMinimumSize()
-      });
-    }
-
-    return itemName;
-  }
-
-  /**
-   * Create a new split and add it to the parent split.
-   * Meant for internal use.
-   * @param _parentSplit Parent split.
-   * @returns Newly created split.
-   */
-  function _addNewSplit(_parentSplit)
-  {
-    // Create split
-    var splitWrapper = newSplit.createObject(_parentSplit);
-
-    // Unique name
-    var splitName = "split_" + Math.floor(Math.random() * 100000)
-    splitWrapper.objectName = splitName;
-
-    // Add to dictionary
-    childSplits[splitName] = splitWrapper;
-
-    // Add to parent
-    _parentSplit.addItem(splitWrapper);
-
-    return splitWrapper;
-  }
-
-  /**
-   * Removes item from its parent split and removes the split if that was
-   * the last item in it.
-   * Meant for internal use.
-   * @param _item Item who is supposed to be removed from its parent split.
-   */
-  function _removeFromSplits(_item)
-  {
-    if (_item === undefined)
-      return;
-
-    var split = helpers.ancestorByName(_item, /^split_|^background$/);
-
-    if (!split)
-    {
-      console.error("Failed to find parent split for [", _item.objectName, "]")
-      return;
-    }
-
-    if (split === background)
-    {
-      split.removeItem(_item);
-    }
-    else
-    {
-      split.split.removeItem(_item);
-
-      // If split is now empty, remove split
-      if (split.split.__items.length === 0)
-      {
-        // Remove from array
-        delete childSplits[split.objectName]
-
-        // Remove from parent split
-        _removeFromSplits(split);
-
-        // Destroy
-        split.destroy();
-      }
-      else
-      {
-        split.split.recalculateMinimumSize();
+  function calcMinimumWidth(contentChildren) {
+    var maxMinWidth = 0;
+    for (var key in contentChildren) {
+      var child = contentChildren[key];
+      if (child.children.length > 0 && child.children[0].hasOwnProperty("cardMinimumWidth")) {
+        maxMinWidth = Math.max(maxMinWidth, child.children[0].cardMinimumWidth);
       }
     }
+
+    return maxMinWidth;
   }
 
   /**
-   * Component for creating new items
+   * Main SplitView that holds the main view port and the side panel.
    */
-  Component {
-    id: newItem
-
-    Rectangle {
-      Layout.minimumWidth: 100
-      Layout.minimumHeight: 100
-      Layout.fillHeight: false
-      Layout.fillWidth: true
-      color: Material.background
-
-      /**
-       * Notifies that its minimum size has changed.
-       */
-      signal minimumSizeChanged();
-
-      /**
-       * Callback when the layout's minimum width changes.
-       */
-      Layout.onMinimumWidthChanged: {
-        minimumSizeChanged();
-      }
-
-      /**
-       * Callback when the layout's minimum height changes.
-       */
-      Layout.onMinimumHeightChanged: {
-        minimumSizeChanged();
-      }
-
-      /**
-       * Callback when the children array has been changed.
-       */
-      onChildrenChanged: {
-        // Propagate child's minimum size changes to the item.
-        newItem.Layout.minimumWidth = Qt.binding(function() {
-          if (children.length === 0 || children[0] === undefined)
-            return 0;
-          return children[0].Layout.minimumWidth
-        });
-        newItem.Layout.minimumHeight = Qt.binding(function() {
-          if (children.length === 0 || children[0] === undefined)
-            return 0;
-          return children[0].Layout.minimumHeight
-        });
-      }
-    }
-  }
-
-  /**
-   * Component for creating new splits
-   */
-  Component {
-    id: newSplit
+  SplitView
+  {
+    id: background
+    objectName: "background"
+    clip: true
+    anchors.fill: parent
 
     /**
-     * For some reason, the scroll view doesn't work well within a split view,
-     * so we wrap it in a rectangle.
-    */
-    Rectangle {
-      id: splitWrapper
-      color: "transparent"
+     * Main view port
+     * This is intended to only contain one card, so it doesn't need to be a SplitView object,
+     * but keeping the parent type the same between the mainView and the sidePanel makes
+     * the code cleaner.
+     */
+    SplitView {
+      id: mainView
+      clip: true
+      orientation: Qt.Vertical
+      visible: count > 0
+      SplitView.fillWidth : true
+      SplitView.fillHeight : true
+      SplitView.minimumWidth: root.calcMinimumWidth(mainView.contentChildren)
+    }
 
-      /**
-       * Expose the split view.
-       */
-      property var split: split
-
-      /**
-       * Offset of 17 to accommodate for ScrollView scroll bar
-       */
+    ScrollView {
+      id: scrollView
+      clip: true
+      visible: sidePanel.count > 0
       property var scrollBarWidth: 17
 
-      Layout.minimumWidth: split.Layout.minimumWidth + scrollBarWidth
-      Layout.minimumHeight: split.Layout.minimumHeight
+      contentHeight: Math.max(sidePanel.contentHeight, parent.height)
+      contentWidth: availableWidth
 
-      ScrollView {
-        contentHeight: split.height
-        contentWidth: split.width + scrollBarWidth
+      SplitView.minimumWidth: root.calcMinimumWidth(sidePanel.contentChildren) + scrollBarWidth
 
-        ScrollBar.vertical.policy: ScrollBar.AlwaysOn
+      ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
-        // TODO(louise) This only works for a very specific split
-        height: window.height - window.header.height
+      SplitView {
+        id: sidePanel
+        orientation: Qt.Vertical
+        visible: count > 0
+        clip: true
+        anchors.fill: parent
+        anchors.rightMargin: scrollView.scrollBarWidth
 
-        SplitView {
-          id: split
-          width: splitWrapper.width - scrollBarWidth
-          height: Math.max(childItems[Object.keys(childItems)[0]].height,
-                      split.Layout.minimumHeight)
+        readonly property double handleHeight: handle.createObject().implicitHeight
 
-          /**
-           * Iterate over all current child items and update the split's minimum
-           * width accordingly.
-           */
-          function recalculateMinimumSize()
+        // Establish a binding for contentHeight on the children's minimumHeight and maximumHeight,
+        // but not their height as doing so causes a subtle binding loop.
+        onContentChildrenChanged: {
+          for (var i in contentChildren)
           {
-            // TODO(louise): generalize to support horizontal splits
-            if (orientation === Qt.Horizontal)
-            {
-              return;
-            }
-
-            // Sync minimum sizes
-            var heightSum = 0;
-            var minHeightSum = 0;
-            for (var i = 0; i < __items.length; i++)
-            {
-              var child = __items[i];
-
-              // Minimum width matches the largest minimum width among children
-              if (child.Layout.minimumWidth > Layout.minimumWidth)
-              {
-                Layout.minimumWidth = child.Layout.minimumWidth;
-              }
-              heightSum += child.height;
-
-              var collapsed = child.Layout.maximumHeight == 50
-              minHeightSum += collapsed ? child.height : child.Layout.minimumHeight
-            }
-
-            // Minimum height to show all children
-            Layout.minimumHeight = minHeightSum;
-            split.height = Math.max(minHeightSum, background.height);
-
-            // Squish all children if there's no slack
-            if (heightSum > background.height)
-            {
-              for (var i = 0; i < __items.length; i++)
-              {
-                var child = __items[i];
-                child.height = child.Layout.minimumHeight;
-              }
-            }
+            var child = contentChildren[i]
+            child.SplitView.onMinimumHeightChanged.connect(calcContentHeight)
+            child.SplitView.onMaximumHeightChanged.connect(calcContentHeight)
           }
+        }
+
+        function calcContentHeight() {
+          var height = 0
+          for (var i in contentChildren)
+          {
+            var child = contentChildren[i]
+            height += helpers.clamp(child.height, child.SplitView.minimumHeight, child.SplitView.maximumHeight)
+          }
+
+          // Account for the height of the handle that's placed between each draggable
+          // item in a SplitView
+          if (count > 0)
+          {
+            height += (count - 1) * handleHeight
+          }
+
+          contentHeight = height
+        }
+      }
+    }
+
+    GzHelpers {
+      id: helpers
+      visible: false
+    }
+
+
+    /**
+     * This adds the container split item and places the card init. This is called from Application.cc
+     */
+    function addCard(card) {
+      var splitItem = _addSplitItem()
+      card.parent = splitItem
+    }
+
+    function _addSplitItem() {
+      if (mainView.count == 0) {
+        return _addNewItem(mainView);
+      } else {
+        return _addNewItem(sidePanel);
+      }
+    }
+
+    function _addNewItem(_split) {
+      // Create item
+      var item = newItem.createObject(_split);
+
+      // Unique name
+      var itemName = "split_item_" + Math.floor(Math.random() * 100000)
+      item.objectName = itemName;
+
+      // Add to parent
+      _split.addItem(item);
+      return item;
+    }
+
+    Component {
+      id: newItem
+      Item {
+        id: cardContainer
+        clip: true
+        SplitView.minimumWidth: children.length > 0 ? children[0].cardMinimumWidth: 0
+        SplitView.minimumHeight: children.length > 0 ? children[0].cardMinimumHeight: 0
+        SplitView.maximumHeight: children.length > 0 ? children[0].cardMaximumHeight: 0
+
+        implicitWidth: children.length > 0 ? children[0].implicitWidth: 0
+        implicitHeight: children.length > 0 ? children[0].implicitHeight: 0
+
+        function dockingArea() {
+          return background
+        }
+
+        /**
+         * This is called from GzCard to put the card in the floating state.
+         * This removes the card from the parent (cardContainer) and places it
+         * in the floatingArea object
+         */
+        function floatCard(card) {
+          removeFromParent();
+          card.parent = floatingArea
+        }
+
+        function removeFromParent()
+        {
+          SplitView.view.removeItem(this);
         }
       }
     }
   }
 }
-

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -298,17 +298,10 @@ bool Application::RemovePlugin(const std::string &_pluginName)
   if (nullptr == cardItem)
     return false;
 
+  QMetaObject::invokeMethod(cardItem, "removeFromParent");
+
   // Remove on QML
   cardItem->deleteLater();
-
-  // Remove split on QML
-  auto bgItem = this->dataPtr->mainWin->QuickWindow()
-      ->findChild<QQuickItem *>("background");
-  if (bgItem && cardItem->parentItem())
-  {
-    QMetaObject::invokeMethod(bgItem, "removeSplitItem",
-        Q_ARG(QVariant, cardItem->parentItem()->objectName()));
-  }
 
   // Unload shared library
   this->RemovePlugin(plugin);
@@ -737,22 +730,12 @@ bool Application::AddPluginsToWindow()
     if (!cardItem)
       continue;
 
-    // Add split item
-    QVariant splitName;
-    QMetaObject::invokeMethod(bgItem, "addSplitItem",
-        Q_RETURN_ARG(QVariant, splitName));
-
-    auto *splitItem = bgItem->findChild<QQuickItem *>(
-        splitName.toString());
-    if (!splitItem)
-    {
-      gzerr << "Internal error: failed to create split ["
-             << splitName.toString().toStdString() << "]" << std::endl;
-      return false;
-    }
+    // Add card to GzSplit
+    QMetaObject::invokeMethod(bgItem, "addCard",
+        Q_ARG(QVariant, QVariant::fromValue(cardItem)));
 
     // Add card to main window
-    cardItem->setParentItem(splitItem);
+    // gzdbg << "Adding to:" << splitItem.toString().toStdString() << std::endl;
     cardItem->setParent(this->dataPtr->engine);
     plugin->setParent(this->dataPtr->mainWin);
 

--- a/src/Application.cc
+++ b/src/Application.cc
@@ -735,7 +735,6 @@ bool Application::AddPluginsToWindow()
         Q_ARG(QVariant, QVariant::fromValue(cardItem)));
 
     // Add card to main window
-    // gzdbg << "Adding to:" << splitItem.toString().toStdString() << std::endl;
     cardItem->setParent(this->dataPtr->engine);
     plugin->setParent(this->dataPtr->mainWin);
 

--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -742,8 +742,8 @@ TEST(MainWindowTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ApplyConfig))
     WindowConfig c;
 //    c.posX = 1000;
 //    c.posY = 2000;
-    c.width = 100;
-    c.height = 200;
+    c.width = 300;
+    c.height = 400;
     c.materialTheme = "Dark";
     c.materialPrimary = "#ff0000";
     c.materialAccent = "Indigo";
@@ -765,8 +765,8 @@ TEST(MainWindowTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ApplyConfig))
 //    EXPECT_NE(c.posX, 1000);
 //    EXPECT_NE(c.posY, 2000);
 
-    EXPECT_EQ(c.width, 100);
-    EXPECT_EQ(c.height, 200);
+    EXPECT_EQ(c.width, 300);
+    EXPECT_EQ(c.height, 400);
     EXPECT_EQ(c.materialTheme, "Dark");
     EXPECT_EQ(c.materialPrimary, "#ff0000");
     // Always save hex

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -427,7 +427,7 @@ QQuickItem *Plugin::CardItem() const
   if (!cardItem)
   {
     gzerr << "Internal error: Failed to instantiate QML file [" << qmlFile
-           << "]" << std::endl;
+           << "]\n" << cardComp.errorString().toStdString() << std::endl;
     return nullptr;
   }
 

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -52,7 +52,11 @@ const std::unordered_set<std::string> kAnchorLineSet{
 const std::unordered_set<std::string> kIgnoredProps{
     "objectName",
     "pluginName",
-    "anchored"};
+    "anchored",
+    "floating",
+    "cardMinimumWidth",
+    "cardMinimumHeight",
+    "cardMaximumHeight"};
 }  // namespace
 
 namespace gz::gui

--- a/src/Plugin_TEST.cc
+++ b/src/Plugin_TEST.cc
@@ -273,15 +273,11 @@ TEST(PluginTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ConfigStrInputNoPlugin))
   std::unordered_map<std::string, std::string> pluginTypes;
   pluginProps["showTitleBar"] = "true";
   pluginProps["resizable"] = "true";
-  pluginProps["cardMinimumWidth"] = "290";
-  pluginProps["cardMinimumHeight"] = "110";
   pluginProps["z"] = "0";
   pluginProps["state"] = "docked";
 
   pluginTypes["showTitleBar"] = "bool";
   pluginTypes["resizable"] = "bool";
-  pluginTypes["cardMinimumWidth"] = "int";
-  pluginTypes["cardMinimumHeight"] = "int";
   pluginTypes["z"] = "double";
   pluginTypes["state"] = "string";
 


### PR DESCRIPTION
# 🎉 New feature

Toward #586 

## Summary
The SplitView from QtQuick.Controls 1 has been deprecated for a while and has been removed from Qt6. This change is a stepping stone for migrating to Qt6.

The new SplitView is significantly different from the previous one and so major changes had to be made. The original GzSplit component was also designed with more capabilities in mind for the future, which complicated the code. This has been simplified:

* Instead of determining whether to add a new split for each card added, two splits are hard coded: (1) the main view port (2) the side panel. For every new card added, the code simply checks adds the card to the main view port if its empty. Otherwise, it puts it in the side panel.

* Animations have been removed. It was difficult to get consistent behavior with different split sizes.

* Card items are returned instead of their names when calling `addCard`. This simplifies the code that searches for items by name

* Logic to detect if cards have been collapsed manually by resizing the card has been removed. It's not clear if it is even possible to do this with any of the cards/plugins in Gazebo since the `minimumHeight` constraint would prevent resizing the cards that small.

**New SplitView**
![image](https://github.com/user-attachments/assets/0740c1ef-40f3-4f5f-9817-421d3aa2f3f6)


**Old SplitView**
![image](https://github.com/user-attachments/assets/8d9f1557-545c-499c-b616-5a8f5f2c2872)



## Test it

- `gz gui -c examples/config/layout.config`
- `gz sim camera_sensor.sdf`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
