### PR TITLE
Fix miscellaneous issues and warnings

### DIFF
--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -21,11 +21,8 @@
 
 #include <iostream>
 #include <limits>
-#include <qchar.h>
 #include <string>
 #include <vector>
-
-#include <QUuid>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Image.hh>
@@ -63,19 +60,20 @@ class ImageDisplay::Implementation
 ImageDisplay::ImageDisplay()
   : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
-  this->dataPtr->providerName =
-      QUuid::createUuid().toString(QUuid::WithoutBraces) + "_imagedisplay";
-
   this->dataPtr->provider = new ImageProvider();
-
-  App()->Engine()->addImageProvider(this->dataPtr->providerName,
-                                    this->dataPtr->provider);
 }
 
 /////////////////////////////////////////////////
 ImageDisplay::~ImageDisplay()
 {
   App()->Engine()->removeImageProvider(this->ImageProviderName());
+}
+
+void ImageDisplay::RegisterImageProvider(const QString &_uniqueName)
+{
+  this->dataPtr->providerName = _uniqueName;
+  App()->Engine()->addImageProvider(_uniqueName,
+                                    this->dataPtr->provider);
 }
 
 QString ImageDisplay::ImageProviderName() {
@@ -240,7 +238,6 @@ void ImageDisplay::OnTopic(const QString _topic)
 /////////////////////////////////////////////////
 void ImageDisplay::OnRefresh()
 {
-  gzwarn << "OnRefresh\n";
   // Clear
   this->dataPtr->topicList.clear();
 
@@ -265,7 +262,6 @@ void ImageDisplay::OnRefresh()
   // Select first one
   if (this->dataPtr->topicList.count() > 0)
     this->OnTopic(this->dataPtr->topicList.at(0));
-  gzwarn << "TopicListChanged\n";
   emit this->TopicListChanged();
 }
 

--- a/src/plugins/image_display/ImageDisplay.cc
+++ b/src/plugins/image_display/ImageDisplay.cc
@@ -110,8 +110,7 @@ void ImageDisplay::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   if (!topic.empty())
   {
-    auto qTopic =  QString::fromStdString(topic);
-    this->SetTopicList({qTopic});
+    this->SetTopicList({QString::fromStdString(topic)});
   }
   else
     this->OnRefresh();

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -54,8 +54,7 @@ namespace gz::gui::plugins
       if (!this->img.isNull())
       {
         // Must return a copy
-        QImage copy(this->img);
-        return copy;
+        return this->img;
       }
 
       // Placeholder in case we have no image yet

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -18,8 +18,9 @@
 #ifndef GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_
 #define GZ_GUI_PLUGINS_IMAGEDISPLAY_HH_
 
-#include <algorithm>
-#include <memory>
+#include <QImage>
+#include <QString>
+#include <QStringList>
 #include <QQuickImageProvider>
 
 #include <gz/msgs/image.pb.h>
@@ -114,6 +115,10 @@ namespace gz::gui::plugins
     /// 'gz.msgs.StringMsg'
     /// \param[in] _topicList Message type
     public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
+
+    /// \brief Register the image provider with the given name
+    /// \param[in] _uniqueName Unique name for the provider to be registered
+    public: Q_INVOKABLE void RegisterImageProvider(const QString &_uniqueName);
 
     /// \brief Get the provider name unique to this plugin instance
     public: Q_INVOKABLE QString ImageProviderName();

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -115,6 +115,9 @@ namespace gz::gui::plugins
     /// \param[in] _topicList Message type
     public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
 
+    /// \brief Get the provider name unique to this plugin instance
+    public: Q_INVOKABLE QString ImageProviderName();
+
     /// \brief Notify that topic list has changed
     signals: void TopicListChanged();
 

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -43,7 +43,8 @@ Rectangle {
     if (undefined === parent)
       return;
 
-    uniqueName = ImageDisplay.ImageProviderName();
+    uniqueName = parent.card().objectName + "imagedisplay";
+    ImageDisplay.RegisterImageProvider(uniqueName);
     image.reload();
   }
 

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -43,7 +43,7 @@ Rectangle {
     if (undefined === parent)
       return;
 
-    uniqueName = parent.card().objectName + "imagedisplay";
+    uniqueName = ImageDisplay.ImageProviderName();
     image.reload();
   }
 

--- a/src/plugins/world_stats/WorldStats.qml
+++ b/src/plugins/world_stats/WorldStats.qml
@@ -93,7 +93,7 @@ Rectangle {
         }
         PropertyChanges {
           target: hideButton
-          x: worldStats.width - hideToolButton.width - compactLabel.width - 10
+          x: worldStats.width - hideToolButton.width - compactLabel.implicitWidth - 10
         }
         PropertyChanges {
           target: compactLabel


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
- Binding loop warning in WorldStats
- ImageDisplay warning stating that the image source is invalid
  - This happened because the provider is being initialized in LoadConfig which runs after the QML has been loaded. The solution was to move it to the constructor. However, it depends on a unique name obtained from the QML, which causes a chicken and egg problem. ~To fix this, I've opted for generating a random string based on a UUID number.~ To fix this, the QML now calls a member function of ImageDisplay to register the image provider with a unique name.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
