### PR TITLE
Update GzSpinBox to use the SpinBox QML module from QtQuick.Controls2

### DIFF
--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -65,6 +65,7 @@ Item {
       anchors.fill : parent
       bottomPadding: 0
       topPadding: 0
+      leftPadding: 5
       implicitHeight: 40
       clip: true
 
@@ -93,12 +94,43 @@ Item {
       contentItem: TextInput {
         font.pointSize: 10
         text: spinBox.textFromValue(spinBox.value, spinBox.locale)
-        horizontalAlignment: Qt.AlignHCenter
+        horizontalAlignment: Qt.AlignRight
         verticalAlignment: Qt.AlignVCenter
         readOnly: !spinBox.editable
         validator: spinBox.validator
         inputMethodHints: Qt.ImhFormattedNumbersOnly
         selectByMouse: true
+        clip: true
+      }
+
+       up.indicator: Rectangle {
+        x: spinBox.mirrored ? 0 : parent.width - width
+        implicitWidth: 20
+        implicitHeight: 20
+        color: "transparent"
+
+        Text {
+            text: "⏶"
+            opacity: spinBox.up.pressed ? 1: 0.6
+            anchors.fill: parent
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignBottom
+        }
+      }
+       down.indicator: Rectangle {
+        x: spinBox.mirrored ? 0 : parent.width - width
+        y: 20
+        implicitWidth: 20
+        implicitHeight: 20
+        color: "transparent"
+
+        Text {
+            text: "⏷"
+            opacity: spinBox.down.pressed ? 1: 0.6
+            anchors.fill: parent
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignTop
+        }
       }
 
       validator: DoubleValidator {
@@ -117,9 +149,9 @@ Item {
       }
 
       background: Rectangle {
-        implicitWidth: 70
+        implicitWidth: 40
         implicitHeight: parent.implicitHeight
         border.color: "gray"
       }
+    }
   }
-}

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -14,9 +14,9 @@
  * limitations under the License.
  *
 */
-import QtQml 2.15
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQml 2.15
 
 
 Item {
@@ -28,7 +28,6 @@ Item {
   property real stepSize: 1.0
   property int decimals: 0
 
-  implicitWidth: spinBox.implicitWidth
   implicitHeight: spinBox.implicitHeight
 
   readonly property int kMaxInt: Math.pow(2, 31) - 1
@@ -57,6 +56,7 @@ Item {
     property: 'value'
     value: intToDecimal(spinBox.value)
     when: false
+    restoreMode: Binding.RestoreBinding
   }
 
   SpinBox {


### PR DESCRIPTION
Toward #586

## Summary
The SpinBox module from QtQuick.Controls1 has been deprecated in Qt5 and removed in Qt6. The new SpinBox has a different API and does not directly support floating point values. The workaround in this PR is to store the floating point numbers in a fixed-point representation.

The implementation was inspired by the example in https://doc.qt.io/qt-5/qml-qtquick-controls2-spinbox.html

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.