### PR TITLE
Fix GzSpinBox in cases where the value property has a binding

### DIFF
--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -29,6 +29,7 @@ Item {
   property int decimals: 0
 
   onValueChanged: {
+    console.log("root val", value)
     if (!spinBox.__modifying)
     {
       spinBox.value = decimalToInt(root.value)
@@ -40,6 +41,7 @@ Item {
   readonly property int kMaxInt: Math.pow(2, 31) - 1
 
   function decimalToInt(decimal) {
+    //console.log("dec:", decimal)
     var result = decimal * spinBox.decimalFactor
     if (result >= kMaxInt) {
       return kMaxInt
@@ -51,6 +53,7 @@ Item {
   }
 
   function intToDecimal(intVal) {
+    //console.log("int:", intVal)
     return intVal / spinBox.decimalFactor
   }
 
@@ -81,7 +84,17 @@ Item {
       leftPadding: 5
       implicitHeight: 40
       clip: true
+      value: 0
 
+      // Keep the decimal representation of value so that we
+      // can decimalFactor changes properly. This is different from
+      // root.value because this does not have any bindings and thus
+      // cannot be modified from outside of this SpinBox element.
+      property real __valueAsDecimal: 0.0
+      onValueChanged: {
+        console.log("spinbox val ch:", value)
+        __valueAsDecimal = intToDecimal(value)
+      }
       // Note that this is a different event than ValueChanged. The
       // ValueModified event only fires when the value is edited by user
       // input from the GUI.
@@ -92,9 +105,13 @@ Item {
         // emitting the editingFinished signal so users GzSpinBox can be
         // notified and take the new value of the spinbox, and finally
         // disabling valueUpdater to restore the original bindings.
+        console.log("valUp before when=true", value)
         valueUpdater.when = true
+        console.log("valUp after when=true", value)
         root.editingFinished()
+        console.log("valUp before when=false", value)
         valueUpdater.when = false
+        console.log("valUp after when=false", value)
         __modifying = false
       }
 
@@ -106,6 +123,11 @@ Item {
       anchors.centerIn: parent
 
       readonly property real decimalFactor: Math.pow(10, root.decimals)
+      onDecimalFactorChanged: {
+        console.log("dec chang:", decimals, root.value, spinBox.value)
+        value = decimalToInt(__valueAsDecimal)
+        console.log("after dec chang:", decimals, root.value, spinBox.value)
+      }
 
       contentItem: TextInput {
         font.pointSize: 10

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -29,7 +29,6 @@ Item {
   property int decimals: 0
 
   onValueChanged: {
-    console.log("root val", value)
     if (!spinBox.__modifying)
     {
       spinBox.value = decimalToInt(root.value)
@@ -41,7 +40,6 @@ Item {
   readonly property int kMaxInt: Math.pow(2, 31) - 1
 
   function decimalToInt(decimal) {
-    //console.log("dec:", decimal)
     var result = decimal * spinBox.decimalFactor
     if (result >= kMaxInt) {
       return kMaxInt
@@ -53,7 +51,6 @@ Item {
   }
 
   function intToDecimal(intVal) {
-    //console.log("int:", intVal)
     return intVal / spinBox.decimalFactor
   }
 
@@ -92,7 +89,6 @@ Item {
       // cannot be modified from outside of this SpinBox element.
       property real __valueAsDecimal: 0.0
       onValueChanged: {
-        console.log("spinbox val ch:", value)
         __valueAsDecimal = intToDecimal(value)
       }
       // Note that this is a different event than ValueChanged. The
@@ -105,13 +101,9 @@ Item {
         // emitting the editingFinished signal so users GzSpinBox can be
         // notified and take the new value of the spinbox, and finally
         // disabling valueUpdater to restore the original bindings.
-        console.log("valUp before when=true", value)
         valueUpdater.when = true
-        console.log("valUp after when=true", value)
         root.editingFinished()
-        console.log("valUp before when=false", value)
         valueUpdater.when = false
-        console.log("valUp after when=false", value)
         __modifying = false
       }
 
@@ -124,9 +116,7 @@ Item {
 
       readonly property real decimalFactor: Math.pow(10, root.decimals)
       onDecimalFactorChanged: {
-        console.log("dec chang:", decimals, root.value, spinBox.value)
         value = decimalToInt(__valueAsDecimal)
-        console.log("after dec chang:", decimals, root.value, spinBox.value)
       }
 
       contentItem: TextInput {

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -38,7 +38,6 @@ GridLayout {
   Connections {
     target: GridConfig
     function onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
-      console.log("newParams", _pos, _pos.x)
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -38,6 +38,7 @@ GridLayout {
   Connections {
     target: GridConfig
     function onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
+      console.log("newParams", _pos, _pos.x)
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Before this fix, if the value property has a binding instead of a value,
any modification from the GUI (e.g. hitting the up arrow on the spin
box) would not actually change the displayed value because it is
immediately reset back to the value set by the binding. This is the case
in the `GzPose` module and the effect can be easily be seen in the
`GridConfig` plugin. To test, run:

`gz gui -c examples/config/grid_config.config`

You will see that, before this change, modifying the x,y,z,roll,pitch,
yaw values actually changes the grid configuration, but the updated values are
not displayed in the spinbox.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
