### PR TITLE
Fix GridConfig pose updates

### DIFF
--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -29,6 +29,7 @@ Item {
   property int decimals: 0
 
   onValueChanged: {
+    console.log("root val", value)
     if (!spinBox.__modifying)
     {
       spinBox.value = decimalToInt(root.value)
@@ -40,6 +41,7 @@ Item {
   readonly property int kMaxInt: Math.pow(2, 31) - 1
 
   function decimalToInt(decimal) {
+    //console.log("dec:", decimal)
     var result = decimal * spinBox.decimalFactor
     if (result >= kMaxInt) {
       return kMaxInt
@@ -51,6 +53,7 @@ Item {
   }
 
   function intToDecimal(intVal) {
+    //console.log("int:", intVal)
     return intVal / spinBox.decimalFactor
   }
 
@@ -81,7 +84,17 @@ Item {
       leftPadding: 5
       implicitHeight: 40
       clip: true
+      value: 0
 
+      // Keep the decimal representation of value so that we
+      // can decimalFactor changes properly. This is different from
+      // root.value because this does not have any bindings and thus
+      // cannot be modified from outside of this SpinBox element.
+      property real __valueAsDecimal: 0.0
+      onValueChanged: {
+        console.log("spinbox val ch:", value)
+        __valueAsDecimal = intToDecimal(value)
+      }
       // Note that this is a different event than ValueChanged. The
       // ValueModified event only fires when the value is edited by user
       // input from the GUI.
@@ -92,9 +105,13 @@ Item {
         // emitting the editingFinished signal so users GzSpinBox can be
         // notified and take the new value of the spinbox, and finally
         // disabling valueUpdater to restore the original bindings.
+        console.log("valUp before when=true", value)
         valueUpdater.when = true
+        console.log("valUp after when=true", value)
         root.editingFinished()
+        console.log("valUp before when=false", value)
         valueUpdater.when = false
+        console.log("valUp after when=false", value)
         __modifying = false
       }
 
@@ -106,6 +123,11 @@ Item {
       anchors.centerIn: parent
 
       readonly property real decimalFactor: Math.pow(10, root.decimals)
+      onDecimalFactorChanged: {
+        console.log("dec chang:", decimals, root.value, spinBox.value)
+        value = decimalToInt(__valueAsDecimal)
+        console.log("after dec chang:", decimals, root.value, spinBox.value)
+      }
 
       contentItem: TextInput {
         font.pointSize: 10

--- a/include/gz/gui/qml/GzSpinBox.qml
+++ b/include/gz/gui/qml/GzSpinBox.qml
@@ -29,7 +29,6 @@ Item {
   property int decimals: 0
 
   onValueChanged: {
-    console.log("root val", value)
     if (!spinBox.__modifying)
     {
       spinBox.value = decimalToInt(root.value)
@@ -41,7 +40,6 @@ Item {
   readonly property int kMaxInt: Math.pow(2, 31) - 1
 
   function decimalToInt(decimal) {
-    //console.log("dec:", decimal)
     var result = decimal * spinBox.decimalFactor
     if (result >= kMaxInt) {
       return kMaxInt
@@ -53,7 +51,6 @@ Item {
   }
 
   function intToDecimal(intVal) {
-    //console.log("int:", intVal)
     return intVal / spinBox.decimalFactor
   }
 
@@ -92,7 +89,6 @@ Item {
       // cannot be modified from outside of this SpinBox element.
       property real __valueAsDecimal: 0.0
       onValueChanged: {
-        console.log("spinbox val ch:", value)
         __valueAsDecimal = intToDecimal(value)
       }
       // Note that this is a different event than ValueChanged. The
@@ -105,13 +101,9 @@ Item {
         // emitting the editingFinished signal so users GzSpinBox can be
         // notified and take the new value of the spinbox, and finally
         // disabling valueUpdater to restore the original bindings.
-        console.log("valUp before when=true", value)
         valueUpdater.when = true
-        console.log("valUp after when=true", value)
         root.editingFinished()
-        console.log("valUp before when=false", value)
         valueUpdater.when = false
-        console.log("valUp after when=false", value)
         __modifying = false
       }
 
@@ -124,9 +116,7 @@ Item {
 
       readonly property real decimalFactor: Math.pow(10, root.decimals)
       onDecimalFactorChanged: {
-        console.log("dec chang:", decimals, root.value, spinBox.value)
         value = decimalToInt(__valueAsDecimal)
-        console.log("after dec chang:", decimals, root.value, spinBox.value)
       }
 
       contentItem: TextInput {

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -292,8 +292,6 @@ void GridConfig::ConnectToGrid()
             grid->CellCount(),
             grid->VerticalCellCount(),
             grid->CellLength(),
-            convert(grid->Parent()->LocalPose().Pos()),
-            convert(grid->Parent()->LocalPose().Rot().Euler()),
             convert(grid->Parent()->Material()->Ambient()));
       }
     }

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -130,6 +130,7 @@ void GridConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
         std::stringstream poseStr;
         poseStr << std::string(elem->GetText());
         poseStr >> gridParam.pose;
+        this->emit GridPoseChanged();
       }
 
       elem = insertElem->FirstChildElement("color");
@@ -285,6 +286,7 @@ void GridConfig::ConnectToGrid()
         this->dataPtr->gridParam.vCellCount = grid->VerticalCellCount();
         this->dataPtr->gridParam.cellLength = grid->CellLength();
         this->dataPtr->gridParam.pose = grid->Parent()->LocalPose();
+        this->emit GridPoseChanged();
         this->dataPtr->gridParam.color = grid->Parent()->Material()->Ambient();
         emit this->newParams(
             grid->CellCount(),
@@ -345,11 +347,20 @@ void GridConfig::UpdateCellLength(double _length)
 }
 
 /////////////////////////////////////////////////
-void GridConfig::SetPose(
-  double _x, double _y, double _z,
-  double _roll, double _pitch, double _yaw)
+void GridConfig::SetGridPose(const QList<double> &_gridPose)
 {
-  this->dataPtr->gridParam.pose = math::Pose3d(_x, _y, _z, _roll, _pitch, _yaw);
+  if (_gridPose == this->GridPose())
+    return;
+
+  this->dataPtr->gridParam.pose = math::Pose3d(
+    _gridPose[0],
+    _gridPose[1],
+    _gridPose[2],
+    _gridPose[3],
+    _gridPose[4],
+    _gridPose[5]);
+  emit this->GridPoseChanged();
+
   this->dataPtr->dirty = true;
 }
 
@@ -405,6 +416,20 @@ void GridConfig::RefreshList()
     this->OnName(this->dataPtr->nameList.at(0));
   emit this->NameListChanged();
 }
+
+/////////////////////////////////////////////////
+QList<double> GridConfig::GridPose() const
+{
+  return QList({
+    this->dataPtr->gridParam.pose.Pos().X(),
+    this->dataPtr->gridParam.pose.Pos().Y(),
+    this->dataPtr->gridParam.pose.Pos().Z(),
+    this->dataPtr->gridParam.pose.Rot().Roll(),
+    this->dataPtr->gridParam.pose.Rot().Pitch(),
+    this->dataPtr->gridParam.pose.Rot().Yaw()
+  });
+}
+
 }  // namespace gz::gui
 
 // Register this plugin

--- a/src/plugins/grid_config/GridConfig.hh
+++ b/src/plugins/grid_config/GridConfig.hh
@@ -146,8 +146,6 @@ namespace gz::gui::plugins
         int _hCellCount,
         int _vCellCount,
         double _cellLength,
-        QVector3D _pos,
-        QVector3D _rot,
         QColor _color);
 
     /// \internal

--- a/src/plugins/grid_config/GridConfig.hh
+++ b/src/plugins/grid_config/GridConfig.hh
@@ -56,6 +56,14 @@ namespace gz::gui::plugins
       NOTIFY NameListChanged
     )
 
+    /// \brief Grid pose (QList order is x, y, z, roll, pitch, yaw)
+    Q_PROPERTY(
+      QList<double> gridPose
+      READ GridPose
+      WRITE SetGridPose
+      NOTIFY GridPoseChanged
+    )
+
     /// \brief Constructor
     public: GridConfig();
 
@@ -79,6 +87,17 @@ namespace gz::gui::plugins
 
     /// \brief Refresh list of grids. This is called in the rendering thread.
     public: void RefreshList();
+
+    /// \brief Get the current grid camera pose.
+    public: Q_INVOKABLE QList<double> GridPose() const;
+
+    /// \brief Set the grid pose
+    /// \param[in] _gridPose GridPose to set.
+    /// The QList elements are x, y, z, roll, pitch, yaw
+    public slots: void SetGridPose(const QList<double> &_gridPose);
+
+    /// \brief Notify that the grid pose has changed.
+    signals: void GridPoseChanged();
 
     /// \brief Callback when refresh button is pressed.
     public slots: void OnRefresh();
@@ -110,12 +129,6 @@ namespace gz::gui::plugins
     /// \param[in] _length new cell length
     public slots: void UpdateCellLength(double _length);
 
-    /// \brief Callback to update grid pose
-    /// \param[in] _x, _y, _z cartesion coordinates
-    /// \param[in] _roll, _pitch, _yaw principal coordinates
-    public slots: void SetPose(double _x, double _y, double _z,
-                               double _roll, double _pitch, double _yaw);
-
     /// \brief Callback to update grid color
     /// \param[in] _r, _g, _b, _a RGB color model with fourth alpha channel
     public slots: void SetColor(double _r, double _g, double _b, double _a);
@@ -128,8 +141,6 @@ namespace gz::gui::plugins
     /// \param[in] _hCellCount Horizontal cell count
     /// \param[in] _vCellCount Vertical cell count
     /// \param[in] _cellLength Cell length
-    /// \param[in] _pos XYZ Position
-    /// \param[in] _rot RPY orientation
     /// \param[in] _color Grid color
     signals: void newParams(
         int _hCellCount,

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -37,16 +37,10 @@ GridLayout {
 
   Connections {
     target: GridConfig
-    function onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
+    function onNewParams(_hCellCount, _vCellCount, _cellLength, _color) {
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;
-      gzPoseInstance.xValue = _pos.x;
-      gzPoseInstance.yValue = _pos.y;
-      gzPoseInstance.zValue = _pos.z;
-      gzPoseInstance.rollValue = _rot.x;
-      gzPoseInstance.pitchValue = _rot.y;
-      gzPoseInstance.yawValue = _rot.z;
       gzColorGrid.r = _color.r;
       gzColorGrid.g = _color.g;
       gzColorGrid.b = _color.b;
@@ -182,17 +176,18 @@ GridLayout {
     Layout.columnSpan: 4
     Layout.fillWidth: true
     readOnly: false
-    xValue: 0.00
-    yValue: 0.00
-    zValue: 0.00
-    rollValue: 0.00
-    pitchValue: 0.00
-    yawValue: 0.00
+
+    xValue: GridConfig.gridPose[0]
+    yValue: GridConfig.gridPose[1]
+    zValue: GridConfig.gridPose[2]
+    rollValue: GridConfig.gridPose[3]
+    pitchValue: GridConfig.gridPose[4]
+    yawValue: GridConfig.gridPose[5]
 
     onGzPoseSet: {
       // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
       // from gz-gui GzPose.qml
-      GridConfig.SetPose(_x, _y, _z, _roll, _pitch, _yaw)
+      GridConfig.SetGridPose([_x, _y, _z, _roll, _pitch, _yaw])
     }
     expand: true
     gzPlotEnabled: false
@@ -220,4 +215,3 @@ GridLayout {
     onGzColorSet: GridConfig.SetColor(gzColorGrid.r, gzColorGrid.g, gzColorGrid.b, gzColorGrid.a)
   }
 }
-

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -38,7 +38,6 @@ GridLayout {
   Connections {
     target: GridConfig
     function onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
-      console.log("newParams", _pos, _pos.x)
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;

--- a/src/plugins/grid_config/GridConfig.qml
+++ b/src/plugins/grid_config/GridConfig.qml
@@ -38,6 +38,7 @@ GridLayout {
   Connections {
     target: GridConfig
     function onNewParams(_hCellCount, _vCellCount, _cellLength, _pos, _rot, _color) {
+      console.log("newParams", _pos, _pos.x)
       horizontalCellCount.value = _hCellCount;
       verticalCellCount.value = _vCellCount;
       cellLength.value = _cellLength;


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Follow up to #656. This PR fixes pose updates the GridConfig plugin. 

Previously if you click on one of the GzPose spinboxes, e.g. `x`, followed by clicking on another spinbox, e.g. `y`, the first pose component (`x`) gets reset to the initial value. It was found that it was because the GzPose instance (`gzPoseInstance`)  properties were incorrectly bound to the initial pose values (passed in by `onNewParams` in QML). This PR adds a new `gridPose` property for handling read/writes from C++ and QML.

Before:
![gridconfig_pose_before](https://github.com/user-attachments/assets/dd77e963-f049-4da0-821c-be47de6ddf00)

After:
![gridconfig_pose_after](https://github.com/user-attachments/assets/85549e95-9ada-4a22-acde-e2d139cefdb9)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.



