### PR TITLE
Fix Transport Plotting GUI plugin

### DIFF
--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -14,14 +14,25 @@
  * limitations under the License.
  *
 */
+#include <gz/gui/PlottingInterface.hh>
 #include <gz/plugin/Register.hh>
-#include <gz/utils/ImplPtr.hh>
 #include "TransportPlotting.hh"
 
 namespace gz::gui::plugins
 {
+
+class TransportPlotting::Implementation
+{
+  /// \brief Interface to communicate with Qml
+  public: std::unique_ptr<gui::PlottingInterface> plottingIface{nullptr};
+};
+
 //////////////////////////////////////////
-TransportPlotting::TransportPlotting() = default;
+TransportPlotting::TransportPlotting()
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
+{
+  this->dataPtr->plottingIface = std::make_unique<gui::PlottingInterface>();
+};
 
 //////////////////////////////////////////
 TransportPlotting::~TransportPlotting() = default;

--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
 */
+
+#include <memory>
+
 #include <gz/gui/PlottingInterface.hh>
 #include <gz/plugin/Register.hh>
 #include "TransportPlotting.hh"

--- a/src/plugins/plotting/TransportPlotting.cc
+++ b/src/plugins/plotting/TransportPlotting.cc
@@ -27,7 +27,7 @@ namespace gz::gui::plugins
 class TransportPlotting::Implementation
 {
   /// \brief Interface to communicate with Qml
-  public: std::unique_ptr<gui::PlottingInterface> plottingIface{nullptr};
+  public: std::unique_ptr<gui::PlottingInterface> plottingIface;
 };
 
 //////////////////////////////////////////

--- a/src/plugins/plotting/TransportPlotting.hh
+++ b/src/plugins/plotting/TransportPlotting.hh
@@ -19,11 +19,7 @@
 #define GZ_GUI_PLUGINS_TRANSPORTPLOTTING_HH_
 
 #include <gz/gui/Plugin.hh>
-#include <gz/gui/PlottingInterface.hh>
 #include <gz/utils/ImplPtr.hh>
-#include <gz/utils/SuppressWarning.hh>
-
-#include <memory>
 
 namespace gz::gui::plugins
 {
@@ -41,6 +37,9 @@ class TransportPlotting : public gz::gui::Plugin
 
   // Documentation inherited
   public: void LoadConfig(const tinyxml2::XMLElement *) override;
+
+  /// \brief Private data member.
+  private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };
 }  // namespace gz::gui::plugins
 


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

The transport gui plugin tool was broken by #584 as it mistakenly removed the `PlottingIface` object that's needed for QML -> C++ integration to work. This PR adds the variable back in the private implementation class.

Without the changes in this PR, when plotting a field from a topic, you'll see the following warning message in the console:

```sh
[warning] [Application.cc:915] [GUI] [QT] qrc:/qml/PlottingInterface.qml:114: ReferenceError: PlottingIface is not defined
```

## To test

1. Open `Transport Plotting` GUI plugin
1. Open `Topic Viewer` plugin
1. Try plotting any field from a topic 
1. Hit Play -> it should work now and you should see a line drawn on the graph

![transport_plotting](https://github.com/user-attachments/assets/dc852300-8a80-4bea-a75e-34d696910e6e)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
