### PR TITLE
Image Display Depth Visual Flip

### DIFF
--- a/examples/config/image.config
+++ b/examples/config/image.config
@@ -12,5 +12,10 @@
 </plugin>
 
 <!--plugin filename="ImageDisplay">
+  <title>Without Flip Depth Visualization</title>
+  <show_depth_flip>false</show_depth_flip>
+</plugin-->
+
+<!--plugin filename="ImageDisplay">
   <title>With picker</title>
 </plugin-->

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -122,6 +122,12 @@ namespace gz::gui::plugins
     /// \brief Get the provider name unique to this plugin instance
     public: Q_INVOKABLE QString ImageProviderName();
 
+    /// \brief Set whether darker pixels in depth image have
+    /// higher values or lower values
+    /// \param[in] _value Boolean value for flipping the depth image
+    /// display style
+    public: Q_INVOKABLE void FlipDepthVisual(bool _value);
+
     /// \brief Notify that topic list has changed
     signals: void TopicListChanged();
 

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -78,7 +78,7 @@ namespace gz::gui::plugins
   /// \<topic\> : Set the topic to receive image messages.
   /// \<topic_picker\> : Whether to show the topic picker, true by default. If
   ///                    this is false, a \<topic\> must be specified.
-  /// \<show_depth_flip\> : Wheter to show the Flip Depth Image
+  /// \<show_depth_flip\> : Whether to show the Flip Depth Image
   ///                                Visualization Checkbox, true by default.
   class ImageDisplay_EXPORTS_API ImageDisplay : public Plugin
   {
@@ -123,6 +123,13 @@ namespace gz::gui::plugins
 
     /// \brief Get the provider name unique to this plugin instance
     public: Q_INVOKABLE QString ImageProviderName();
+
+    /// \brief Enable or disable the depth image flip checkbox
+    /// \param[in] _enable Boolean value for enabling/disabling the
+    ///                    depth image flip checkbox
+    /// \note This is used to disable the checkbox when the image
+    ///       format is not depth
+    public: inline void SetEnableDepthFlip(bool _enable);
 
     /// \brief Set whether darker pixels in depth image have
     /// higher values or lower values

--- a/src/plugins/image_display/ImageDisplay.hh
+++ b/src/plugins/image_display/ImageDisplay.hh
@@ -78,6 +78,8 @@ namespace gz::gui::plugins
   /// \<topic\> : Set the topic to receive image messages.
   /// \<topic_picker\> : Whether to show the topic picker, true by default. If
   ///                    this is false, a \<topic\> must be specified.
+  /// \<show_depth_flip\> : Wheter to show the Flip Depth Image
+  ///                                Visualization Checkbox, true by default.
   class ImageDisplay_EXPORTS_API ImageDisplay : public Plugin
   {
     Q_OBJECT
@@ -126,7 +128,7 @@ namespace gz::gui::plugins
     /// higher values or lower values
     /// \param[in] _value Boolean value for flipping the depth image
     /// display style
-    public: Q_INVOKABLE void FlipDepthVisual(bool _value);
+    public: Q_INVOKABLE void SetFlipDepthVisualization(bool _value);
 
     /// \brief Notify that topic list has changed
     signals: void TopicListChanged();

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -58,6 +58,19 @@ Rectangle {
     anchors.fill: parent
     anchors.margins: 10
 
+    CheckBox {
+      objectName: "flipDepthImageColorCheckBox"
+      Layout.alignment: Qt.AlignHCenter
+      id: displayVisual
+      Layout.columnSpan: 6
+      Layout.fillWidth: true
+      text: qsTr("Flip Depth Visual")
+      checked: false
+      onClicked: {
+        ImageDisplay.FlipDepthVisual(checked);
+      }
+    }
+
     RowLayout {
       visible: showPicker
       RoundButton {

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -32,6 +32,11 @@ Rectangle {
   property bool showPicker: false
 
   /**
+   * True to show the checkbox to flip depth visualization
+   */
+  property bool showDepthFlip: false
+
+  /**
    * Unique name for this plugin instance
    */
   property string uniqueName: ""
@@ -59,16 +64,21 @@ Rectangle {
     anchors.margins: 10
 
     CheckBox {
+      visible: showDepthFlip
       objectName: "flipDepthImageColorCheckBox"
       Layout.alignment: Qt.AlignHCenter
       id: displayVisual
       Layout.columnSpan: 6
       Layout.fillWidth: true
-      text: qsTr("Flip Depth Visual")
+      text: qsTr("Flip Depth Visualization")
       checked: false
       onClicked: {
-        ImageDisplay.FlipDepthVisual(checked);
+        ImageDisplay.SetFlipDepthVisualization(checked);
       }
+      ToolTip.visible: hovered
+      ToolTip.delay: tooltipDelay
+      ToolTip.timeout: tooltipTimeout
+      ToolTip.text: qsTr("Flip the depth image color to match rviz")
     }
 
     RowLayout {

--- a/src/plugins/image_display/ImageDisplay.qml
+++ b/src/plugins/image_display/ImageDisplay.qml
@@ -37,6 +37,11 @@ Rectangle {
   property bool showDepthFlip: false
 
   /**
+   * True to enable the checkbox to flip depth visualization
+   */
+  property bool enableDepthFlip: false
+
+  /**
    * Unique name for this plugin instance
    */
   property string uniqueName: ""
@@ -64,6 +69,7 @@ Rectangle {
     anchors.margins: 10
 
     CheckBox {
+      enabled: enableDepthFlip
       visible: showDepthFlip
       objectName: "flipDepthImageColorCheckBox"
       Layout.alignment: Qt.AlignHCenter
@@ -71,14 +77,14 @@ Rectangle {
       Layout.columnSpan: 6
       Layout.fillWidth: true
       text: qsTr("Flip Depth Visualization")
-      checked: false
+      checked: true   // default behavior is to flip depth image
       onClicked: {
         ImageDisplay.SetFlipDepthVisualization(checked);
       }
       ToolTip.visible: hovered
       ToolTip.delay: tooltipDelay
       ToolTip.timeout: tooltipTimeout
-      ToolTip.text: qsTr("Flip the depth image color to match rviz")
+      ToolTip.text: qsTr("Flip the depth image color")
     }
 
     RowLayout {

--- a/src/plugins/image_display/ImageDisplay_TEST.cc
+++ b/src/plugins/image_display/ImageDisplay_TEST.cc
@@ -96,6 +96,15 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DefaultConfig))
   auto topicList = topicProp.toStringList();
   EXPECT_EQ(topicList.size(), 0);
 
+  auto flipDepthImageColorCheckBox = 
+    plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
+  ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
+  
+  auto flipDepthImageColorCheckBoxProp 
+    = flipDepthImageColorCheckBox->property("checked");
+  EXPECT_TRUE(flipDepthImageColorCheckBoxProp.isValid());
+  EXPECT_FALSE(flipDepthImageColorCheckBoxProp.toBool());
+
   auto refreshButton =
     plugin->PluginItem()->findChild<QObject *>("refreshButton");
   ASSERT_NE(refreshButton, nullptr);

--- a/src/plugins/image_display/ImageDisplay_TEST.cc
+++ b/src/plugins/image_display/ImageDisplay_TEST.cc
@@ -96,11 +96,11 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DefaultConfig))
   auto topicList = topicProp.toStringList();
   EXPECT_EQ(topicList.size(), 0);
 
-  auto flipDepthImageColorCheckBox = 
+  auto flipDepthImageColorCheckBox =
     plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
   ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
-  
-  auto flipDepthImageColorCheckBoxProp 
+
+  auto flipDepthImageColorCheckBoxProp
     = flipDepthImageColorCheckBox->property("checked");
   EXPECT_TRUE(flipDepthImageColorCheckBoxProp.isValid());
   EXPECT_FALSE(flipDepthImageColorCheckBoxProp.toBool());

--- a/src/plugins/image_display/ImageDisplay_TEST.cc
+++ b/src/plugins/image_display/ImageDisplay_TEST.cc
@@ -100,10 +100,15 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DefaultConfig))
     plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
   ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
 
-  auto flipDepthImageColorCheckBoxProp
-    = flipDepthImageColorCheckBox->property("checked");
+  auto flipDepthImageColorCheckBoxProp =
+    flipDepthImageColorCheckBox->property("checked");
   EXPECT_TRUE(flipDepthImageColorCheckBoxProp.isValid());
   EXPECT_FALSE(flipDepthImageColorCheckBoxProp.toBool());
+
+  auto showDepthFlipCheckboxProp =
+    plugin->PluginItem()->property("visible");
+  EXPECT_TRUE(showDepthFlipCheckboxProp.isValid());
+  EXPECT_TRUE(showDepthFlipCheckboxProp.toBool());
 
   auto refreshButton =
     plugin->PluginItem()->findChild<QObject *>("refreshButton");
@@ -207,6 +212,7 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImage))
     "<plugin filename=\"ImageDisplay\">"
       "<topic>/image_test</topic>"
       "<topic_picker>false</topic_picker>"
+      "<show_depth_flip>false</show_depth_flip>"
     "</plugin>";
 
   tinyxml2::XMLDocument pluginDoc;
@@ -233,6 +239,16 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImage))
   auto pickerProp = picker->property("visible");
   EXPECT_TRUE(pickerProp.isValid());
   EXPECT_FALSE(pickerProp.toBool());
+
+  // Doesn't have a flip depth image color checkbox by checking
+  // `showDepthFlipCheckbox == false`
+  auto flipDepthImageColorCheckBox =
+    plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
+  ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
+  auto showDepthFlipCheckboxProp =
+    flipDepthImageColorCheckBox->property("visible");
+  EXPECT_TRUE(showDepthFlipCheckboxProp.isValid());
+  EXPECT_FALSE(showDepthFlipCheckboxProp.toBool());
 
   // Starts with no image (gray image)
   auto providerBase = app.Engine()->imageProvider(

--- a/src/plugins/image_display/ImageDisplay_TEST.cc
+++ b/src/plugins/image_display/ImageDisplay_TEST.cc
@@ -103,12 +103,17 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DefaultConfig))
   auto flipDepthImageColorCheckBoxProp =
     flipDepthImageColorCheckBox->property("checked");
   EXPECT_TRUE(flipDepthImageColorCheckBoxProp.isValid());
-  EXPECT_FALSE(flipDepthImageColorCheckBoxProp.toBool());
+  EXPECT_TRUE(flipDepthImageColorCheckBoxProp.toBool());
 
   auto showDepthFlipCheckboxProp =
-    plugin->PluginItem()->property("visible");
+    flipDepthImageColorCheckBox->property("visible");
   EXPECT_TRUE(showDepthFlipCheckboxProp.isValid());
   EXPECT_TRUE(showDepthFlipCheckboxProp.toBool());
+
+  auto enaledDepthFlipCheckBoxProp =
+    flipDepthImageColorCheckBox->property("enabled");
+  EXPECT_TRUE(enaledDepthFlipCheckBoxProp.isValid());
+  EXPECT_TRUE(enaledDepthFlipCheckBoxProp.toBool());
 
   auto refreshButton =
     plugin->PluginItem()->findChild<QObject *>("refreshButton");
@@ -446,6 +451,16 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImageFloat32))
     }
   }
 
+  // Check that the flip depth image color checkbox is enabled
+  auto flipDepthImageColorCheckBox =
+    plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
+  ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
+
+  auto enaledDepthFlipCheckBoxProp =
+    flipDepthImageColorCheckBox->property("enabled");
+  EXPECT_TRUE(enaledDepthFlipCheckBoxProp.isValid());
+  EXPECT_TRUE(enaledDepthFlipCheckBoxProp.toBool());
+
   // Cleanup
   plugins.clear();
 }
@@ -559,6 +574,16 @@ TEST(ImageDisplayTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ReceiveImageInt16))
       }
     }
   }
+
+  // Check that the flip depth image color checkbox is disabled
+  auto flipDepthImageColorCheckBox =
+    plugin->PluginItem()->findChild<QObject *>("flipDepthImageColorCheckBox");
+  ASSERT_NE(flipDepthImageColorCheckBox, nullptr);
+
+  auto enaledDepthFlipCheckBoxProp =
+    flipDepthImageColorCheckBox->property("enabled");
+  EXPECT_TRUE(enaledDepthFlipCheckBoxProp.isValid());
+  EXPECT_FALSE(enaledDepthFlipCheckBoxProp.toBool());
 
   // Cleanup
   plugins.clear();


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gz-sensors/issues/473

## Summary
### Issue brief

**Expected behavior:**
The rviz2 visualizer for depth image should match the visualization in the Image Display Viewer in Gazebo

**Actual behavior:**
The far point of a depth image in rviz2 is set as white but in gazebo it is black. These are default behaviors for these systems for a long time. 

| Rviz2    | Gazebo Image Display |
| ---------- | ---------------------------------|
| ![image](https://github.com/user-attachments/assets/64502f18-e1dc-4efc-b45e-6d3ded809c85) | ![image](https://github.com/user-attachments/assets/a85b0e34-84d5-40b0-b672-4848e862f384) |

### Solution
To quote @azeey 
> There doesn't seem to be a standard on how to display depth images. A quick look on the web shows both approaches being used in different places. Since the behavior in Gazebo has been around for a long time, I don't think we should change it. Perhaps a flag in the "Image Display" plugin to revert the colors could be an option. https://github.com/gazebosim/gz-sensors/issues/473#issuecomment-2457773426

From this, I simply added a checkbox in the image display plugin which switches a 'flip/no flip' flag in qml and a callback function to handle the toggling. This flag is passed directly into `common::Image::ConvertToRGBImage` as the `_flip` argument for `float32` type image, where the actual pixel value flipping is handled. This argument was previously set to `true` always, causing the mismatch.
**Note:** A new mutex was also introduced named `service_lock` to safely update the flag.

### Unit Tests
Implemented a couple of tests to ensure (in order):
1. The object can be found by its name.
2. The checkbox property is valid, i.e. is loaded properly.
3. The checkbox property matches the default value set in the code on startup.

## Manually test it
1. Launch a sdf with a depth camera using ros2 and bridge.
4. Add the Image Display plugiin gazebo.
5. View the depth image in rviz2.
6. Notice that far point in gazebo is black but in rviz it is white. This is the mismatch issue.

| Rviz2    | Gazebo Image Display |
| ---------- | ---------------------------------|
|![Screenshot from 2025-03-30 13-41-06](https://github.com/user-attachments/assets/dd377dec-245b-4c94-9f90-24383b4f6ead) | ![Screenshot from 2025-03-30 13-41-15](https://github.com/user-attachments/assets/cd9b0e27-b8bf-46bd-9c52-f2b167c2a599) |  


7. Click the Flip Depth Visual checkbox in Image Display window, and watch the rviz2 image and gazebo image match.

| Rviz2    | Flipped Gazebo Image Display |
| ---------- | ---------------------------------|
|![Screenshot from 2025-03-30 13-41-06](https://github.com/user-attachments/assets/dd377dec-245b-4c94-9f90-24383b4f6ead) | ![Screenshot from 2025-03-30 13-41-19](https://github.com/user-attachments/assets/8b3715d4-f27a-4c78-8f9a-8413b3323513) |

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
