### PR TITLE
Remove build RUNPATH from installed libGrid3D.so

### DIFF
--- a/src/plugins/grid_config/CMakeLists.txt
+++ b/src/plugins/grid_config/CMakeLists.txt
@@ -7,8 +7,14 @@ gz_gui_add_plugin(GridConfig
     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
 )
 
-# Also install as Grid3D, which was a legacy plugin with a subset of features
-install (
-  FILES $<TARGET_FILE:GridConfig>
-  RENAME ${CMAKE_SHARED_LIBRARY_PREFIX}Grid3D${CMAKE_SHARED_LIBRARY_SUFFIX}
-  DESTINATION ${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR})
+# Also install Grid3D (a legacy plugin with a subset of features) by copying the installed GridConfig library. This ensures the correct RUNPATH is used.
+
+install(CODE "
+  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\"
+    \"\${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGrid3D.so\")
+  else()
+    message(WARNING \"Source file for Grid3D (legacy plugin) copy not found, skipping copy: \${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}/libGridConfig.so\")
+  endif()
+")


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #627

## Summary
Installs libGrid3D.so (a legacy alias for libGridConfig.so) by copying the already installed libGridConfig.so using install(CODE ...) instead of install(FILES ...). This ensures the build directory RUNPATH is correctly stripped, matching other installed plugins.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers