### PR TITLE
Backport minimal scene shutdown fix

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -837,6 +837,9 @@ void GzRenderer::SetGraphicsAPI(const rendering::GraphicsAPI &_graphicsAPI)
 /////////////////////////////////////////////////
 void GzRenderer::Destroy()
 {
+  if (!this->initialized)
+    return;
+
   auto *engine = rendering::engine(this->engineName);
   if (engine == nullptr)
     return;

--- a/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.cc
+++ b/src/plugins/minimal_scene/MinimalSceneRhiOpenGL.cc
@@ -210,6 +210,7 @@ void RenderThreadRhiOpenGL::ShutDown()
   if (this->dataPtr->surface)
   {
     this->dataPtr->surface->deleteLater();
+    this->dataPtr->surface = nullptr;
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Backport a fix for opening and closing a second minimal scene. see https://github.com/gazebosim/gz-gui/pull/666#issuecomment-2814009969. The fix was done as part of the Qt6 migration targeted at `main` in #666

To reproduce: 
1. launch gz sim
2. Load another `minimal_scene` GUI plugin
3. Close the newly opened `minimal_scene` GUI plugin -> Gazebo should no longer crash.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
