### PR TITLE
Backport Publisher plugin layout updates

### DIFF
--- a/src/plugins/publisher/Publisher.qml
+++ b/src/plugins/publisher/Publisher.qml
@@ -28,7 +28,7 @@ Rectangle {
   property int tooltipDelay: 500
   property int tooltipTimeout: 1000
 
-  Column {
+  ColumnLayout {
     anchors.fill: parent
     anchors.margins: 10
 
@@ -40,6 +40,7 @@ Rectangle {
       id: msgTypeField
       text: Publisher.msgType
       selectByMouse: true
+      Layout.fillWidth: true
     }
 
     Label {
@@ -50,6 +51,7 @@ Rectangle {
       id: topicField
       text: Publisher.topic
       selectByMouse: true
+      Layout.fillWidth: true
     }
 
     Label {
@@ -60,6 +62,7 @@ Rectangle {
       id: msgDataField
       text: Publisher.msgData
       selectByMouse: true
+      Layout.fillWidth: true
     }
 
     Label {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Backport layout update for the Publisher GUI plugin. The fix was done as part of the Qt6 migration targeted at main in https://github.com/gazebosim/gz-gui/pull/666

The `message type` field was truncated in the Publisher GUI plugin. This makes the text field fill the whole width of the plugin. See images of before and after the changes in https://github.com/gazebosim/gz-gui/pull/666#issuecomment-2814012395. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

