### PR TITLE
Fix world reset dialog crash and cancel button in WorldControl plugin

### DIFF
--- a/src/plugins/world_control/WorldControl.qml
+++ b/src/plugins/world_control/WorldControl.qml
@@ -15,7 +15,7 @@
  *
 */
 import QtQuick 2.9
-import QtQuick.Controls 2.5
+import QtQuick.Controls
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts 1.3
 import "qrc:/qml"
@@ -235,15 +235,14 @@ RowLayout {
 
     modal: true
     focus: true
-    parent: ApplicationWindow.overlay
+    parent: Overlay.overlay
     width: 500
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
     closePolicy: Popup.CloseOnEscape
-    standardButtons: Dialog.Ok  | Dialog.Discard
+    standardButtons: Dialog.Ok  | Dialog.Cancel
 
     Component.onCompleted: {
-      confirmationDialogOnReset.standardButton(Dialog.Discard).text = "Cancel"
       confirmationDialogOnReset.standardButton(Dialog.Ok).text = "Reset"
     }
 


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Fixes 2 issues:
* Fix crash when closing gazebo while the reset dialog window is open.
    * Similar to the fix in https://github.com/gazebosim/gz-sim/pull/2900
* Fix Cancel button - previously there was no response when the button was pressed.

To test:

1. launch gz-sim 
2. click on the world reset button on the bottom left of the window -> a modal dialog should appear
3. click `CANCEL` - > the modal dialog should now close properly
4. click on the world reset button again to open the dialog
5. close gazebo by clicking on the `x` button on the top right corner of the window -> gazebo should close without crashing.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

