### PR TITLE
Fix null pointer crashes when running a plugin as a standalone window

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## Gazebo GUI 9 mo mo fix
+## Gazebo GUI 9
 
 ### Gazebo GUI 9.0.1 (2025-02-12)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## Gazebo GUI 9
+## Gazebo GUI 9 mo mo fix
 
 ### Gazebo GUI 9.0.1 (2025-02-12)
 

--- a/src/plugins/camera_fps/CameraFps.cc
+++ b/src/plugins/camera_fps/CameraFps.cc
@@ -96,7 +96,11 @@ void CameraFps::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Camera FPS";
 
-  App()->findChild<MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -733,7 +733,11 @@ void CameraTracking::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     }
   }
 
-  App()->findChild<MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/camera_tracking_config/CameraTrackingConfig.cc
+++ b/src/plugins/camera_tracking_config/CameraTrackingConfig.cc
@@ -95,8 +95,11 @@ void CameraTrackingConfig::LoadConfig(const tinyxml2::XMLElement *)
   gzmsg << "CameraTrackingConfig: Tracking topic publisher advertised on ["
          << this->dataPtr->cameraTrackingTopic << "]" << std::endl;
 
-  gui::App()->findChild<
-      MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/grid_config/GridConfig.cc
+++ b/src/plugins/grid_config/GridConfig.cc
@@ -144,8 +144,11 @@ void GridConfig::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     }
   }
 
-  gui::App()->findChild<
-      MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/interactive_view_control/InteractiveViewControl.cc
+++ b/src/plugins/interactive_view_control/InteractiveViewControl.cc
@@ -428,8 +428,11 @@ void InteractiveViewControl::LoadConfig(
         << this->dataPtr->cameraViewControlSensitivityService << "]"
         << std::endl;
 
-  gz::gui::App()->findChild<
-    gz::gui::MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/key_publisher/KeyPublisher.cc
+++ b/src/plugins/key_publisher/KeyPublisher.cc
@@ -67,8 +67,11 @@ void KeyPublisher::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Key publisher";
 
-  gui::App()->findChild
-    <MainWindow *>()->QuickWindow()->installEventFilter(this);
+  if (auto *mainWindow = gui::App()->findChild<MainWindow *>()) {
+    if (auto *quickWindow = mainWindow->QuickWindow()) {
+      quickWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/marker_manager/MarkerManager.cc
+++ b/src/plugins/marker_manager/MarkerManager.cc
@@ -763,7 +763,11 @@ void MarkerManager::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
   QQmlProperty::write(this->PluginItem(), "statsTopic",
       QString::fromStdString(statsTopic));
 
-  App()->findChild<MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -682,9 +682,6 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   // Load engine if there's no engine yet
   if (loadedEngines.empty())
   {
-    QQuickWindow *quickWindow =
-      gz::gui::App()->findChild<gz::gui::MainWindow *>()->QuickWindow();
-
     this->dataPtr->rhiParams["winID"] = std::to_string(quickWindow->winId());
 
 #if GZ_GUI_HAVE_VULKAN

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -666,7 +666,7 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
 {
   if (this->initialized)
     return {};
-  // make sure ervery part is initialized
+  // make sure every part is initialized
   auto *mainWindow = gz::gui::App()->findChild<gz::gui::MainWindow *>();
   if (!mainWindow) {
     return "Failed to find main window.";

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -666,7 +666,15 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
 {
   if (this->initialized)
     return {};
-
+  // make sure ervery part is initialized
+  auto *mainWindow = gz::gui::App()->findChild<gz::gui::MainWindow *>();
+  if (!mainWindow) {
+    return "Failed to find main window.";
+  }
+  QQuickWindow *quickWindow = mainWindow->QuickWindow();
+  if (!quickWindow) {
+    return "Failed to get quick window from main window.";
+  }
   // Currently only support one engine at a time
   rendering::RenderEngine *engine{nullptr};
   auto loadedEngines = rendering::loadedEngines();

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -141,7 +141,7 @@ void PointCloud::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   if (auto app = gz::gui::App()) {
     if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
-          mainWindow->installEventFilter(this);
+      mainWindow->installEventFilter(this);
     }
   }
 }

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -139,8 +139,8 @@ void PointCloud::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   }
 
-    if (auto app = gz::gui::App()) {
-      if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
           mainWindow->installEventFilter(this);
     }
   }

--- a/src/plugins/point_cloud/PointCloud.cc
+++ b/src/plugins/point_cloud/PointCloud.cc
@@ -139,8 +139,11 @@ void PointCloud::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   }
 
-  gz::gui::App()->findChild<
-    gz::gui::MainWindow *>()->installEventFilter(this);
+    if (auto app = gz::gui::App()) {
+      if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+          mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/plugins/screenshot/Screenshot.cc
+++ b/src/plugins/screenshot/Screenshot.cc
@@ -97,7 +97,11 @@ void Screenshot::LoadConfig(const tinyxml2::XMLElement *)
   gzmsg << "Screenshot service on ["
          << this->dataPtr->screenshotService << "]" << std::endl;
 
-  App()->findChild<MainWindow *>()->installEventFilter(this);
+  if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/tape_measure/TapeMeasure.cc
+++ b/src/plugins/tape_measure/TapeMeasure.cc
@@ -104,10 +104,12 @@ void TapeMeasure::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Tape measure";
 
-  gz::gui::App()->findChild<gz::gui::MainWindow *>
-      ()->installEventFilter(this);
-  gz::gui::App()->findChild<gz::gui::MainWindow *>
-      ()->QuickWindow()->installEventFilter(this);
+  if (auto *mainWindow = gz::gui::App()->findChild<MainWindow *>()) {
+    mainWindow->installEventFilter(this);
+    if (auto *quickWindow = mainWindow->QuickWindow()) {
+      quickWindow->installEventFilter(this);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/teleop/Teleop.cc
+++ b/src/plugins/teleop/Teleop.cc
@@ -128,7 +128,12 @@ void Teleop::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
       this->SetTopic(topicElem->GetText());
   }
 
-  App()->findChild<MainWindow *>()->QuickWindow()->installEventFilter(this);
+  if (auto *qw = App() ? App()->findChild<MainWindow *>() ?
+                        App()->findChild<MainWindow *>()->QuickWindow():
+                        nullptr : nullptr)
+  {
+    qw->installEventFilter(this);
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -249,9 +249,9 @@ void TransportSceneManager::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   else
   {
     if (auto app = gz::gui::App()) {
-    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
-      mainWindow->installEventFilter(this);
-    }
+      if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+        mainWindow->installEventFilter(this);
+      }
   }
   }
 }

--- a/src/plugins/transport_scene_manager/TransportSceneManager.cc
+++ b/src/plugins/transport_scene_manager/TransportSceneManager.cc
@@ -248,7 +248,11 @@ void TransportSceneManager::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   }
   else
   {
-    App()->findChild<MainWindow *>()->installEventFilter(this);
+    if (auto app = gz::gui::App()) {
+    if (auto mainWindow = app->findChild<gz::gui::MainWindow *>()) {
+      mainWindow->installEventFilter(this);
+    }
+  }
   }
 }
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #687 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
The fix replaces unsafe direct pointer dereferences with null pointer checks to prevent potential crashes.
before fix : use `gz gui -s` plus any plugin noted in #687 , gazebo crashes
after fix: `gz gui -s` plus any plugin noted in #687 , gazebo workes correctly as expected
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))