### PR TITLE
Increase the test setting parameters to avoid being less than the minimum height and width in `Main.qml`

### DIFF
--- a/src/MainWindow_TEST.cc
+++ b/src/MainWindow_TEST.cc
@@ -742,8 +742,8 @@ TEST(MainWindowTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ApplyConfig))
     WindowConfig c;
 //    c.posX = 1000;
 //    c.posY = 2000;
-    c.width = 100;
-    c.height = 200;
+    c.width = 300;
+    c.height = 400;
     c.materialTheme = "Dark";
     c.materialPrimary = "#ff0000";
     c.materialAccent = "Indigo";
@@ -765,8 +765,8 @@ TEST(MainWindowTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ApplyConfig))
 //    EXPECT_NE(c.posX, 1000);
 //    EXPECT_NE(c.posY, 2000);
 
-    EXPECT_EQ(c.width, 100);
-    EXPECT_EQ(c.height, 200);
+    EXPECT_EQ(c.width, 300);
+    EXPECT_EQ(c.height, 400);
     EXPECT_EQ(c.materialTheme, "Dark");
     EXPECT_EQ(c.materialPrimary, "#ff0000");
     // Always save hex


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #661 

## Summary
This test case failed because `minimumWidth` and `minimumHeight` are both set to `300` in `Main.qml`. It can not work when we set them to `100` and `200` seperately. So ,incresing the test parameters is a good way to let it work.
The following code describes the information about `Main.qml`.
```
title: qsTr("Gazebo GUI")
  width: 1200
  height: 1000
  minimumWidth: 300
  minimumHeight: 300
  visible: true
  id: window
  objectName: "window"
  font.family: "Roboto"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers