### PR TITLE
Qt6 Migration tutorial and doc updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ gz_create_docs(
   ADDITIONAL_INPUT_DIRS "${CMAKE_SOURCE_DIR}/src/plugins"
   IMAGE_PATH_DIRS "${CMAKE_SOURCE_DIR}/tutorials/images"
   TAGFILES
-    "${CMAKE_SOURCE_DIR}/doc/qt.tag.xml=http://doc.qt.io/qt-5/"
+    "${CMAKE_SOURCE_DIR}/doc/qt.tag.xml=https://doc.qt.io/qt-6/"
     "${GZ-MATH_DOXYGEN_TAGFILE} = ${GZ-MATH_API_URL}"
     "${GZ-MSGS_DOXYGEN_TAGFILE} = ${GZ-MSGS_API_URL}"
     "${GZ-RENDERING_DOXYGEN_TAGFILE} = ${GZ-RENDERING_API_URL}"

--- a/Migration.md
+++ b/Migration.md
@@ -7,6 +7,12 @@ release will remove the deprecated code.
 
 ## Gazebo GUI 9.X to 10.X
 
+* Upgraded GUI framework from Qt5 to Qt6. All GUI plugins distributed by gz-gui
+have been migrated. This upgrade affects all users' custom Gazebo GUI plugins.
+Please see the
+[Qt6 Migration tutorial](https://github.com/gazebosim/gz-gui/blob/main/tutorials/09_migration_qt6.html)
+for information on how to port your Qt5 based plugins to Qt6.
+
 * The environment variable `GZ_GUI_PLUGIN_INSTALL_DIR` is removed. Use
 `gz::gui::getPluginInstallDir()` instead.
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Doxygen)
 
 set(GZ_DOXYGEN_TAGFILES
-  "\"${CMAKE_SOURCE_DIR}/doc/qt.tag.xml=http://doc.qt.io/qt-5/\" \
+  "\"${CMAKE_SOURCE_DIR}/doc/qt.tag.xml=https://doc.qt.io/qt-6/\" \
    \"${GZ-MATH_DOXYGEN_TAGFILE} = ${GZ-MATH_API_URL}\" \
    \"${GZ-MSGS_DOXYGEN_TAGFILE} = ${GZ-MSGS_API_URL}\" \
    \"${GZ-TRANSPORT_DOXYGEN_TAGFILE} = ${GZ-TRANSPORT_API_URL}\" \
@@ -24,6 +24,6 @@ if (DOXYGEN_FOUND)
 
     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
-  install(FILES ${CMAKE_BINARY_DIR}/doc/${PROJECT_NAME_LOWER}.tag.xml 
+  install(FILES ${CMAKE_BINARY_DIR}/doc/${PROJECT_NAME_LOWER}.tag.xml
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gz/${PROJECT_NAME_LOWER}_${PROJECT_VERSION_MINOR})
 endif()

--- a/examples/config/plugin_params.config
+++ b/examples/config/plugin_params.config
@@ -15,7 +15,7 @@
     <!--
       Properties passed directly to the QML card.
       It includes:
-      * All Pane properties: https://doc.qt.io/qt-5/qml-qtquick-controls2-pane-members.html
+      * All Pane properties: https://doc.qt.io/qt-6/qml-qtquick-controls-pane-members.html
       * All custom properties within GzCard.qml
     -->
     <property type="bool" key="showDockButton">false</property>

--- a/examples/plugin/custom_context_menu/CMakeLists.txt
+++ b/examples/plugin/custom_context_menu/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set (CMAKE_AUTOMOC ON)
 
-# Find Qt5
+# Find Qt6
 find_package (Qt6 6.4
   COMPONENTS
     Core

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -83,7 +83,7 @@ class Plugin::Implementation
 
   /// \brief Map of card properties to be passed to QML card object.
   /// Accepts all QML Pane properties plus custom Gazebo: GUI properties.
-  /// https://doc.qt.io/qt-5/qml-qtquick-controls2-pane-members.html
+  /// https://doc.qt.io/qt-6/qml-qtquick-controls-pane-members.html
   public: std::map<std::string, QVariant> cardProperties;
 
   /// \brief Holds all anchor information

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -19,7 +19,7 @@ Gazebo @GZ_DESIGNATION_CAP@ library and how to use the library effectively.
 
 1. \subpage scene "3D Scene": How to use the rendering scene
 2. \subpage screenshot "Screenshot": Save screenshots of the 3D scene
-2. \subpage migration_qt6 "Qt6 Migration": Migrating Qt5 GUI plugins to Qt6
+3. \subpage migration_qt6 "Qt6 Migration": Migrating Qt5 GUI plugins to Qt6
 
 ## License
 

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -19,6 +19,7 @@ Gazebo @GZ_DESIGNATION_CAP@ library and how to use the library effectively.
 
 1. \subpage scene "3D Scene": How to use the rendering scene
 2. \subpage screenshot "Screenshot": Save screenshots of the 3D scene
+2. \subpage migration_qt6 "Qt6 Migration": Migrating Qt5 GUI plugins to Qt6
 
 ## License
 

--- a/tutorials/03_plugins.md
+++ b/tutorials/03_plugins.md
@@ -5,9 +5,9 @@ Previous Tutorial: \ref commandline
 
 ## About Plugins
 
-A Gazebo GUI plugin is a shared library that defines a widget. 
+A Gazebo GUI plugin is a shared library that defines a widget.
 
-The plugin contains [QML](http://doc.qt.io/qt-5/qtqml-index.html) code that specifies what the widget looks like, as well as C++ code that defines the plugin's behavior and ties it to other libraries.
+The plugin contains [QML](https://doc.qt.io/qt-6/qtqml-index.html) code that specifies what the widget looks like, as well as C++ code that defines the plugin's behavior and ties it to other libraries.
 
 ## Starting a pre-built plugin (example)
 

--- a/tutorials/05_style.md
+++ b/tutorials/05_style.md
@@ -6,7 +6,7 @@ Previous Tutorial: \ref layout
 ## Overview
 
 Gazebo GUI leverages
-[QtQuick Controls 2 Styles](https://doc.qt.io/qt-5.9/qtquickcontrols2-styles.html)
+[QtQuick Controls Styles](https://doc.qt.io/qt-6/qtquickcontrols-styles.html)
 for styling. The recommended and best supported style is the Material Style,
 but it is also possible to use others such as Default and Universal. This tutorial
 focuses on customizing the Material style.
@@ -34,7 +34,7 @@ Users can customize the whole application's material style using just a few vari
 * Accent color
 
 QML types provided by
-[QtQuick Controls 2](https://doc.qt.io/qt-5/qtquick-controls2-qmlmodule.html),
+[QtQuick Controls](https://doc.qt.io/qt-6/qtquick-controls-qmlmodule.html),
 as well as QML types provided by Gazebo GUI, use these variables as appropriate.
 It's recommended that developers make sure their plugins use these variables
 for a more integrated experience.
@@ -65,7 +65,7 @@ choose "Style settings".
 
 A dialog will open, where you can change the theme (Light / Dark) and primary /
 accent colors. From the color dropdown menu, it is possible to choose one of the
-[pre-defined material colors](https://doc.qt.io/qt-5.9/qtquickcontrols2-material.html#pre-defined-material-colors),
+[pre-defined material colors](https://doc.qt.io/qt-6/qtquickcontrols-material.html#pre-defined-material-colors),
 and from the button next to it, it is possible to choose any custom color.
 
 \note Custom colors won't be automatically shaded based on the theme.
@@ -75,7 +75,7 @@ and from the button next to it, it is possible to choose any custom color.
 ## Environment variables
 
 See
-[Supported Environment Variables in Qt Quick Controls 2](https://doc.qt.io/qt-5.9/qtquickcontrols2-environment.html).
+[Supported Environment Variables in Qt Quick Controls](https://doc.qt.io/qt-6/qtquickcontrols-environment.html).
 
 You can try running the following command for example:
 

--- a/tutorials/09_migration_qt6.md
+++ b/tutorials/09_migration_qt6.md
@@ -5,7 +5,7 @@ Prerequisite Tutorial: \ref plugins
 ## Overview
 
 Qt5 is planned to be removed in Ubuntu 26.04 LTS. In response to this,
-Gazebo GUI has upgraded its GUI framework from Qt5 to Qt6 in gz-gui10
+Gazebo GUI has upgraded its GUI framework from Qt5 to Qt6 in `gz-gui10`
 (Gazebo Jetty). This directly impacts all users who have developed
 their own custom Gazebo GUI plugins in Qt5.
 
@@ -20,7 +20,7 @@ required changes for porting to Qt6 will be in the QML code.
 
 In a Gazebo GUI plugin, users can create a QML interface that invokes C++
 functionality and vice versa. There is one major syntax change to how
-this should be done from gz-gui10 onwards. Prior to gz-gui10, access to
+this should be done from `gz-gui10` onwards. Prior to `gz-gui10`, access to
 C++ functions or properties was done with the following syntax in QML:
 
 ```qml
@@ -55,7 +55,6 @@ the C++ end.
 > [screenshot](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L37).
 > Hence a decision was made to add the `_` prefix to avoid any potential
 > naming conflicts.
-
 
 ## QML Migration
 

--- a/tutorials/09_migration_qt6.md
+++ b/tutorials/09_migration_qt6.md
@@ -13,8 +13,8 @@ This tutorial will highlight important changes that users need to make
 to migrate their existing Qt5 Gazebo GUI plugins to Qt6.
 
 A Gazebo GUI is made up of C++, QML code, and configuration file, see
-\ref plugins for more information.  We expect that most of the required
-changes for porting to Qt6 will be in the QML code.
+the \ref plugins tutorial for more information. We expect that most of the
+required changes for porting to Qt6 will be in the QML code.
 
 ## QML and C++ Integration
 
@@ -33,12 +33,12 @@ The new syntax for doing this in Qt6 based Gazebo GUI plugin is:
 _MyClass::FunctionFoo()
 ```
 
-As an example, back in our Qt5 based Screenshot GUI plugin's QML code, we call
+As an example, in the Qt5 based `Screenshot` GUI plugin's QML code, we call
 [Screenshot.OnScreenshot()](https://github.com/gazebosim/gz-gui/blob/e0c95585919d95a01fbf3af9a33c7fcd653ab154/src/plugins/screenshot/Screenshot.qml#L50)
 which inovkes the corresponding [C++ function](https://github.com/gazebosim/gz-gui/blob/e0c95585919d95a01fbf3af9a33c7fcd653ab154/src/plugins/screenshot/Screenshot.cc#L188)
-defined in the Screenshot C++ class.
+defined in the `Screenshot` C++ class.
 
-In Qt6 based Gazebo GUI plugins, the code is changed to
+In the Qt6 based Gazebo GUI plugin, the code is changed to
 [\_Screenshot.OnScreeShot()](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L50)
 for the QML and C++ binding to work correctly.
 
@@ -47,14 +47,14 @@ names should not begin with an upper case letter. Gazebo adds an
 underscore prefix to workaround this problem. No changes should be needed on
 the C++ end.
 
-> An alternative approach would be to choose a name that starts
-with a lower case letter, i.e. `myClass.FunctionFoo()`. However, it was
-noted that in many cases there exists an QML object with the id `myClass`
-already which would conflict with the name of the C++ object. For example, the
-Screenshot GUI plugin has a tool button with the id:
-[screenshot](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L37).
-Hence a decision was made to add the `_` prefix to avoid any potential
-naming conflicts.
+> Note: An alternative approach would be to choose a name that starts
+> with a lower case letter, i.e. `myClass.FunctionFoo()`. However, it was
+> noted that in many cases there exists an QML object with the id `myClass`
+> already which would conflict with the name of the C++ object. For example, the
+> Screenshot GUI plugin has a tool button with the id:
+> [screenshot](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L37).
+> Hence a decision was made to add the `_` prefix to avoid any potential
+> naming conflicts.
 
 
 ## QML Migration
@@ -68,9 +68,10 @@ some QML types have significant syntax changes.
 
 Common changes for porting Qt5 QML code to Qt6 include:
 * Importing a newer version of the Qt module, which can be done by removing the
-  version number, e.g. `import QtQuick.Dialogs 1.0` -> `import QtQuick.Dialogs`
-* Adding `_` to C++ object name as described in the `QML and C++ Integration`
-  section above
+  version number, e.g. `import QtQuick.Dialogs 1.0` becomes
+  `import QtQuick.Dialogs`.
+* Adding the `_` prefix to the C++ object name as described in the
+  `QML and C++ Integration` section above.
 * QML types requiring more code changes include but not limited to:
   [FileDialog](https://doc.qt.io/qt-6/qml-qtquick-dialogs-filedialog.html) and
   [TreeView](https://doc.qt.io/qt-6/qml-qtquick-treeview.html).
@@ -79,11 +80,12 @@ Common changes for porting Qt5 QML code to Qt6 include:
 
 ## Qt App and Event Loop
 
-The core of Gazebo GUI sets up the necessary code for running an Qt applicatio
- and its event loop. Here are some related migration notes:
+The core of Gazebo GUI sets up the necessary code for running an Qt application
+and its event loop. Here are some related migration notes:
 
 * The main C++ API in Gazebo GUI for retrieving the running Qt Application
-is `App()` which essentially returns a
+is [App()](https://github.com/gazebosim/gz-gui/blob/e0c95585919d95a01fbf3af9a33c7fcd653ab154/include/gz/gui/Application.hh#L224)
+which essentially returns a
 [qGuiApp](https://doc.qt.io/qt-6/qguiapplication.html#qGuiApp) pointer.
 This pointer is no longer always guaranteed to be non-null. Users should check this
 pointer to make sure it is valid before using it.

--- a/tutorials/09_migration_qt6.md
+++ b/tutorials/09_migration_qt6.md
@@ -1,0 +1,92 @@
+\page migration_qt6 Migrating Qt5 GUI plugins to Qt6
+
+Prerequisite Tutorial: \ref plugins
+
+## Overview
+
+Qt5 is planned to be removed in Ubuntu 26.04 LTS. In response to this,
+Gazebo GUI has upgraded its GUI framework from Qt5 to Qt6 in gz-gui10
+(Gazebo Jetty). This directly impacts all users who have developed
+their own custom Gazebo GUI plugins in Qt5.
+
+This tutorial will highlight important changes that users need to make
+to migrate their existing Qt5 Gazebo GUI plugins to Qt6.
+
+A Gazebo GUI is made up of C++, QML code, and configuration file, see
+\ref plugins for more information.  We expect that most of the required
+changes for porting to Qt6 will be in the QML code.
+
+## QML and C++ Integration
+
+In a Gazebo GUI plugin, users can create a QML interface that invokes C++
+functionality and vice versa. There is one major syntax change to how
+this should be done from gz-gui10 onwards. Prior to gz-gui10, access to
+C++ functions or properties was done with the following syntax in QML:
+
+```qml
+MyClass::FunctionFoo()
+```
+
+The new syntax for doing this in Qt6 based Gazebo GUI plugin is:
+
+```qml
+_MyClass::FunctionFoo()
+```
+
+As an example, back in our Qt5 based Screenshot GUI plugin's QML code, we call
+[Screenshot.OnScreenshot()](https://github.com/gazebosim/gz-gui/blob/e0c95585919d95a01fbf3af9a33c7fcd653ab154/src/plugins/screenshot/Screenshot.qml#L50)
+which inovkes the corresponding [C++ function](https://github.com/gazebosim/gz-gui/blob/e0c95585919d95a01fbf3af9a33c7fcd653ab154/src/plugins/screenshot/Screenshot.cc#L188)
+defined in the Screenshot C++ class.
+
+In Qt6 based Gazebo GUI plugins, the code is changed to
+[\_Screenshot.OnScreeShot()](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L50)
+for the QML and C++ binding to work correctly.
+
+This is mainly because Qt6 enforces stricter property rules and that property
+names should not begin with an upper case letter. Gazebo adds an
+underscore prefix to workaround this problem. No changes should be needed on
+the C++ end.
+
+> An alternative approach would be to choose a name that starts
+with a lower case letter, i.e. `myClass.FunctionFoo()`. However, it was
+noted that in many cases there exists an QML object with the id `myClass`
+already which would conflict with the name of the C++ object. For example, the
+Screenshot GUI plugin has a tool button with the id:
+[screenshot](https://github.com/gazebosim/gz-gui/blob/c7093159ac92031350cdf2c31283e3fdfd944194/src/plugins/screenshot/Screenshot.qml#L37).
+Hence a decision was made to add the `_` prefix to avoid any potential
+naming conflicts.
+
+
+## QML Migration
+
+Gazebo gives users the freedom to import any QML modules in their QML code
+and create their UI in a way that is no different from writing other Qt
+programs. So users would need to follow the general
+[porting guide](https://doc.qt.io/qt-6/portingguide.html), paying attention
+to the QML and module changes. Some QML modules and types are obsolete while
+some QML types have significant syntax changes.
+
+Common changes for porting Qt5 QML code to Qt6 include:
+* Importing a newer version of the Qt module, which can be done by removing the
+  version number, e.g. `import QtQuick.Dialogs 1.0` -> `import QtQuick.Dialogs`
+* Adding `_` to C++ object name as described in the `QML and C++ Integration`
+  section above
+* QML types requiring more code changes include but not limited to:
+  [FileDialog](https://doc.qt.io/qt-6/qml-qtquick-dialogs-filedialog.html) and
+  [TreeView](https://doc.qt.io/qt-6/qml-qtquick-treeview.html).
+  *  This [Qt6 migration pull request](https://github.com/gazebosim/gz-sim/pull/2832/files#diff-a93324029765acbdf791f6e6ed06b1ea2e2886a756f949e7948f7824a57b4e7b)
+    shows examples of porting various Qt5 Gazebo GUI plugins to Qt6.
+
+## Qt App and Event Loop
+
+The core of Gazebo GUI sets up the necessary code for running an Qt applicatio
+ and its event loop. Here are some related migration notes:
+
+* The main C++ API in Gazebo GUI for retrieving the running Qt Application
+is `App()` which essentially returns a
+[qGuiApp](https://doc.qt.io/qt-6/qguiapplication.html#qGuiApp) pointer.
+This pointer is no longer always guaranteed to be non-null. Users should check this
+pointer to make sure it is valid before using it.
+* Users are discouraged from calling
+[QCoreApplication::processEvents](https://doc.qt.io/qt-6/qcoreapplication.html#processEvents)
+manually in Qt6.


### PR DESCRIPTION


# 🎉 New feature

## Summary

Adds a tutorial that serves as a migration guide for users to port their Qt5 based Gazebo GUI plugin to Qt5.

Additionally, updates all Qt5 references to Qt6 in our code base.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
