### PR TITLE
Fix Qt6 migration tutorial QML syntax

### DIFF
--- a/tutorials/09_migration_qt6.md
+++ b/tutorials/09_migration_qt6.md
@@ -24,13 +24,13 @@ this should be done from `gz-gui10` onwards. Prior to `gz-gui10`, access to
 C++ functions or properties was done with the following syntax in QML:
 
 ```qml
-MyClass::FunctionFoo()
+MyClass.FunctionFoo()
 ```
 
 The new syntax for doing this in Qt6 based Gazebo GUI plugin is:
 
 ```qml
-_MyClass::FunctionFoo()
+_MyClass.FunctionFoo()
 ```
 
 As an example, in the Qt5 based `Screenshot` GUI plugin's QML code, we call


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Fixes QML syntax in the C++ / QML integration section. Function calls are done with a `.` and not `::`


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
