### PR TITLE
Fix loading and saving gui config

### DIFF
--- a/include/gz/gui/qml/Main.qml
+++ b/include/gz/gui/qml/Main.qml
@@ -300,7 +300,7 @@ ApplicationWindow
     currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
     nameFilters: [ "Config files (*.config)" ]
     onAccepted: {
-      _MainWindow.OnLoadConfig(fileUrl)
+      _MainWindow.OnLoadConfig(selectedFile)
     }
   }
 
@@ -314,7 +314,7 @@ ApplicationWindow
     currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
     nameFilters: [ "Config files (*.config)" ]
     onAccepted: {
-      var selected = fileUrl.toString();
+      var selected = selectedFile.toString();
 
       if (!selected.endsWith(".config"))
       {


### PR DESCRIPTION

# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gazebo_test_cases/issues/1823

## Summary

Missed this during Qt5 -> Qt6 migration. The `fileUrl` var has changed to `selectedFile`. A similar change was done in one of the the Qt5 -> Qt6 [PRs](https://github.com/gazebosim/gz-sim/pull/2832/files#diff-dd74c558abfb62d53bfde23c0145a811675f7907e7dc42c14fdd0ad927b38351)

To test:

launch gz-sim with any world and try to Save and Load Client Configuration. You should see the issue reported in https://github.com/gazebosim/gazebo_test_cases/issues/1823#issuecomment-3240454961


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

