### PR TITLE
Explicitly set OpenGL as the graphics API for QtQuick

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -168,6 +168,7 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
   }
   else
   {
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
     gzdbg << "Qt using OpenGL graphics interface" << std::endl;
   }
 #endif


### PR DESCRIPTION
# 🦟 Bug fix

Toward: https://github.com/gazebosim/gz-sim/issues/2945

## Summary
The default rendering backend has been changed to Direct3D 11 in Qt6 (see https://doc.qt.io/qt-6/qtquick-visualcanvas-scenegraph-renderer.html#rendering-via-the-qt-rendering-hardware-interface). Without this change, Gazebo crashes on windows as it tries to initialize an OpenGL context.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.