### PR TITLE
[DRAFT] Prepare for 10.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,6 @@
 ## Gazebo GUI 10
 
-### Gazebo GUI 10.X.X (202X-XX-XX)
-
-### Gazebo GUI 10.0.0 (2025-09-XX)
+### Gazebo GUI 10.0.0 (2025-09-30)
 
 1. Qt6 migration and updates
     * [Pull request #697](https://github.com/gazebosim/gz-gui/pull/697)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,32 @@
 
 ### Gazebo GUI 10.0.0 (2025-09-30)
 
+1. Fix link in scene tutorial
+    * [Pull request #714](https://github.com/gazebosim/gz-gui/pull/714)
+
+1. Update dependency on gz-cmake3 to gz-cmake
+    * [Pull request #713](https://github.com/gazebosim/gz-gui/pull/713)
+
+1. Fix loading and saving gui config
+    * [Pull request #711](https://github.com/gazebosim/gz-gui/pull/711)
+
+1. Fix syntax error in package.xml entry
+    * [Pull request #710](https://github.com/gazebosim/gz-gui/pull/710)
+
+1. Fix dead links in config tutorial
+    * [Pull request #709](https://github.com/gazebosim/gz-gui/pull/709)
+
+1. Update 02_commandline.md tutorial with help message
+    * [Pull request #708](https://github.com/gazebosim/gz-gui/pull/708)
+
+1. Update references of main to gz-gui10
+    * [Pull request #707](https://github.com/gazebosim/gz-gui/pull/707)
+
+1. Replace Protobuf DebugString with PrintToString
+    * [Pull request #703](https://github.com/gazebosim/gz-gui/pull/703)
+
 1. Qt6 migration and updates
+    * [Pull request #712](https://github.com/gazebosim/gz-gui/pull/712)
     * [Pull request #697](https://github.com/gazebosim/gz-gui/pull/697)
     * [Pull request #693](https://github.com/gazebosim/gz-gui/pull/693)
     * [Pull request #691](https://github.com/gazebosim/gz-gui/pull/691)


### PR DESCRIPTION
# 🎈 Release

Preparation for 10.0.0 release.

Comparison to 10.0.0~pre2: https://github.com/gazebosim/gz-gui/compare/gz-gui10_10.0.0-pre2...gz-gui10

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
