### PR TITLE
Capture this explicitly in the QTimer timeout callbacks

### DIFF
--- a/src/plugins/camera_tracking/CameraTracking.cc
+++ b/src/plugins/camera_tracking/CameraTracking.cc
@@ -527,7 +527,7 @@ CameraTracking::CameraTracking()
   : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   this->dataPtr->timer = new QTimer(this);
-  connect(this->dataPtr->timer, &QTimer::timeout, this->dataPtr->timer, [=]()
+  connect(this->dataPtr->timer, &QTimer::timeout, this->dataPtr->timer, [this]()
   {
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
     if (!this->dataPtr->camera)

--- a/src/plugins/publisher/Publisher.cc
+++ b/src/plugins/publisher/Publisher.cc
@@ -145,7 +145,8 @@ void Publisher::OnPublish(const bool _checked)
   }
 
   this->dataPtr->timer->setInterval(1000/this->dataPtr->frequency);
-  connect(this->dataPtr->timer, &QTimer::timeout, this->dataPtr->timer, [=]()
+  connect(this->dataPtr->timer, &QTimer::timeout, this->dataPtr->timer,
+      [this, msgType, msgData]()
   {
     auto newMsg = msgs::Factory::New(msgType, msgData);
     this->dataPtr->pub.Publish(*newMsg);


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-cmake#580

## Summary

`[=]` implicitly captured `this`, which is deprecated in C++20. Both lambdas are `QTimer::timeout` callbacks. `CameraTracking` only uses `this->dataPtr`, so the capture is now `[this]`. `Publisher` also uses the local `msgType` and `msgData`, so it becomes `[this, msgType, msgData]` rather than `[=, this]`, which is not valid C++17. No behavior change, and it is valid C++17, so it can land before any standard bump.

Before:
```
src/plugins/camera_tracking/CameraTracking.cc:530:73: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
src/plugins/publisher/Publisher.cc:148:73: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
```

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opus 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
