### PR TITLE
Wayland support

### DIFF
--- a/src/Application.cc
+++ b/src/Application.cc
@@ -16,6 +16,7 @@
  */
 
 #include <qsgrendererinterface.h>
+#include <qsurfaceformat.h>
 #include <tinyxml2.h>
 #include <queue>
 
@@ -168,6 +169,21 @@ Application::Application(int &_argc, char **_argv, const WindowType _type,
   }
   else
   {
+    // Explicitly request a desktop OpenGL context. Without this, Qt's
+    // Wayland EGL platform integration was observed to default to
+    // EGL_OPENGL_ES_API (GLES) instead - confirmed via
+    // eglQueryContext(..., EGL_CONTEXT_CLIENT_TYPE, ...) on the context
+    // Qt made current, which reported EGL_OPENGL_ES_API / GLES 3.2. Ogre's
+    // GL3Plus RenderSystem (used by the "ogre2" render engine here) is
+    // desktop-GL-only, so under native Wayland (GZ_GUI_WAYLAND=1) adopting
+    // that GLES context via "currentGLContext" fails outright (gl3w can't
+    // initialise against it). XWayland/GLX never hit this because GLX
+    // contexts are inherently desktop GL only. Setting this unconditionally
+    // is harmless for XWayland/GLX too - it's already desktop GL there.
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    QSurfaceFormat::setDefaultFormat(format);
+
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
     gzdbg << "Qt using OpenGL graphics interface" << std::endl;
   }

--- a/src/plugins/minimal_scene/CMakeLists.txt
+++ b/src/plugins/minimal_scene/CMakeLists.txt
@@ -21,6 +21,23 @@ if (APPLE)
   )
 endif()
 
+# Native Wayland support (experimental, opt-in - see gz-sim's Gui.cc for the
+# runtime opt-in gate). Only needs wayland-client to bind a throwaway
+# wl_compositor/wl_surface; the wl_display itself comes from Qt6's public
+# QNativeInterface::QWaylandApplication API, not from this dependency.
+find_package(PkgConfig QUIET)
+set(GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT FALSE)
+if (PkgConfig_FOUND AND UNIX AND NOT APPLE)
+  pkg_check_modules(WAYLAND_CLIENT QUIET wayland-client)
+  if (WAYLAND_CLIENT_FOUND)
+    set(GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT TRUE)
+    set(SOURCES
+      ${SOURCES}
+      WaylandNativeSurface.cc
+    )
+  endif()
+endif()
+
 gz_gui_add_plugin(MinimalScene
   SOURCES
     ${SOURCES}
@@ -32,6 +49,15 @@ gz_gui_add_plugin(MinimalScene
    gz-transport::gz-transport
    ${PROJECT_LINK_LIBS}
 )
+
+if (GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT)
+  target_compile_definitions(MinimalScene
+    PRIVATE GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT=1)
+  target_include_directories(MinimalScene
+    PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
+  target_link_libraries(MinimalScene
+    PRIVATE ${WAYLAND_CLIENT_LIBRARIES})
+endif()
 
 # Enable ARC on selected source files
 if (APPLE)

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -58,6 +58,12 @@
 #  include <gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh>
 #endif  // GZ_GUI_HAVE_VULKAN
 
+#if GZ_GUI_HAVE_WAYLAND
+#  include <QGuiApplication>
+#  include <QtGui/qguiapplication_platform.h>
+#  include "WaylandNativeSurface.hh"
+#endif  // GZ_GUI_HAVE_WAYLAND
+
 Q_DECLARE_OPAQUE_POINTER(gz::gui::plugins::RenderSync*)
 
 namespace gz::gui::plugins
@@ -117,6 +123,14 @@ class GzRenderer::Implementation
 
   /// \brief Render hardware interface for the texture
   public: std::unique_ptr<GzCameraTextureRhi> rhi;
+
+#if GZ_GUI_HAVE_WAYLAND
+  /// \brief Throwaway Wayland surface used only to bootstrap OGRE-Next's
+  /// native Wayland EGL primary render window (see WaylandNativeSurface's
+  /// class comment). Must outlive the render engine, hence owned here
+  /// rather than as a function-local in Initialize().
+  public: std::unique_ptr<WaylandNativeSurface> waylandSurface;
+#endif  // GZ_GUI_HAVE_WAYLAND
 };
 
 /// \brief Qt and Ogre rendering is happening in different threads
@@ -682,7 +696,47 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
   // Load engine if there's no engine yet
   if (loadedEngines.empty())
   {
-    this->dataPtr->rhiParams["winID"] = std::to_string(quickWindow->winId());
+#if GZ_GUI_HAVE_WAYLAND
+    bool nativeWayland = QGuiApplication::platformName() == "wayland";
+#else
+    bool nativeWayland = false;
+#endif  // GZ_GUI_HAVE_WAYLAND
+
+    if (nativeWayland)
+    {
+#if GZ_GUI_HAVE_WAYLAND
+      auto *waylandApp =
+          qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+      wl_display *display = waylandApp ? waylandApp->display() : nullptr;
+      if (!display)
+      {
+        return "Failed to obtain wl_display from Qt's Wayland platform "
+               "integration.";
+      }
+
+      try
+      {
+        this->dataPtr->waylandSurface =
+            std::make_unique<WaylandNativeSurface>(display);
+      }
+      catch (const std::exception &_e)
+      {
+        return std::string(
+            "Failed to create a native Wayland surface: ") + _e.what();
+      }
+
+      this->dataPtr->rhiParams["wayland"] = "true";
+      this->dataPtr->rhiParams["waylandDisplay"] =
+          std::to_string(reinterpret_cast<size_t>(display));
+      this->dataPtr->rhiParams["waylandSurface"] = std::to_string(
+          reinterpret_cast<size_t>(this->dataPtr->waylandSurface->Surface()));
+#endif  // GZ_GUI_HAVE_WAYLAND
+    }
+    else
+    {
+      this->dataPtr->rhiParams["winID"] =
+          std::to_string(quickWindow->winId());
+    }
 
 #if GZ_GUI_HAVE_VULKAN
     // externalInstance & externalDevice MUST be declared at this scope

--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -702,6 +702,17 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
     bool nativeWayland = false;
 #endif  // GZ_GUI_HAVE_WAYLAND
 
+    gzdbg << "[GUI] Qt platform: ["
+          << QGuiApplication::platformName().toStdString()
+          << "], GZ_GUI_HAVE_WAYLAND=" <<
+#if GZ_GUI_HAVE_WAYLAND
+          "1"
+#else
+          "0"
+#endif  // GZ_GUI_HAVE_WAYLAND
+          << ", nativeWayland=" << (nativeWayland ? "true" : "false")
+          << std::endl;
+
     if (nativeWayland)
     {
 #if GZ_GUI_HAVE_WAYLAND
@@ -725,7 +736,7 @@ std::string GzRenderer::Initialize(RenderThreadRhi &_rhi)
             "Failed to create a native Wayland surface: ") + _e.what();
       }
 
-      this->dataPtr->rhiParams["wayland"] = "true";
+      this->dataPtr->rhiParams["wayland"] = "1";
       this->dataPtr->rhiParams["waylandDisplay"] =
           std::to_string(reinterpret_cast<size_t>(display));
       this->dataPtr->rhiParams["waylandSurface"] = std::to_string(

--- a/src/plugins/minimal_scene/MinimalSceneRhi.hh
+++ b/src/plugins/minimal_scene/MinimalSceneRhi.hh
@@ -33,6 +33,19 @@
 
 #define GZ_GUI_HAVE_METAL __APPLE__
 
+// GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT is a CMake-provided compile definition
+// (see this plugin's CMakeLists.txt), set when wayland-client dev headers
+// were found at configure time. QT_VERSION_CHECK(6, 0, 0) reflects that
+// QNativeInterface::QWaylandApplication (used to obtain a wl_display*) is
+// a Qt6-only public API.
+#if defined(GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT)
+#  define GZ_GUI_HAVE_WAYLAND \
+    (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)) && \
+    GZ_GUI_BUILD_HAVE_WAYLAND_CLIENT
+#else
+#  define GZ_GUI_HAVE_WAYLAND 0
+#endif
+
 namespace gz::gui::plugins
 {
   /// \brief Render interface class to handle OpenGL / Metal compatibility

--- a/src/plugins/minimal_scene/WaylandNativeSurface.cc
+++ b/src/plugins/minimal_scene/WaylandNativeSurface.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "WaylandNativeSurface.hh"
+
+#include <cstring>
+#include <stdexcept>
+
+#include <wayland-client.h>
+
+namespace gz::gui::plugins
+{
+class WaylandNativeSurface::Implementation
+{
+  public: wl_display *display{nullptr};
+  public: wl_registry *registry{nullptr};
+  public: wl_compositor *compositor{nullptr};
+  public: wl_surface *surface{nullptr};
+
+  public: static void RegistryGlobal(void *_data, wl_registry *_registry,
+      uint32_t _name, const char *_interface, uint32_t)
+  {
+    auto *impl = static_cast<Implementation *>(_data);
+    if (std::strcmp(_interface, "wl_compositor") == 0)
+    {
+      impl->compositor = static_cast<wl_compositor *>(wl_registry_bind(
+          _registry, _name, &wl_compositor_interface, 4));
+    }
+  }
+
+  public: static void RegistryGlobalRemove(void *, wl_registry *, uint32_t)
+  {
+  }
+};
+
+/////////////////////////////////////////////////
+WaylandNativeSurface::WaylandNativeSurface(wl_display *_display)
+  : dataPtr(std::make_unique<Implementation>())
+{
+  this->dataPtr->display = _display;
+
+  static const wl_registry_listener kRegistryListener = {
+    &Implementation::RegistryGlobal,
+    &Implementation::RegistryGlobalRemove
+  };
+
+  this->dataPtr->registry = wl_display_get_registry(this->dataPtr->display);
+  wl_registry_add_listener(
+      this->dataPtr->registry, &kRegistryListener, this->dataPtr.get());
+
+  // One-shot, synchronous roundtrip to let the registry_global events for
+  // already-advertised globals (including wl_compositor) arrive. This is
+  // safe to do here (at startup, before any Ogre swap activity) even
+  // though this class never dispatches the display afterwards.
+  wl_display_roundtrip(this->dataPtr->display);
+
+  if (!this->dataPtr->compositor)
+  {
+    throw std::runtime_error(
+        "WaylandNativeSurface: wl_compositor was not advertised by the "
+        "compositor");
+  }
+
+  this->dataPtr->surface =
+      wl_compositor_create_surface(this->dataPtr->compositor);
+  if (!this->dataPtr->surface)
+  {
+    throw std::runtime_error(
+        "WaylandNativeSurface: wl_compositor_create_surface failed");
+  }
+}
+
+/////////////////////////////////////////////////
+WaylandNativeSurface::~WaylandNativeSurface()
+{
+  if (this->dataPtr->surface)
+    wl_surface_destroy(this->dataPtr->surface);
+  if (this->dataPtr->compositor)
+    wl_compositor_destroy(this->dataPtr->compositor);
+  if (this->dataPtr->registry)
+    wl_registry_destroy(this->dataPtr->registry);
+  // this->dataPtr->display is not owned - never destroyed/disconnected here.
+}
+
+/////////////////////////////////////////////////
+wl_surface *WaylandNativeSurface::Surface() const
+{
+  return this->dataPtr->surface;
+}
+}  // namespace gz::gui::plugins

--- a/src/plugins/minimal_scene/WaylandNativeSurface.hh
+++ b/src/plugins/minimal_scene/WaylandNativeSurface.hh
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_GUI_PLUGINS_MINIMALSCENE_WAYLANDNATIVESURFACE_HH_
+#define GZ_GUI_PLUGINS_MINIMALSCENE_WAYLANDNATIVESURFACE_HH_
+
+#include <memory>
+
+// Opaque forward declarations so this header doesn't require
+// <wayland-client.h> (and thus GZ_GUI_HAVE_WAYLAND) to be visible to
+// consumers that merely hold a pointer to this class.
+struct wl_display;
+struct wl_surface;
+struct wl_compositor;
+struct wl_registry;
+
+namespace gz::gui::plugins
+{
+  /// \brief Creates and owns a small, throwaway Wayland surface used solely
+  /// to give OGRE-Next's native Wayland EGL backend something to bootstrap
+  /// an EGL context/window against.
+  ///
+  /// This is NOT the surface Gazebo's 3D scene is actually displayed on -
+  /// gz-rendering's Ogre2 backend renders to an offscreen FBO texture that
+  /// is handed directly to Qt Quick's scenegraph (see
+  /// Ogre2Camera::RenderTextureGLId()); the "primary" Ogre render window
+  /// this surface backs is a 1x1 bootstrap window that OGRE-Next's own
+  /// render loop never swaps (verified: every swapBuffers call in OgreMain
+  /// is workspace-driven, and no compositor workspace is ever attached to
+  /// the primary window). Because of that, this surface deliberately has no
+  /// Wayland "role" (no xdg_toplevel) - it is never mapped or shown.
+  ///
+  /// Uses only Qt6's PUBLIC QNativeInterface::QWaylandApplication API for
+  /// the wl_display (the caller obtains and passes that in); this class
+  /// itself only needs libwayland-client to bind its own wl_compositor and
+  /// create the surface, avoiding any dependency on Qt's private/unstable
+  /// QtWaylandClient headers (which would otherwise be needed to extract a
+  /// specific QWindow's real wl_surface).
+  class WaylandNativeSurface
+  {
+    /// \brief Constructor.
+    /// \param[in] _display A live wl_display connection (not owned - the
+    /// caller, e.g. Qt's Wayland QPA plugin, must keep it alive and must
+    /// continue dispatching it; this class never dispatches it itself).
+    /// Throws std::runtime_error if a wl_compositor can't be bound or the
+    /// surface can't be created.
+    public: explicit WaylandNativeSurface(wl_display *_display);
+
+    /// \brief Destructor. Destroys the surface and the compositor binding.
+    /// Does not touch _display.
+    public: ~WaylandNativeSurface();
+
+    /// \brief Copying/moving would complicate ownership of the registry
+    /// listener's `this` pointer; not needed, so disabled.
+    public: WaylandNativeSurface(const WaylandNativeSurface &) = delete;
+    public: WaylandNativeSurface &operator=(
+        const WaylandNativeSurface &) = delete;
+
+    /// \brief Returns the created surface.
+    public: wl_surface *Surface() const;
+
+    /// \brief Private implementation.
+    private: class Implementation;
+    private: std::unique_ptr<Implementation> dataPtr;
+  };
+}  // namespace gz::gui::plugins
+
+#endif  // GZ_GUI_PLUGINS_MINIMALSCENE_WAYLANDNATIVESURFACE_HH_


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds native Wayland EGL rendering support to the `MinimalScene` GUI plugin, as an
opt-in alternative to the current XWayland fallback.

Two changes:

1. **`src/Application.cc`** — explicitly requests a desktop OpenGL context
   (`QSurfaceFormat::setRenderableType(QSurfaceFormat::OpenGL)`) before any
   `QOpenGLContext`/`QWindow` is created. Without this, Qt's Wayland platform
   integration was observed to default to a GLES context instead — confirmed via
   `eglQueryContext(..., EGL_CONTEXT_CLIENT_TYPE, ...)`, which reported
   `EGL_OPENGL_ES_API` / GLES 3.2. gz-rendering's `ogre2` backend (GL3Plus) is
   desktop-GL-only, so under native Wayland it can't adopt that context at all —
   this was the actual root cause of a crash at "Creating texture node render
   interface for OpenGL". Harmless under XWayland/GLX too, since it's already
   desktop GL there.
2. **`src/plugins/minimal_scene/{MinimalScene.cc, WaylandNativeSurface.cc, WaylandNativeSurface.hh}`**
   (new file: `WaylandNativeSurface`) — when Qt reports `wayland` as the active
   platform, `GzRenderer::Initialize()` now obtains the live `wl_display` from Qt's
   public `QNativeInterface::QWaylandApplication` API, creates a small throwaway
   `wl_surface` via `WaylandNativeSurface` (no `xdg_toplevel` role — it's never mapped
   or shown, purely a bootstrap target for OGRE-Next's primary render window; the
   actual 3D scene is an offscreen FBO texture handed straight to Qt Quick's
   scenegraph), and passes `wayland=1`/`waylandDisplay`/`waylandSurface` through to
   gz-rendering instead of `winID`.

This depends on companion changes in OGRE-Next and gz-rendering, and is used by
gz-sim's opt-in flag:
- OGRECave/ogre-next#593 (adopt Qt's current EGL context — required for this to work
  correctly)
- gazebosim/gz-rendering#1325
- gazebosim/gz-sim#3943 (adds the `GZ_GUI_WAYLAND=1` opt-in env var this reads)

## Backport Policy
- [ ] I am not sure

## Test it
Requires the OGRE-Next and gz-rendering PRs above built and installed first (this repo
alone builds and runs exactly as before under XWayland/GLX — no behavior change unless
`GZ_GUI_WAYLAND=1` is set, which is gz-sim's opt-in, see that PR).

1. Build against the OGRE-Next/gz-rendering branches linked above, sharing an install
   prefix.
2. Run a real `gz sim` GUI session under native Wayland:
   unset QT_QPA_PLATFORM
   GZ_GUI_WAYLAND=1 gz sim -v 4 examples/worlds/shapes.sdf
3. Confirm no crash at "Creating texture node render interface for OpenGL" and that
the scene renders correctly (screenshot attached, taken via the `/gui/screenshot`
service since no `gz` CLI was available in the verification environment — the
`gz sim` GUI itself was still used for the actual render).
4. Without `GZ_GUI_WAYLAND=1` set, confirm behavior is unchanged (falls back to xcb as
before).

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix
- [ ] Added tests — no gtest coverage added; the Wayland path needs a live compositor
   CI doesn't have, so verification is the manual `gz sim` run above
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed
- [x] All tests passed (53/54 locally; the one failure is a pre-existing environment
   gap in `INTEGRATION_ExamplesBuild_TEST` unrelated to this change — builds
   `examples/plugin`/`examples/standalone`, neither touched here)
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise. — N/A,
   this repo has no Bazel build files
- [ ] While waiting for a review on your PR, please help review another open pull request
- [x] Was GenAI used to generate this PR?

Assisted-by: Claude (Anthropic) — used for implementation and debugging assistance.