### PR TITLE
Fix MinimalScene render synchronization during shutdown

### DIFF
--- a/src/plugins/minimal_scene/MinimalScene.cc
+++ b/src/plugins/minimal_scene/MinimalScene.cc
@@ -249,13 +249,17 @@ void RenderSync::WaitForQtThreadAndBlock(std::unique_lock<std::mutex> &_lock)
   { return this->renderStallState == RenderStallState::WorkerCanProceed ||
            this->renderStallState == RenderStallState::ShuttingDown; });
 
+  if (this->renderStallState == RenderStallState::ShuttingDown)
+    return;
+
   this->renderStallState = RenderStallState::WorkerIsProceeding;
 }
 
 /////////////////////////////////////////////////
 void RenderSync::ReleaseQtThreadFromBlock(std::unique_lock<std::mutex> &_lock)
 {
-  this->renderStallState = RenderStallState::QtCanProceed;
+  if (this->renderStallState != RenderStallState::ShuttingDown)
+    this->renderStallState = RenderStallState::QtCanProceed;
   _lock.unlock();
   this->cv.notify_one();
 }
@@ -271,6 +275,9 @@ void RenderSync::WaitForWorkerThread()
     return this->renderStallState == RenderStallState::QtCanProceed ||
            this->renderStallState == RenderStallState::ShuttingDown;
   } );
+
+  if (this->renderStallState == RenderStallState::ShuttingDown)
+    return;
 
   // Worker thread asked us to wait!
   this->renderStallState = RenderStallState::WorkerCanProceed;
@@ -296,7 +303,7 @@ void RenderSync::Shutdown()
     this->renderStallState = RenderStallState::ShuttingDown;
 
     lock.unlock();
-    this->cv.notify_one();
+    this->cv.notify_all();
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The GUI can hang on shutdown because queued rendering callbacks can overwrite `RenderSync::ShuttingDown`. This leaves the render thread waiting for a Qt handshake that will never happen, while the GUI waits for the thread to exit.

This fix keeps `ShuttingDown` terminal and wakes all synchronization waiters during shutdown. No public API changes.

### Validation

- A local C++ harness reproduced both worker-side and Qt-side hangs before the fix. Both pass afterward, along with the normal rendering handshake.
- `INTEGRATION_minimal_scene` and local `codecheck` passed. Cppcheck reported informational missing-system-header messages.
- Tested the fix on gz-gui 10.0.0 with gz-sim 10.5.0 / ROS 2 Lyrical: the GUI exited within two seconds of SIGINT in both runs.

## Backport Policy

- [x] This is safe to backport to the following versions:
    - [x] Jetty

The same affected code exists in `gz-gui10`, where this fix was also tested. Older versions have not been evaluated.

## Checklist

- [x] Signed all commits for DCO
- [ ] Added a screen capture or video (as needed)
- [ ] Added tests (local harness only; no committed regression test)
- [ ] Updated documentation (not needed)
- [ ] Updated migration guide (not needed)
- [ ] Consider updating Python bindings (not applicable)
- [x] `codecheck` passed locally
- [ ] All tests passed (only targeted tests run locally)
- [ ] Updated Bazel files (not applicable; no new files)
- [ ] Help review another open pull request
- [x] Was GenAI used to generate this PR? Yes

Assisted-by: GitHub Copilot

**Note to maintainers**: Use **Squash-Merge**, retaining `Signed-off-by`, `Assisted-by`, and any `Generated-by` trailers.

**Backports:** Use **Rebase and Merge**.