### PR TITLE
Fix macOS Metal viewport gamma by reinterpreting sRGB texture view

### DIFF
--- a/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
+++ b/src/plugins/minimal_scene/MinimalSceneRhiMetal.mm
@@ -56,6 +56,7 @@ namespace plugins
   {
     public: id<MTLTexture> metalTexture = nil;
     public: id<MTLTexture> newMetalTexture = nil;
+    public: id<MTLTexture> viewTexture = nil;
     public: QSize size {0, 0};
     public: QSize newSize {0, 0};
     public: QMutex mutex;
@@ -65,8 +66,31 @@ namespace plugins
     public: void CreateTexture(id<MTLTexture> _id, QSize _size)
     {
       delete this->texture;
+      this->texture = nullptr;
+
+      id<MTLTexture> tex = _id;
+      if (_id && _id.pixelFormat == MTLPixelFormatRGBA8Unorm_sRGB)
+      {
+        // Metal counterpart to GL_SKIP_DECODE_EXT (see PR #630):
+        // Ogre2 renders to an sRGB render target, where hardware ROP encodes linear
+        // RGB values into sRGB colorspace bytes.
+        // Qt Quick's Scene Graph samples this texture and writes it to a non-sRGB
+        // swapchain framebuffer. If sampled as an sRGB texture, the Metal hardware
+        // sampler automatically decodes sRGB -> linear, and the display server then
+        // applies gamma to already-linearized values, causing severe darkening.
+        // Creating a texture view reinterpreted as MTLPixelFormatRGBA8Unorm prevents
+        // sampler decoding, passing through the encoded sRGB bytes bit-exact.
+        this->viewTexture =
+            [_id newTextureViewWithPixelFormat:MTLPixelFormatRGBA8Unorm];
+        tex = this->viewTexture;
+      }
+      else
+      {
+        this->viewTexture = nil;
+      }
+
       this->texture = QNativeInterface::QSGMetalTexture::fromNative(
-        _id,
+        tex,
         this->window,
         _size);
     }


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

### Problem
On macOS with the Metal rendering backend, the 3D scene viewport is noticeably darker than on Linux/OpenGL, crushing midtones and shadows.

### Root Cause
1. **Ogre2 Metal Pipeline**: Ogre-Next physically-based rendering computes in linear floating-point color space. Its render target has format `PFG_RGBA8_UNORM_SRGB` (`MTLPixelFormatRGBA8Unorm_sRGB`). When writing out pixels, the GPU hardware Render Output Unit (ROP) automatically applies the linear -> sRGB transfer curve. As a result, the bytes in GPU VRAM are already in standard sRGB color space.
2. **Qt Quick Presentation**: `MinimalSceneRhiMetal.mm` wraps this Metal texture into `QSGMetalTexture` for Qt Quick's Scene Graph to render onto the GUI window.
3. **Double Gamma Application**:
   - Qt Quick renders to a non-sRGB swapchain framebuffer (`MTLPixelFormatBGRA8Unorm`).
   - When Qt Quick sampled Ogre's `MTLPixelFormatRGBA8Unorm_sRGB` texture, the Metal hardware sampler automatically decoded sRGB -> linear.
   - Qt Quick wrote these linearized values into the non-sRGB window framebuffer.
   - The macOS display server then presented the window framebuffer as sRGB, applying display gamma to already-linearized data.
   - This caused double-gamma decay ($\approx \text{color}^{2.2 \times 2.2}$), severely darkening the viewport.

### Fix
This is the Apple Metal counterpart to the Linux/OpenGL fix in #630 (which set `GL_SKIP_DECODE_EXT` on the OpenGL texture sampler).

Metal does not have a sampler parameter to skip sRGB decoding. Instead, the standard Apple-idiomatic mechanism is to create a zero-copy reinterpreted texture view:
```objc
this->viewTexture = [_id newTextureViewWithPixelFormat:MTLPixelFormatRGBA8Unorm];
```

> **Note on Objective-C syntax:** In Objective-C++, square brackets `[receiver message:argument]` denote method invocation. Calling [`newTextureViewWithPixelFormat:`](https://developer.apple.com/documentation/metal/mtltexture/newtextureviewwithpixelformat:texturetype:levels:slices:) creates a zero-copy texture view sharing the exact same underlying GPU memory allocation, reinterpreted as `MTLPixelFormatRGBA8Unorm`.
>
> In `MinimalScene.cc:792`, the camera render target is already configured with `SetImageFormat(..., true /* reinterpretable */)`, which instructs Ogre to create the underlying Metal texture with the `MTLTextureUsagePixelFormatView` usage flag required by Metal for texture view reinterpretation.

Sampling through this `Unorm` view prevents the Metal hardware sampler from decoding the sRGB bytes, passing through the already-encoded sRGB bytes bit-exact to the window framebuffer.

*With fix*
<img width="2400" height="2056" alt="image" src="https://github.com/user-attachments/assets/d35b6eff-fc75-49bc-a66f-566b60a61bb0" />

*Without fix*
<img width="2400" height="2056" alt="image" src="https://github.com/user-attachments/assets/0098a2d4-9447-4c53-9b15-19a45ebfc25d" />

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.8 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
