### PR TITLE
Teleop: make default velocities configurable

### DIFF
--- a/src/plugins/teleop/Teleop.cc
+++ b/src/plugins/teleop/Teleop.cc
@@ -126,6 +126,13 @@ void Teleop::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
     auto topicElem = _pluginElem->FirstChildElement("topic");
     if (nullptr != topicElem && nullptr != topicElem->GetText())
       this->SetTopic(topicElem->GetText());
+    if (auto maxFwd = _pluginElem->FirstChildElement("max_forward_velocity"))
+      this->SetMaxForwardVel(maxFwd->DoubleText(this->dataPtr->maxForwardVel));
+    if (auto maxVrt = _pluginElem->FirstChildElement("max_vertical_velocity"))
+      this->SetMaxVerticalVel(
+        maxVrt->DoubleText(this->dataPtr->maxVerticalVel));
+    if (auto maxYaw = _pluginElem->FirstChildElement("max_yaw_velocity"))
+      this->SetMaxYawVel(maxYaw->DoubleText(this->dataPtr->maxYawVel));
   }
 
   if (auto *qw = App() ? App()->findChild<MainWindow *>() ?

--- a/src/plugins/teleop/Teleop.hh
+++ b/src/plugins/teleop/Teleop.hh
@@ -43,6 +43,9 @@ namespace gz::gui::plugins
   /// vehicle in the world.
   /// ## Configuration
   /// * `<topic>`: Topic to publish twist messages to.
+  /// * `<max_forward_velocity>`: Maximum forward velocity.
+  /// * `<max_vertical_velocity>`: Maximum vertical velocity.
+  /// * `<max_yaw_velocity>`: Maximum yaw velocity.
   class Teleop_EXPORTS_API Teleop : public Plugin
   {
     Q_OBJECT


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
(retarget #778  to main)

Teleop plugin can be used with various types of machines.
And having configurable default velocity values is a quality of life improvement.

<img width="512" height="592" alt="image" src="https://github.com/user-attachments/assets/566450dc-bc7e-4467-add4-7d83f360d7df" />

To spawn plugin, add to world (maybe you also need rest default GUI plugins)
```
    <gui>
      <plugin filename="Teleop" name="Teleop">
        <gz-gui>
          <property type="string" key="state">docked</property>
        </gz-gui>
        <topic>/cmd_vel</topic>
        <max_forward_velocity>14</max_forward_velocity>
        <max_vertical_velocity>2</max_vertical_velocity>
        <max_yaw_velocity>3</max_yaw_velocity>
      </plugin>
    </gui>
```

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.